### PR TITLE
Fix: Texture Fixes to Stop Recode Loop and Bad Decodes (Mergeable)

### DIFF
--- a/indra/llimage/llimagej2c.cpp
+++ b/indra/llimage/llimagej2c.cpp
@@ -265,11 +265,12 @@ S32 LLImageJ2C::calcDataSizeJ2C(S32 w, S32 h, S32 comp, S32 discard_level, F32 r
     S32 surface = w*h;
     S32 s = 64*64;    
     S32 precision = 8; // assumed bitrate per component channel, might change in future for HDR support
-    S32 totalbytes = (S32)(s * comp * precision * rate); // total assumed bits in pyramid, first level computed before loop
+    S32 max_components = 4; // assume file has the maximum number of components, three for color and one for alpha.
+    S32 totalbytes = (S32)(s * max_components * precision * rate); // total assumed bits in pyramid, first level computed before loop
     while (surface > s)
     {
         if (nb_layers <= (5 - discard_level))
-            totalbytes += (S32)(s * comp * precision * rate);
+            totalbytes += (S32)(s * max_components * precision * rate);
         nb_layers++;
         s *= 4;
     }

--- a/indra/llimage/llimagej2c.cpp
+++ b/indra/llimage/llimagej2c.cpp
@@ -263,13 +263,13 @@ S32 LLImageJ2C::calcDataSizeJ2C(S32 w, S32 h, S32 comp, S32 discard_level, F32 r
     // Estimate the number of layers. This is consistent with what's done for j2c encoding in LLImageJ2CKDU::encodeImpl().
     S32 nb_layers = 1;
     S32 surface = w*h;
-    S32 s = 64*64;
+    S32 s = 64*64;    
     S8  precision = 8; // assumed bitrate per component channel
-    S32 totalbytes = 0; // total assumed bits in pyramid
+    S32 totalbytes = (s * comp * (S32) precision) * rate; // total assumed bits in pyramid, first level computed before loop
     while (surface > s)
     {
-        if (nb_layers <= (6 - discard_level))
-        totalbytes += (s * comp * (S32) precision) * rate;
+        if (nb_layers <= (5 - discard_level))
+            totalbytes += (s * comp * (S32) precision) * rate;
         nb_layers++;
         s *= 4;
     }
@@ -290,9 +290,9 @@ S32 LLImageJ2C::calcDataSizeJ2C(S32 w, S32 h, S32 comp, S32 discard_level, F32 r
     S32 new_bytes = (S32) (sqrt((F32)(w*h))*(F32)(comp)*rate*1000.f/layer_factor);
     S32 old_bytes = (S32)((F32)(w*h*comp)*rate);
     bytes = (LLImage::useNewByteRange() && (new_bytes < old_bytes) ? new_bytes : old_bytes);
-    bytes = llmax(totalbytes, calcHeaderSizeJ2C());
-    //LL_WARNS() << "Calculate w-h-c-d-p " << w << "-" << h << "-" << comp << "-" << discard_level << "-" << (S32)precision
-    //           << " Test : " << totalbytes << " new : " << new_bytes << " old : " << old_bytes << LL_ENDL;
+    bytes = llmax((S32)totalbytes, calcHeaderSizeJ2C());
+    LL_WARNS() << "Calculate w-h-c-d-p " << w << "-" << h << "-" << comp << "-" << discard_level << "-" << (S32)precision
+               << " Pyramid: " << (S32)totalbytes << " LayerFactored: " << new_bytes << " WJCR: " << old_bytes << LL_ENDL;
     return bytes;
 }
 

--- a/indra/llimage/llimagej2c.cpp
+++ b/indra/llimage/llimagej2c.cpp
@@ -268,6 +268,7 @@ S32 LLImageJ2C::calcDataSizeJ2C(S32 w, S32 h, S32 comp, S32 discard_level, F32 r
     S32 totalbytes = 0; // total assumed bits in pyramid
     while (surface > s)
     {
+        if (nb_layers <= (6 - discard_level))
         totalbytes += (s * comp * (S32) precision) * rate;
         nb_layers++;
         s *= 4;
@@ -290,7 +291,7 @@ S32 LLImageJ2C::calcDataSizeJ2C(S32 w, S32 h, S32 comp, S32 discard_level, F32 r
     S32 old_bytes = (S32)((F32)(w*h*comp)*rate);
     bytes = (LLImage::useNewByteRange() && (new_bytes < old_bytes) ? new_bytes : old_bytes);
     bytes = llmax(totalbytes, calcHeaderSizeJ2C());
-    //LL_WARNS() << "Calculate w-h-c-d-p " << w << "-" << h << "-" << comp << "-" << original_discard << "-" << (S32)precision
+    //LL_WARNS() << "Calculate w-h-c-d-p " << w << "-" << h << "-" << comp << "-" << discard_level << "-" << (S32)precision
     //           << " Test : " << totalbytes << " new : " << new_bytes << " old : " << old_bytes << LL_ENDL;
     return bytes;
 }

--- a/indra/llimage/llimagej2c.cpp
+++ b/indra/llimage/llimagej2c.cpp
@@ -265,11 +265,11 @@ S32 LLImageJ2C::calcDataSizeJ2C(S32 w, S32 h, S32 comp, S32 discard_level, F32 r
     S32 surface = w*h;
     S32 s = 64*64;    
     S32 precision = 8; // assumed bitrate per component channel, might change in future for HDR support
-    S32 totalbytes = s * comp * precision * rate; // total assumed bits in pyramid, first level computed before loop
+    S32 totalbytes = (S32)(s * comp * precision * rate); // total assumed bits in pyramid, first level computed before loop
     while (surface > s)
     {
         if (nb_layers <= (5 - discard_level))
-            totalbytes += s * comp * precision * rate;
+            totalbytes += (S32)(s * comp * precision * rate);
         nb_layers++;
         s *= 4;
     }

--- a/indra/llimage/llimagej2c.cpp
+++ b/indra/llimage/llimagej2c.cpp
@@ -264,12 +264,18 @@ S32 LLImageJ2C::calcDataSizeJ2C(S32 w, S32 h, S32 comp, S32 discard_level, F32 r
     S32 nb_layers = 1;
     S32 surface = w*h;
     S32 s = 64*64;
+    S8  precision = 8; // assumed bitrate per component channel
+    S32 totalbytes = 0; // total assumed bits in pyramid
     while (surface > s)
     {
+        totalbytes += (s * comp * (S32) precision) * rate;
         nb_layers++;
         s *= 4;
     }
     F32 layer_factor =  3.0f * (7 - llclamp(nb_layers,1,6));
+
+    totalbytes /= 8; // to bytes
+    totalbytes += calcHeaderSizeJ2C();  // header
 
     // Compute w/pow(2,discard_level) and h/pow(2,discard_level)
     w >>= discard_level;
@@ -283,7 +289,9 @@ S32 LLImageJ2C::calcDataSizeJ2C(S32 w, S32 h, S32 comp, S32 discard_level, F32 r
     S32 new_bytes = (S32) (sqrt((F32)(w*h))*(F32)(comp)*rate*1000.f/layer_factor);
     S32 old_bytes = (S32)((F32)(w*h*comp)*rate);
     bytes = (LLImage::useNewByteRange() && (new_bytes < old_bytes) ? new_bytes : old_bytes);
-    bytes = llmax(bytes, calcHeaderSizeJ2C());
+    bytes = llmax(totalbytes, calcHeaderSizeJ2C());
+    //LL_WARNS() << "Calculate w-h-c-d-p " << w << "-" << h << "-" << comp << "-" << original_discard << "-" << (S32)precision
+    //           << " Test : " << totalbytes << " new : " << new_bytes << " old : " << old_bytes << LL_ENDL;
     return bytes;
 }
 

--- a/indra/llimage/llimagej2c.cpp
+++ b/indra/llimage/llimagej2c.cpp
@@ -264,12 +264,12 @@ S32 LLImageJ2C::calcDataSizeJ2C(S32 w, S32 h, S32 comp, S32 discard_level, F32 r
     S32 nb_layers = 1;
     S32 surface = w*h;
     S32 s = 64*64;    
-    S8  precision = 8; // assumed bitrate per component channel
-    S32 totalbytes = (s * comp * (S32) precision) * rate; // total assumed bits in pyramid, first level computed before loop
+    S32 precision = 8; // assumed bitrate per component channel, might change in future for HDR support
+    S32 totalbytes = s * comp * precision * rate; // total assumed bits in pyramid, first level computed before loop
     while (surface > s)
     {
         if (nb_layers <= (5 - discard_level))
-            totalbytes += (s * comp * (S32) precision) * rate;
+            totalbytes += s * comp * precision * rate;
         nb_layers++;
         s *= 4;
     }
@@ -290,9 +290,9 @@ S32 LLImageJ2C::calcDataSizeJ2C(S32 w, S32 h, S32 comp, S32 discard_level, F32 r
     S32 new_bytes = (S32) (sqrt((F32)(w*h))*(F32)(comp)*rate*1000.f/layer_factor);
     S32 old_bytes = (S32)((F32)(w*h*comp)*rate);
     bytes = (LLImage::useNewByteRange() && (new_bytes < old_bytes) ? new_bytes : old_bytes);
-    bytes = llmax((S32)totalbytes, calcHeaderSizeJ2C());
-    LL_WARNS() << "Calculate w-h-c-d-p " << w << "-" << h << "-" << comp << "-" << discard_level << "-" << (S32)precision
-               << " Pyramid: " << (S32)totalbytes << " LayerFactored: " << new_bytes << " WJCR: " << old_bytes << LL_ENDL;
+    bytes = llmax(totalbytes, calcHeaderSizeJ2C());
+    //LL_WARNS() << "calcDataSizeJ2C w-h-c-d-p " << w << "-" << h << "-" << comp << "-" << discard_level << "-" << precision
+    //           << " Pyramid: " << (S32)totalbytes << " LayerFactored: " << new_bytes << " WJCR: " << old_bytes << LL_ENDL;
     return bytes;
 }
 

--- a/indra/newview/llviewertexture.cpp
+++ b/indra/newview/llviewertexture.cpp
@@ -1339,11 +1339,19 @@ void LLViewerFetchedTexture::setDeletionCandidate()
 }
 
 //set the texture inactive
-void LLViewerFetchedTexture::setInactive()
+void LLViewerFetchedTexture::setInactive(bool found_on_face)
 {
-    if(mTextureState == ACTIVE && mGLTexturep.notNull() && mGLTexturep->getTexName() && !mGLTexturep->getBoundRecently())
+    if (mTextureState > DELETION_CANDIDATE && mTextureState != NO_DELETE
+        && mGLTexturep.notNull() && mGLTexturep->getTexName() && !mGLTexturep->getBoundRecently())
     {
-        mTextureState = INACTIVE;
+        if (found_on_face)
+        {
+            mTextureState = ACTIVE;
+        }
+        else
+        {
+            mTextureState = INACTIVE;
+        }
     }
 }
 

--- a/indra/newview/llviewertexture.h
+++ b/indra/newview/llviewertexture.h
@@ -413,7 +413,7 @@ public:
     BOOL isInactive() ;
     BOOL isDeletionCandidate();
     void setDeletionCandidate() ;
-    void setInactive() ;
+    void setInactive(bool found_on_face);
     BOOL getUseDiscard() const { return mUseMipMaps && !mDontDiscard; }
     //---------------
 

--- a/indra/newview/llviewertexturelist.cpp
+++ b/indra/newview/llviewertexturelist.cpp
@@ -888,6 +888,7 @@ static void touch_texture(LLViewerFetchedTexture* tex, F32 vsize)
     if (tex)
     {
         tex->addTextureStats(vsize);
+        tex->getLastReferencedTimer()->reset();
     }
 }
 
@@ -902,7 +903,7 @@ void LLViewerTextureList::updateImageDecodePriority(LLViewerFetchedTexture* imag
     }
 
     llassert(!gCubeSnapshot);
-
+    bool onFace = false;
     static LLCachedControl<F32> bias_distance_scale(gSavedSettings, "TextureBiasDistanceScale", 1.f);
 
     LL_PROFILE_ZONE_SCOPED_CATEGORY_TEXTURE
@@ -915,6 +916,7 @@ void LLViewerTextureList::updateImageDecodePriority(LLViewerFetchedTexture* imag
 
                 if (face && face->getViewerObject() && face->getTextureEntry())
                 {
+                    onFace = true;
 // <FS:Beq> Fix Blurry textures and use importance weight
                     F32 radius;
                     F32 cos_angle_to_view_dir;
@@ -1020,6 +1022,7 @@ void LLViewerTextureList::updateImageDecodePriority(LLViewerFetchedTexture* imag
             imagep->getLastReferencedTimer()->reset();
 
             //reset texture state.
+            if (!onFace)
             imagep->setInactive();
         }
     }

--- a/indra/newview/llviewertexturelist.cpp
+++ b/indra/newview/llviewertexturelist.cpp
@@ -976,6 +976,9 @@ void LLViewerTextureList::updateImageDecodePriority(LLViewerFetchedTexture* imag
     F32 max_inactive_time = 20.f; // actually delete
     S32 min_refs = 3; // 1 for mImageList, 1 for mUUIDMap, 1 for local reference
 
+    // reset texture state.
+    imagep->setInactive(onFace);
+
     //
     // Flush formatted images using a lazy flush
     //
@@ -1020,10 +1023,6 @@ void LLViewerTextureList::updateImageDecodePriority(LLViewerFetchedTexture* imag
         else
         {
             imagep->getLastReferencedTimer()->reset();
-
-            //reset texture state.
-            if (!onFace)
-            imagep->setInactive();
         }
     }
 


### PR DESCRIPTION
I apologize for the last PR, I did not realize I had not made a patch branch.

I refactored the code to be more similar to what Linden Labs accepted as solution for the unnecessary texture unloading and included the updated file size calculations to help the decodes receive a more reliable amount of file.

Edit: This is a resubmission of PR 33: https://github.com/FirestormViewer/phoenix-firestorm/pull/33