### PR TITLE
FIRE-33613: Allow camera to view negative Z in OpenSim builds

### DIFF
--- a/indra/newview/llagentcamera.cpp
+++ b/indra/newview/llagentcamera.cpp
@@ -2145,10 +2145,21 @@ LLVector3d LLAgentCamera::calcCameraPositionTargetGlobal(BOOL *hit_limit)
     }
 // [/RLVa:KB]
 
+// <FS:humbletim> FIRE-33613: [OpenSim] [PBR] Camera cannot be located at negative Z
+    F32 camera_ground_plane = F_ALMOST_ZERO;
+#ifdef OPENSIM
+    // integrate OpenSimExtras.MinSimHeight into the camera ground plane calculation
+    if (auto regionp = LLWorld::getInstance()->getRegionFromPosGlobal(camera_position_global))
+    {
+      camera_ground_plane += regionp->getMinSimHeight();
+    }
+#endif
+// </FS:humbletim>
+
     // Don't let camera go underground
     F32 camera_min_off_ground = getCameraMinOffGround();
     camera_land_height = LLWorld::getInstance()->resolveLandHeightGlobal(camera_position_global);
-    F32 minZ = llmax(F_ALMOST_ZERO, camera_land_height + camera_min_off_ground);
+    F32 minZ = llmax(camera_ground_plane, camera_land_height + camera_min_off_ground);
     if (camera_position_global.mdV[VZ] < minZ)
     {
         camera_position_global.mdV[VZ] = minZ;

--- a/indra/newview/llviewerregion.cpp
+++ b/indra/newview/llviewerregion.cpp
@@ -675,7 +675,8 @@ LLViewerRegion::LLViewerRegion(const U64 &handle,
 // </FS:Beq>
     // <FS:CR> Aurora Sim
     mWidth(region_width_meters),
-    mWidthScaleFactor(region_width_meters / REGION_WIDTH_METERS) // <FS:Ansariel> FIRE-19563: Scaling for OpenSim VarRegions
+    mWidthScaleFactor(region_width_meters / REGION_WIDTH_METERS), // <FS:Ansariel> FIRE-19563: Scaling for OpenSim VarRegions
+    mMinSimHeight(0.f) // <FS:humbletim> FIRE-33613: [OpenSim] [PBR] Camera cannot be located at negative Z
 {
     // Moved this up... -> mWidth = region_width_meters;
 // </FS:CR>
@@ -2632,6 +2633,11 @@ void LLViewerRegion::setSimulatorFeatures(const LLSD& sim_features)
     mMaxTEs   = LLAvatarAppearanceDefines::ETextureIndex::TEX_NUM_INDICES;
 #endif // OPENSIM
 // </FS:Beq>
+// <FS:humbletim> FIRE-33613: [OpenSim] [PBR] Camera cannot be located at negative Z
+#ifdef OPENSIM
+    mMinSimHeight = !mSimulatorFeatures.has("OpenSimExtras") ? 0.0f : mSimulatorFeatures["OpenSimExtras"]["MinSimHeight"].asReal();
+#endif
+// </FS:humbletim>
 }
 
 //this is called when the parent is not cacheable.

--- a/indra/newview/llviewerregion.h
+++ b/indra/newview/llviewerregion.h
@@ -249,6 +249,7 @@ public:
 
     F32 getWidth() const                        { return mWidth; }
     F32 getWidthScaleFactor() const             { return mWidthScaleFactor; } // <FS:Ansariel> FIRE-19563: Scaling for OpenSim VarRegions
+    F32 getMinSimHeight() const                 { return mMinSimHeight; } // <FS:humbletim/> FIRE-33613: [OpenSim] [PBR] Camera cannot be located at negative Z
 
     // regions are expensive to release, this function gradually releases cache from memory
     static void idleCleanup(F32 max_update_time);
@@ -548,7 +549,8 @@ public:
     S32         mLastUpdate; //last time called idleUpdate()
     F32         mWidthScaleFactor; // <FS:Ansariel> FIRE-19563: Scaling for OpenSim VarRegions
     S32         mMaxBakes; // <FS:Beq/> store max bakes on the region
-    S32         mMaxTEs; // <FS:Beq/> store max bakes on the region
+    S32         mMaxTEs; // <FS:Beq/> store max texture entries on the region
+    F32         mMinSimHeight; // <FS:humbletim/> FIRE-33613: [OpenSim] [PBR] Camera cannot be located at negative Z
     // simulator name
     std::string mName;
     std::string mZoning;


### PR DESCRIPTION
This PR addresses a regression introduced in recent Firestorm releases (7.1.3 and likely earlier) that prevents the camera from being positioned below Z=0 in OpenSim regions. This issue disrupts the ability of users to view avatars and objects situated at negative Z, hindering interaction with underwater builds and other scenarios. 

**Changes:**

- **Introduced `LLViewerRegion::mMinSimHeight` and `LLViewerRegion::getMinSimHeight()`** to track the minimum simulation height advertised by OpenSim regions. 
- **Refined the camera position calculation** in `llagentcamera.cpp` to respect `mMinSimHeight` when applicable, effectively removing the artificial Z=0 floor for OpenSim regions.

This solution leverages existing OpenSim infrastructure by using the `OpenSimExtras.MinSimHeight` value advertised in Simulation Features. If this value is not present, the default behavior is preserved, ensuring compatibility with Second Life.

**See also:**

- [FIRE-33613: [OpenSim] [PBR] Camera cannot be located at negative Z](https://jira.firestormviewer.org/browse/FIRE-33613) Jira bug report
- [metaverse-crossroads/hypergrid-junction#2](https://github.com/metaverse-crossroads/hypergrid-junction/issues/2) for detailed discussion and investigation. 
