### PR TITLE
Fix "duplicated copyright" error.

### DIFF
--- a/scripts/packages-formatter.py
+++ b/scripts/packages-formatter.py
@@ -86,7 +86,7 @@ viewer_copyright = copyrights.readline() # first line is the copyright for the v
 # Two different autobuild outputs, but we treat them essentially the same way:
 # populating each into a dict; each a subdict of 'info'.
 for key, rawdata in ("versions", versions), ("copyrights", copyrights):
-# <FS:Al> The trick with re-entering `for line in lines:` doesn't work: it causes all lines to be read twice (on my machine).
+# <FS:PR-Aleric> The trick with re-entering `for line in lines:` doesn't work: it causes all lines to be read twice (on my machine).
     # Just read the output once and use simple(r) logic.
     lines = rawdata.readlines();
     first_line = True
@@ -108,7 +108,7 @@ for key, rawdata in ("versions", versions), ("copyrights", copyrights):
         if not first_line:
             add_info(key, pkg, pkg_lines)
         first_line = False;
-# </FS:Al>
+# </FS:PR-Aleric>
 
 # Now that we've run through all of both outputs -- are there duplicates?
 if any(pkgs for pkgs in list(dups.values())):


### PR DESCRIPTION
This solves a 'Duplicate copyrights for zlib-ng' problem. The reason turned out to be a mysterious restart of reading the output pipe of the command

  copyrights=autobuild('install', '--copyrights', '--install-dir', args.install_dir).

The output of that command is:
```
  Copyright (c) 2023, The Phoenix Firestorm Project, Inc.
  SDL2: Copyright (C) 1997-2022 Sam Lantinga
  ...
  zlib-ng: Copyright (C) 1995-2013 Jean-loup Gailly and Mark Adler
```
where the first line is consumed by `viewer_copyright = copyrights.readline()`.

But because the stream is read twice, it looks as if we have:
```
  ...
  zlib-ng: Copyright (C) 1995-2013 Jean-loup Gailly and Mark Adler
  Copyright (c) 2023, The Phoenix Firestorm Project, Inc.
  SDL2: Copyright (C) 1997-2022 Sam Lantinga
  ...
  zlib-ng: Copyright (C) 1995-2013 Jean-loup Gailly and Mark Adler
```
and now that first `Copyright (c) 2023, The Phoenix Firestorm Project, Inc.` line is added to the copyright line(s) of zlib-ng (because it doesn't begin with `packagename:`), which then results in "two" zlib-ng packages with a "different" copyright line.

I am not sure if the code was buggy or that python3 on Arch is buggy, but this code is shorter and easier to understand, too.