### PR TITLE
Fix linker error.

### DIFF
--- a/indra/newview/llviewerwindow.cpp
+++ b/indra/newview/llviewerwindow.cpp
@@ -224,7 +224,8 @@
 // </FS:Ansariel> [FS communication UI]
 #include "llwindowlistener.h"
 #include "llviewerwindowlistener.h"
-#include "llpaneltopinfobar.h"
+// <FS:Zi> We don't use the mini location panel in Firestorm
+// #include "llpaneltopinfobar.h"
 #include "llcleanup.h"
 #include "llimview.h"
 #include "llviewermenufile.h"


### PR DESCRIPTION
<FS:Zi> missed this one.

Including this header leads to a linker error when compiling without optimization because then the LLPanelTopInfoBar constructor isn't inlined.

/usr/bin/ld: CMakeFiles/firestorm-bin.dir/llviewerwindow.cpp.o: in function `std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > LLSingletonBase::classname<LLPanelTopInfoBar>()':
/opt/secondlife/viewers/firestorm/phoenix-firestorm-git/indra/llcommon/llsingleton.h:126:(.text._ZN15LLSingletonBase9classnameI17LLPanelTopInfoBarEENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEv[_ZN15LLSingletonBase9classnameI17LLPanelTopInfoBarEENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEv]+0x1e): undefined reference to `typeinfo for LLPanelTopInfoBar'
/usr/bin/ld: CMakeFiles/firestorm-bin.dir/llviewerwindow.cpp.o: in function `void LLSingleton<LLPanelTopInfoBar>::constructSingleton<>(llthread::LockStatic<LLSingleton<LLPanelTopInfoBar>::SingletonData>&)':
/opt/secondlife/viewers/firestorm/phoenix-firestorm-git/indra/llcommon/llsingleton.h:362:(.text._ZN11LLSingletonI17LLPanelTopInfoBarE18constructSingletonIJEEEvRN8llthread10LockStaticINS1_13SingletonDataEEEDpOT_[_ZN11LLSingletonI17LLPanelTopInfoBarE18constructSingletonIJEEEvRN8llthread10LockStaticINS1_13SingletonDataEEEDpOT_]+0x6b): undefined reference to `LLPanelTopInfoBar::LLPanelTopInfoBar()'