### PR TITLE
llrender must be compiled with -fPIC.

### DIFF
--- a/indra/llrender/CMakeLists.txt
+++ b/indra/llrender/CMakeLists.txt
@@ -88,6 +88,8 @@ endif (BUILD_HEADLESS)
 add_library (llrender ${llrender_SOURCE_FILES})
 target_include_directories( llrender  INTERFACE   ${CMAKE_CURRENT_SOURCE_DIR})
 
+set_property(TARGET llrender PROPERTY POSITION_INDEPENDENT_CODE ON)
+
 # Libraries on which this library depends, needed for Linux builds
 # Sort by high-level to low-level
 target_link_libraries(llrender


### PR DESCRIPTION
I didn't like that fs-build-variables dragged in a -fPIC as CXXFLAGS because,

1) that is not how one should do that when using cmake (see this patch for how to do that).
2) that causes ALL files to be compiled with that flag, also normal viewer files that don't need it.
3) it isn't necessary for amd64.

Hence, I removed that flag locally.

Turns out this (one file of llrender) is the only thing that *does* need to be compiled with -fPIC (despite being on amd64) because [...].

So, added this line to make it so.

Needless to say that if you keep -fPIC in fs-build-variables anyway then this change has no effect,
but I'd appreciate it if it is accepted since it makes sense ;).