### PR TITLE
fix build target name in docs RelWithDebInfo_open -> RelWithDebInfoFS…

### DIFF
--- a/doc/building_linux.md
+++ b/doc/building_linux.md
@@ -158,7 +158,7 @@ Available premade firestorm-specific build targets:
 ```
 ReleaseFS           (includes KDU, FMOD)
 ReleaseFS_open      (no KDU, no FMOD)
-RelWithDebInfo_open (no KDU, no FMOD)
+RelWithDebInfoFS_open (no KDU, no FMOD)
 ```
 
 ### Configuration Switches


### PR DESCRIPTION
I assume whoever wrote that accidentally left out the FS, or at least that one exists and the one without FS does not.