### PR TITLE
FIRE-33670 Derender whole avatars, instead of individual attachments

### DIFF
--- a/indra/newview/llviewermenu.cpp
+++ b/indra/newview/llviewermenu.cpp
@@ -3108,10 +3108,18 @@ void derenderObject(bool permanent)
 
 	while ((objp = select_mgr->getSelection()->getFirstRootObject(TRUE)))
 	{
-//		if ( (objp) && (gAgentID != objp->getID()) )
+        if ( (objp) && (objp->isAttachment()) )
+		// Disallow derendering of attachments. Derender the avatar instead. FIRE-33670
+        {
+            select_mgr->deselectObjectOnly(objp);
+            objp = objp->getAvatarAncestor();
+        }
+
+ 		if ( (objp) && (gAgentID != objp->getID()) )
 // [RLVa:KB] - Checked: 2012-03-11 (RLVa-1.4.5) | Added: RLVa-1.4.5 | FS-specific
 		// Don't allow derendering of own attachments when RLVa is enabled
-		if ( (objp) && (gAgentID != objp->getID()) && ((!rlv_handler_t::isEnabled()) || (!objp->isAttachment()) || (!objp->permYouOwner())) )
+		// Obsoleted by disallowing derendering of attachments in general. FIRE-33670
+		// if ( (objp) && (gAgentID != objp->getID()) && ((!rlv_handler_t::isEnabled()) || (!objp->isAttachment()) || (!objp->permYouOwner())) )
 // [/RLVa:KB]
 		{
 			LLUUID id = objp->getID();
@@ -3193,10 +3201,9 @@ void derenderObject(bool permanent)
 			}
 
 		}
-		else if( (objp) && (gAgentID != objp->getID()) && ((rlv_handler_t::isEnabled()) || (objp->isAttachment()) || (objp->permYouOwner())) )
+		else if( (objp) )
 		{
 			select_mgr->deselectObjectOnly(objp);
-			return;
 		}
 	}
 

--- a/indra/newview/skins/default/xui/en/menu_attachment_self.xml
+++ b/indra/newview/skins/default/xui/en/menu_attachment_self.xml
@@ -429,24 +429,6 @@ name="Stand Up">
        function="Object.EnableScriptInfo" />
   </menu_item_call>
   <menu_item_call
-      enabled="true"
-      label="Derender"
-      name="Derender">
-      <menu_item_call.on_click
-       function="Object.Derender" />
-      <menu_item_call.on_enable
-       function="Object.EnableDerender" />
-  </menu_item_call>
-   <menu_item_call
-      enabled="true"
-      label="Derender + Blacklist"
-      name="DerenderPermanent">
-    <menu_item_call.on_click
-      function="Object.DerenderPermanent" />
-    <menu_item_call.on_enable
-      function="Object.EnableDerender" />
-   </menu_item_call>
-  <menu_item_call
  label="Show Textures"
      name="Debug...">
     <menu_item_call.on_click

--- a/indra/newview/skins/default/xui/en/menu_pie_attachment_self.xml
+++ b/indra/newview/skins/default/xui/en/menu_pie_attachment_self.xml
@@ -49,31 +49,6 @@
                 name="EnableTouch"/>
         </pie_slice>
         <pie_menu
-            name="DerenderMenu"
-            label="Derender &gt;">
-			<pie_separator />
-			<pie_separator />
-			<pie_separator />
-			<pie_slice
-				enabled="true"
-				label="Temporary"
-				name="Derender">
-				<pie_slice.on_click
-					function="Object.Derender" />
-				<pie_slice.on_enable
-					function="Object.EnableDerender" />
-			</pie_slice>
-			<pie_slice
-				enabled="true"
-				label="Blacklist"
-				name="DerenderPermanent">
-				<pie_slice.on_click
-					function="Object.DerenderPermanent" />
-				<pie_slice.on_enable
-					function="Object.EnableDerender" />
-			</pie_slice>
-        </pie_menu>
-        <pie_menu
             name="ExportMenu"
             label="Save as &gt;">
             <pie_slice


### PR DESCRIPTION
Individual attachments can no longer be derendered. Closes [FIRE-33670](https://jira.firestormviewer.org/browse/FIRE-33670)

Instead, if you choose derender on an attachment, the whole avatar is derendered

I also removed derender from the menu of your own attachments, since derendering yourself isn't allowed. I'm open to re-allowing derendering your own attachments. It was already disabled if RLVa was enabled, due to being a blindfold HUD workaround