### PR TITLE
Compile warning/error workaround.

### DIFF
--- a/indra/newview/llenvironment.cpp
+++ b/indra/newview/llenvironment.cpp
@@ -1141,7 +1141,18 @@ void LLEnvironment::onRegionChange()
     }
     if (!cur_region->capabilitiesReceived())
     {
+// <FS:PR-Aleric> GCC13 warning: maybe-uninitialized - probably bogus
+#if defined(__GNUC__) && (__GNUC__ >= 13)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+// </FS:PR-Aleric>
         cur_region->setCapabilitiesReceivedCallback([](const LLUUID &region_id, LLViewerRegion* regionp) {  LLEnvironment::instance().requestRegion(); });
+// <FS:PR-Aleric> GCC13 warning: maybe-uninitialized - probably bogus
+#if defined(__GNUC__) && (__GNUC__ >= 13)
+#pragma GCC diagnostic pop
+#endif
+// </FS:PR-Aleric>
         return;
     }
     requestRegion();


### PR DESCRIPTION
For the life of me I can't figure out which variable is supposedly undefined:

```
In file included from /usr/include/string.h:548,
                 from /usr/include/c++/13.2.1/cstring:42,
                 from /opt/secondlife/viewers/firestorm/phoenix-firestorm-git/indra/llcommon/linden_common.h:54,
                 from /opt/secondlife/viewers/firestorm/phoenix-firestorm-git/indra/newview/llviewerprecompiledheaders.h:38,
                 from /opt/secondlife/viewers/firestorm/phoenix-firestorm-git/indra/newview/llenvironment.cpp:27:
In function ‘void* memcpy(void*, const void*, size_t)’,

    inlined from ‘void boost::function2<R, T1, T2>::move_assign(boost::function2<R, T1, T2>&) [with R = void; T0 = const LLUUID&; T1 = LLViewerRegion*]’ at /opt/secondlife/viewers/firestorm/phoenix-firestorm-git/build-linux-x86_64/packages/include/boost/function/function_template.hpp:993:24,

    inlined from ‘void boost::function2<R, T1, T2>::swap(boost::function2<R, T1, T2>&) [with R = void; T0 = const LLUUID&; T1 = LLViewerRegion*]’ at /opt/secondlife/viewers/firestorm/phoenix-firestorm-git/build-linux-x86_64/packages/include/boost/function/function_template.hpp:862:22,

    inlined from ‘typename boost::enable_if_<(! boost::is_integral<Functor>::value), boost::function<R(T0, T1)>&>::type boost::function<R(T0, T1)>::operator=(Functor) [with Functor = LLEnvironment::onRegionChange()::<lambda(const LLUUID&, LLViewerRegion*)>; R = void; T0 = const LLUUID&; T1 = LLViewerRegion*]’ at /opt/secondlife/viewers/firestorm/phoenix-firestorm-git/build-linux-x86_64/packages/include/boost/function/function_template.hpp:1121:22,

    inlined from ‘void boost::signals2::slot<R(Args ...), SlotFunction>::init_slot_function(const F&) [with F = LLEnvironment::onRegionChange()::<lambda(const LLUUID&, LLViewerRegion*)>; SlotFunction = boost::function<void(const LLUUID&, LLViewerRegion*)>; R = void; Args = {const LLUUID&, LLViewerRegion*}]’ at /opt/secondlife/viewers/firestorm/phoenix-firestorm-git/build-linux-x86_64/packages/include/boost/signals2/detail/slot_template.hpp:160:24,

    inlined from ‘boost::signals2::slot<R(Args ...), SlotFunction>::slot(const F&) [with F = LLEnvironment::onRegionChange()::<lambda(const LLUUID&, LLViewerRegion*)>; SlotFunction = boost::function<void(const LLUUID&, LLViewerRegion*)>; R = void; Args = {const LLUUID&, LLViewerRegion*}]’ at /opt/secondlife/viewers/firestorm/phoenix-firestorm-git/build-linux-x86_64/packages/include/boost/signals2/detail/slot_template.hpp:85:27,

    inlined from ‘void LLEnvironment::onRegionChange()’ at /opt/secondlife/viewers/firestorm/phoenix-firestorm-git/indra/newview/llenvironment.cpp:1150:52:
/usr/include/bits/string_fortified.h:29:33: error: ‘*(unsigned char (*)[24])((char*)&<unnamed> + offsetof(boost::self_type, boost::function<void(const LLUUID&, LLViewerRegion*)>::<unnamed>.boost::function2<void, const LLUUID&, LLViewerRegion*>::<unnamed>.boost::function_base::functor))’ may be used uninitialized [-Werror=maybe-uninitialized]
   29 |   return __builtin___memcpy_chk (__dest, __src, __len,
      |          ~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~
   30 |                                  __glibc_objsize0 (__dest));
      |                                  ~~~~~~~~~~~~~~~~~~~~~~~~~~
```

where llenvironment.cpp:1150 is:
```
cur_region->setCapabilitiesReceivedCallback([](const LLUUID &region_id, LLViewerRegion* regionp) {  LLEnvironment::instance(). requestRegion(); });
```
Nevertheless, this has never led to a crash as far as I know; so, probably a bogus warning indeed.