### PR TITLE
Workaround for repeated viewer copyright.

### DIFF
--- a/scripts/packages-formatter.py
+++ b/scripts/packages-formatter.py
@@ -109,7 +109,7 @@ for key, rawdata in ("versions", versions), ("copyrights", copyrights):
                     # we hit the start of the next package data
                     add_info(key, pkg, pkg_lines)
                     break
-                else:
+                elif line != viewer_copyright:  # <FS:PR-Aleric> skip possibly repeated viewer copyright line(s).
                     # no package prefix: additional line for same package
                     pkg_lines.append(line.rstrip())
             else:


### PR DESCRIPTION
This happens when autobuild outputs everything twice. I can't figure out why it does that, but it does.

The problem of that is that the second 'viewer copyright' line is then appended to the copyright line(s) of the last packages, causing the error "Duplicated copyright" (thinking we have two packages with the same name but a different copyright).