### PR TITLE
Avoid assert(w != GLH_ZERO) in glh_linear.h.

### DIFF
--- a/indra/newview/llenvironment.cpp
+++ b/indra/newview/llenvironment.cpp
@@ -1644,6 +1644,14 @@ void LLEnvironment::updateEnvironment(LLSettingsBase::Seconds transition, bool f
     }
     // </FS:Beq>
 
+    // <FS:PR-Aleric>
+    // This call uses gGLModelView from llrender (in LLSettingsVOWater::applySpecial).
+    // If at that point that is still filled with all zeroes then we divide by zero or assert on assert(w != GLH_ZERO);
+    // in mult_matrix_vec (glh/glh_linear.h). A work around is to set it to the identity.
+    glh::matrix4f const identity;
+    set_current_modelview(identity);
+    // </FS:PR-Aleric>
+
     if ((mCurrentEnvironment != pinstance) || forced)
     {
         if (transition != TRANSITION_INSTANT)


### PR DESCRIPTION
Don't call updateEnvironment before having called set_current_modelview at least once (with a matrix that has a non-zero determinant).

This initialization of gGLModelView was added to LLEnvironment::updateEnvironment because it turned out there is a race condition in which thread calls this function first; it is also called from a coroutine thread:

  #7  0x0000555557609cb0 in LLSettingsVOWater::applySpecial (this=0x7fffbe790ff0, ptarget=0x7fffc48c0e00, force=false)
  #8  0x00005555564f572a in LLEnvironment::updateGLVariablesForSettings (uniforms=0x7fffc48c0e00,
  #9  0x00005555564f5928 in LLEnvironment::updateSettingsUniforms (this=0x7fffc48c0e00)
  #10 0x00005555564f441a in LLEnvironment::updateEnvironment (this=0x7fffc48c0e00, transition=..., forced=false)
  #11 0x00005555564f72fc in LLEnvironment::recordEnvironment (this=0x7fffc48c0e00, parcel_id=-1,
  #12 0x00005555564f8413 in operator() (__closure=0x7fffcdeb8520, pid=-1,
  #13 0x0000555556518521 in std::__invoke_impl<void, LLEnvironment::requestParcel(S32, environment_apply_fn)::<lambda(S32, LLEnvironment::EnvironmentInfo::ptr_t)>&, int, std::shared_ptr<LLEnvironment::EnvironmentInfo> >(std::__invoke_other, struct {...} &) (__f=...)
  ...
  #24 0x0000555558ab4485 in std::__invoke_impl<void, LLCoros::launch(const std::string&, const callable_t&)::<lambda()> >(std::__invoke_other, struct {...} &&) (__f=...) at /usr/include/c++/13.2.1/bits/invoke.h:61
  ...
  #28 0x0000555558ab4173 in boost::fibers::worker_context<LLCoros::launch(const std::string&, const callable_t&)::<lambda()> >::run_(boost::context::fiber &&) (this=0x7fffcdeb8e00, c=...)
  ...
  #38 0x00005555594b764f in make_fcontext ()

while this change takes care of the assert (or a division by zero without that assert), it seems to me that this is still UB (possible concurrent execution of the same code outside of a critical area). This seems unrelated to this fix however.