### PR TITLE
Compile warning/error workaround.

### DIFF
--- a/indra/newview/llface.cpp
+++ b/indra/newview/llface.cpp
@@ -2130,8 +2130,18 @@ BOOL LLFace::getGeometryVolume(const LLVolume& volume,
 						LLVector4a t;
 						tangent_to_object.rotate(binormal_dir, t);
 						LLVector4a binormal;
+// <FS:PR-Aleric> GCC13 warning: maybe-uninitialized - probably bogus
+#if defined(__GNUC__) && (__GNUC__ >= 13)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+// </FS:PR-Aleric>
 						mat_normal.rotate(t, binormal);
-						
+// <FS:PR-Aleric>
+#if defined(__GNUC__) && (__GNUC__ >= 13)
+#pragma GCC diagnostic pop
+#endif
+// </FS:PR-Aleric>
 						//VECTORIZE THIS
 						if (mDrawablep->isActive())
 						{


### PR DESCRIPTION
Tested by setting mat_normal to some magic value and then asserting that it was changed by the time we get here.