### PR TITLE
fix RelWithDebInfo build error: 'comboTexGen': undeclared identifier

### DIFF
--- a/indra/newview/fspanelface.cpp
+++ b/indra/newview/fspanelface.cpp
@@ -1149,7 +1149,6 @@ struct FSPanelFaceSetTEFunctor : public LLSelectedTEFunctor
 
 		bool align_planar = mPanel->mCheckPlanarAlign->get();
 
-		llassert(comboTexGen);
 		llassert(object);
 
 		if (ctrlTexScaleS)


### PR DESCRIPTION
This fixes the only build error I encountered trying to run `autobuild build -A 64 -c RelWithDebInfoFS_open`:
```
E:\cabbage\sl\phoenix-firestorm\indra\newview\fspanelface.cpp(1152,3): error C2065: 'comboTexGen': undeclared identifie r [E:\cabbage\sl\phoenix-firestorm\build-vc170-64\newview\firestorm-bin.vcxproj]
```
all the `getChild()` calls here are null-checked with an `if`, so I'm not sure why there's any llassert here