### PR TITLE
Fix Linux volume catcher

### DIFF
--- a/indra/media_plugins/cef/linux_volume_catcher.cpp
+++ b/indra/media_plugins/cef/linux_volume_catcher.cpp
@@ -286,7 +286,9 @@ void VolumeCatcherImpl::setVolume(F32 volume)
 
 void VolumeCatcherImpl::pump()
 {
-	return;
+	if (mGotSyms && mMainloop) {
+		llpa_mainloop_iterate(mMainloop, 0, NULL);
+	}
 }
 
 void VolumeCatcherImpl::connected_okay()

--- a/indra/media_plugins/cef/linux_volume_catcher_pa_syms.inc
+++ b/indra/media_plugins/cef/linux_volume_catcher_pa_syms.inc
@@ -21,5 +21,6 @@ LL_PA_SYM(true, pa_sw_volume_from_linear, pa_volume_t, double v);
 LL_PA_SYM(true, pa_mainloop_free, void, pa_mainloop* m);
 LL_PA_SYM(true, pa_mainloop_get_api, pa_mainloop_api*, pa_mainloop* m);
 LL_PA_SYM(true, pa_mainloop_new, pa_mainloop*, void);
+LL_PA_SYM(true, pa_mainloop_iterate, int, pa_mainloop*, int, int*);
 
 // optional symbols to grab


### PR DESCRIPTION
The volume slider for web media didn't seem to work for me. I'm using Pipewire which provides a Pulseaudio interface for other software to use and is fully compatible (through `/run/user/1000/pulse/native`). I took a look at the Linux volume catcher code and realized that `pa_mainloop_run` or `pa_mainloop_iterate` was never run.

In the official `pacat` (`paplay`) tool, they start the loop right after connecting with the newly created context:
https://github.com/pulseaudio/pulseaudio/blob/84f5b742e39ba3e375bac9144e0243b7331f4019/src/utils/pacat.c#L1222

Check out `pa_mainloop_iterate` here:
https://www.freedesktop.org/software/pulseaudio/doxygen/mainloop_8h.html#a491422aebe5487800d8be0bf4153cb81

I figured `pump()` was being called every 100 ms through `idle` message from `llpluginprocesschild.cpp` in `media_plugin_cef.cpp`, so used it for the update loop Pulseaudio requires. CEF seems to get updated through the same `idle` message too. This fixes the issue.

I'm so surprised nobody added the mainloop calls. Perhaps it worked fine with the official Pulseaudio server? It's definitely required if you read through their doxygen docs. Makes me wonder if the Pipewire implementation is more correct than the official one.

https://github.com/FirestormViewer/phoenix-firestorm/assets/8362329/28273779-d6c8-40e6-b410-8155100ba15b