### PR TITLE
Add option to avoid touching attachments when shift clicking avatar

### DIFF
--- a/indra/newview/app_settings/settings.xml
+++ b/indra/newview/app_settings/settings.xml
@@ -22255,6 +22255,17 @@ Change of this parameter will affect the layout of buttons in notification toast
         <key>Value</key>
         <integer>1</integer>
     </map>
+    <key>FSShiftClickAvoidsAvatarAttachments</key>
+    <map>
+        <key>Comment</key>
+        <string>If true, shift clicking on avatar will avoid touching attachments</string>
+        <key>Persist</key>
+        <integer>1</integer>
+        <key>Type</key>
+        <string>Boolean</string>
+        <key>Value</key>
+        <integer>0</integer>
+    </map>
     <key>FSShowInterfaceInMouselook</key>
     <map>
         <key>Comment</key>

--- a/indra/newview/skins/default/xui/en/panel_preferences_move.xml
+++ b/indra/newview/skins/default/xui/en/panel_preferences_move.xml
@@ -254,6 +254,17 @@
          width="350"
          tool_tip="If enabled, temporary derendered objects will stay derendered until teleport. If disabled, they stay derendered until the end of the session or get manually re-rendered via the asset blacklist window."
          control_name="FSTempDerenderUntilTeleport"/>
+        <check_box
+         top_pad="3"
+         follows="left|top"
+         height="16"
+         initial_value="false"
+         label="Shift click on avatar will avoid touching attachments"
+         layout="topleft"
+         left="20"
+         name="FSShiftClickAvoidsAvatarAttachments"
+         width="350"
+         control_name="FSShiftClickAvoidsAvatarAttachments"/>
 	</panel>
 
     <!--Mouselook-->


### PR DESCRIPTION
I have lots of attachments on my avatar and it's become increasingly difficult to click on my avatar to focus and move.

This PR adds an option that lets you avoid touching attachments whilst pressing shift when clicking your avatar.

The only issue I've encountered is that hud attachments stop being touchable when holding shift.

The cursor also still indicates that attachments are clickable.

![image](https://github.com/FirestormViewer/phoenix-firestorm/assets/8362329/99f890b4-2709-4c74-8d36-4e91e725163f)
