### PR TITLE
annotate gcc 13 dangling reference to temporary errors so they are ignored

### DIFF
--- a/indra/llui/llfloaterreg.h
+++ b/indra/llui/llfloaterreg.h
@@ -123,7 +123,18 @@ public:
     static bool destroyInstance(const std::string& name, const LLSD& key = LLSD());
 
     // Iterators
+    // <FS> ignore dangling reference false positives in gcc13
+#if defined(__GNUC__) && (__GNUC__ >= 13)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdangling-reference"
+#endif
+    // </FS>
     static const_instance_list_t& getFloaterList(const std::string& name);
+    // <FS> ignore dangling reference false positives in gcc13
+#if defined(__GNUC__) && (__GNUC__ >= 13)
+#pragma GCC diagnostic pop
+#endif
+    // </FS>
 
     // Visibility Management
 // [RLVa:KB] - Checked: 2012-02-07 (RLVa-1.4.5) | Added: RLVa-1.4.5

--- a/indra/newview/llpathfindingnavmesh.cpp
+++ b/indra/newview/llpathfindingnavmesh.cpp
@@ -139,7 +139,18 @@ void LLPathfindingNavMesh::handleNavMeshResult(const LLSD &pContent, U32 pNavMes
         ENavMeshRequestStatus status;
         if ( pContent.has(NAVMESH_DATA_FIELD) )
         {
+            // <FS> ignore dangling reference false positives in gcc13
+#if defined(__GNUC__) && (__GNUC__ >= 13)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdangling-reference"
+#endif
+            // </FS>
             const LLSD::Binary &value = pContent.get(NAVMESH_DATA_FIELD).asBinary();
+            // <FS> ignore dangling reference false positives in gcc13
+#if defined(__GNUC__) && (__GNUC__ >= 13)
+#pragma GCC diagnostic pop
+#endif
+            // </FS>
             unsigned int binSize = value.size();
             std::string newStr(reinterpret_cast<const char *>(&value[0]), binSize);
             std::istringstream streamdecomp( newStr );

--- a/indra/newview/rlvcommon.cpp
+++ b/indra/newview/rlvcommon.cpp
@@ -490,7 +490,14 @@ void RlvUtil::filterLocation(std::string& strUTF8Text)
 {
     // Filter any mention of the surrounding region names
     LLWorld::region_list_t regions = LLWorld::getInstance()->getRegionList();
+#if defined(__GNUC__) && (__GNUC__ >= 13)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdangling-reference"
+#endif
     const std::string& strHiddenRegion = RlvStrings::getString(RlvStringKeys::Hidden::Region);
+#if defined(__GNUC__) && (__GNUC__ >= 13)
+#pragma GCC diagnostic pop
+#endif
     for (LLWorld::region_list_t::const_iterator itRegion = regions.begin(); itRegion != regions.end(); ++itRegion)
         boost::replace_all_regex(strUTF8Text, boost::regex("\\b" + escape_for_regex((*itRegion)->getName()) + "\\b", boost::regex::icase), strHiddenRegion);
 

--- a/indra/newview/rlvhandler.cpp
+++ b/indra/newview/rlvhandler.cpp
@@ -374,7 +374,14 @@ void RlvHandler::getAttachmentResourcesCoro(const std::string& strUrl)
             for (LLSD::array_const_iterator itAttachObj = sdAttachObjects.beginArray(), endAttachObj = sdAttachObjects.endArray(); itAttachObj != endAttachObj; ++itAttachObj)
             {
                 const LLUUID idObj = itAttachObj->get("id").asUUID();
+#if defined(__GNUC__) && (__GNUC__ >= 13)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdangling-reference"
+#endif
                 const std::string& strObjName = itAttachObj->get("name").asStringRef();
+#if defined(__GNUC__) && (__GNUC__ >= 13)
+#pragma GCC diagnostic pop
+#endif
 
                 // If it's an attachment, it should be a temporary one (NOTE: we might catch it before it's had a chance to attach)
                 const LLViewerObject* pObj = gObjectList.findObject(idObj);


### PR DESCRIPTION
Mostly errors like

```
phoenix-firestorm/indra/newview/fsfloaterimcontainer.cpp: In static member function ‘static void FSFloaterIMContainer::reloadEmptyFloaters()’:
phoenix-firestorm/indra/newview/fsfloaterimcontainer.cpp:433:42: error: possibly dangling reference to a temporary [-Werror=dangling-reference]
  433 |     LLFloaterReg::const_instance_list_t& inst_list = LLFloaterReg::getFloaterList("fs_impanel");
      |                                          ^~~~~~~~~
phoenix-firestorm/indra/newview/fsfloaterimcontainer.cpp:433:82: note: the temporary was destroyed at the end of the full expression ‘LLFloaterReg::getFloaterList(std::__cxx11::basic_string<char>(((const char*)"fs_impanel"), std::allocator<char>()))’
  433 |     LLFloaterReg::const_instance_list_t& inst_list = LLFloaterReg::getFloaterList("fs_impanel");
      |                                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~
```