### PR TITLE
Raised the 512x512 limitation for uploading snapshots to inventory to 2048x2048

### DIFF
--- a/indra/newview/llagentbenefits.cpp
+++ b/indra/newview/llagentbenefits.cpp
@@ -267,6 +267,25 @@ S32 LLAgentBenefits::getTextureUploadCost(const LLImageBase* tex) const
     return getTextureUploadCost();
 }
 
+// <FS:Chanayane> 2048x2048 snapshots upload to inventory
+S32 LLAgentBenefits::getTextureUploadCost(S32 w, S32 h) const
+{
+    if (w > 0 && h > 0)
+    {
+        S32 area = w * h;
+        if (area >= MIN_2K_TEXTURE_AREA)
+        {
+            return get2KTextureUploadCost(area);
+        }
+        else
+        {
+            return getTextureUploadCost();
+        }
+    }
+    return getTextureUploadCost();
+}
+// </FS:Chanayane>
+
 S32 LLAgentBenefits::get2KTextureUploadCost(S32 area) const
 {
     if (m_2k_texture_upload_cost.empty())

--- a/indra/newview/llagentbenefits.h
+++ b/indra/newview/llagentbenefits.h
@@ -54,6 +54,9 @@ public:
     S32 getTextureUploadCost() const;
     S32 getTextureUploadCost(const LLViewerTexture* tex) const;
     S32 getTextureUploadCost(const LLImageBase* tex) const;
+    // <FS:Chanayane> 2048x2048 snapshots upload to inventory
+    S32 getTextureUploadCost(S32 w, S32 h) const;
+    // </FS:Chanayane>
     S32 get2KTextureUploadCost(S32 area) const;
 
     bool findUploadCost(LLAssetType::EType& asset_type, S32& cost) const;

--- a/indra/newview/llfloatersnapshot.cpp
+++ b/indra/newview/llfloatersnapshot.cpp
@@ -58,7 +58,10 @@ LLSnapshotFloaterView* gSnapshotFloaterView = NULL;
 const F32 AUTO_SNAPSHOT_TIME_DELAY = 1.f;
 
 const S32 MAX_POSTCARD_DATASIZE = 1572864; // 1.5 megabyte, similar to simulator limit
-const S32 MAX_TEXTURE_SIZE = 512 ; //max upload texture size 512 * 512
+// <FS:Chanayane> 2048x2048 snapshots upload to inventory
+//const S32 MAX_TEXTURE_SIZE = 512 ; //max upload texture size 512 * 512
+const S32 MAX_TEXTURE_SIZE = 2048 ; //max upload texture size 2048 * 2048
+// <FS:Chanayane> 2048x2048 snapshots upload to inventory
 
 static LLDefaultChildRegistry::Register<LLSnapshotFloaterView> r("snapshot_floater_view");
 

--- a/indra/newview/llpanelsnapshot.cpp
+++ b/indra/newview/llpanelsnapshot.cpp
@@ -41,7 +41,10 @@
 
 #include "llagentbenefits.h"
 
-const S32 MAX_TEXTURE_SIZE = 512 ; //max upload texture size 512 * 512
+// <FS:Chanayane> 2048x2048 snapshots upload to inventory
+//const S32 MAX_TEXTURE_SIZE = 512 ; //max upload texture size 512 * 512
+const S32 MAX_TEXTURE_SIZE = 2048 ; //max upload texture size 2048 * 2048
+// </FS:Chanayane>
 
 S32 power_of_two(S32 sz, S32 upper)
 {
@@ -66,7 +69,12 @@ BOOL LLPanelSnapshot::postBuild()
     LLUICtrl* save_btn = findChild<LLUICtrl>("save_btn");
     if (save_btn)
     {
-        save_btn->setLabelArg("[UPLOAD_COST]", std::to_string(LLAgentBenefitsMgr::current().getTextureUploadCost()));
+        // <FS:Chanayane> 2048x2048 snapshots upload to inventory
+        //save_btn->setLabelArg("[UPLOAD_COST]", std::to_string(LLAgentBenefitsMgr::current().getTextureUploadCost()));
+        S32 w = getTypedPreviewWidth();
+        S32 h = getTypedPreviewHeight();
+        save_btn->setLabelArg("[UPLOAD_COST]", std::to_string(LLAgentBenefitsMgr::current().getTextureUploadCost(w, h)));
+        // </FS:Chanayane>
     }
     // </FS:Ansariel>
     getChild<LLUICtrl>(getImageSizeComboName())->setCommitCallback(boost::bind(&LLPanelSnapshot::onResolutionComboCommit, this, _1));

--- a/indra/newview/llpanelsnapshotinventory.cpp
+++ b/indra/newview/llpanelsnapshotinventory.cpp
@@ -187,7 +187,23 @@ LLPanelSnapshotInventory::~LLPanelSnapshotInventory()
 
 void LLPanelSnapshotInventoryBase::onSend()
 {
-    S32 expected_upload_cost = LLAgentBenefitsMgr::current().getTextureUploadCost();
+    // <FS:Chanayane> 2048x2048 snapshots upload to inventory
+    //S32 expected_upload_cost = LLAgentBenefitsMgr::current().getTextureUploadCost();
+    S32 w = 0;
+    S32 h = 0;
+
+    if( mSnapshotFloater )
+    {
+        LLSnapshotLivePreview* preview = mSnapshotFloater->getPreviewView();
+        if( preview )
+        {
+            preview->getSize(w, h);
+        }
+    }
+
+    S32 expected_upload_cost = LLAgentBenefitsMgr::current().getTextureUploadCost(w, h);
+    // </FS:Chanayane>
+    
     if (can_afford_transaction(expected_upload_cost))
     {
         if (mSnapshotFloater)

--- a/indra/newview/llpanelsnapshotoptions.cpp
+++ b/indra/newview/llpanelsnapshotoptions.cpp
@@ -30,6 +30,7 @@
 #include "llsidetraypanelcontainer.h"
 
 #include "llfloatersnapshot.h" // FIXME: create a snapshot model
+#include "llsnapshotlivepreview.h" // <FS:Chanayane> 2048x2048 snapshots upload to inventory
 #include "llfloaterreg.h"
 #include "llfloaterflickr.h" // <FS:Ansariel> Share to Flickr
 
@@ -92,7 +93,22 @@ void LLPanelSnapshotOptions::onOpen(const LLSD& key)
 
 void LLPanelSnapshotOptions::updateUploadCost()
 {
-    S32 upload_cost = LLAgentBenefitsMgr::current().getTextureUploadCost();
+    // <FS:Chanayane> 2048x2048 snapshots upload to inventory
+    //S32 upload_cost = LLAgentBenefitsMgr::current().getTextureUploadCost();
+    S32 w = 0;
+    S32 h = 0;
+
+    if( mSnapshotFloater )
+    {
+        LLSnapshotLivePreview* preview = mSnapshotFloater->getPreviewView();
+        if( preview )
+        {
+            preview->getSize(w, h);
+        }
+    }
+    
+    S32 upload_cost = LLAgentBenefitsMgr::current().getTextureUploadCost(w, h);
+    // </FS:Chanayane>
     getChild<LLUICtrl>("save_to_inventory_btn")->setLabelArg("[AMOUNT]", llformat("%d", upload_cost));
 }
 

--- a/indra/newview/llsnapshotlivepreview.cpp
+++ b/indra/newview/llsnapshotlivepreview.cpp
@@ -66,7 +66,10 @@ F32 FALL_TIME = 0.6f;
 S32 BORDER_WIDTH = 6;
 S32 TOP_PANEL_HEIGHT = 30;
 
-const S32 MAX_TEXTURE_SIZE = 512 ; //max upload texture size 512 * 512
+// <FS:Chanayane> 2048x2048 snapshots upload to inventory
+//const S32 MAX_TEXTURE_SIZE = 512 ; //max upload texture size 512 * 512
+const S32 MAX_TEXTURE_SIZE = 2048 ; //max upload texture size 2048 * 2048
+// <FS:Chanayane> 2048x2048 snapshots upload to inventory
 
 std::set<LLSnapshotLivePreview*> LLSnapshotLivePreview::sList;
 LLPointer<LLImageFormatted> LLSnapshotLivePreview::sSaveLocalImage = NULL;
@@ -1131,7 +1134,10 @@ void LLSnapshotLivePreview::saveTexture(BOOL outfit_snapshot, std::string name)
         LLAgentUI::buildLocationString(pos_string, LLAgentUI::LOCATION_FORMAT_FULL);
         std::string who_took_it;
         LLAgentUI::buildFullname(who_took_it);
-        S32 expected_upload_cost = LLAgentBenefitsMgr::current().getTextureUploadCost();
+        // <FS:Chanayane> 2048x2048 snapshots upload to inventory
+        //S32 expected_upload_cost = LLAgentBenefitsMgr::current().getTextureUploadCost();
+        S32 expected_upload_cost = LLAgentBenefitsMgr::current().getTextureUploadCost(scaled->getWidth(), scaled->getHeight());
+        // </FS:Chanayane>
         std::string res_name = outfit_snapshot ? name : "Snapshot : " + pos_string;
         std::string res_desc = outfit_snapshot ? "" : "Taken by " + who_took_it + " at " + pos_string;
         LLFolderType::EType folder_type = outfit_snapshot ? LLFolderType::FT_NONE : LLFolderType::FT_SNAPSHOT_CATEGORY;


### PR DESCRIPTION
I don't know if there is a reason why snapshots to inventory have been blocked to 512x512 until now. If there are no reasons, then here is a pull request that allow to upload snapshots to inventory up to 2048x2048.
The cost of the upload is updated according to the area of the snapshot.