### PR TITLE
[FIRE-34403] Recurse and fetch entire inventory at login for OpenSim to fix inventory issues

### DIFF
--- a/indra/newview/llinventorymodelbackgroundfetch.cpp
+++ b/indra/newview/llinventorymodelbackgroundfetch.cpp
@@ -205,7 +205,7 @@ LLInventoryModelBackgroundFetch::LLInventoryModelBackgroundFetch():
 
 LLInventoryModelBackgroundFetch::~LLInventoryModelBackgroundFetch()
 {
-    gIdleCallbacks.deleteFunction(&LLInventoryModelBackgroundFetch::backgroundFetchCB, NULL);
+    gIdleCallbacks.deleteFunction(&LLInventoryModelBackgroundFetch::backgroundFetchCB, nullptr);
 }
 
 bool LLInventoryModelBackgroundFetch::isBulkFetchProcessingComplete() const
@@ -245,7 +245,7 @@ bool LLInventoryModelBackgroundFetch::inventoryFetchCompleted() const
 
 bool LLInventoryModelBackgroundFetch::inventoryFetchInProgress() const
 {
-    return inventoryFetchStarted() && ! inventoryFetchCompleted();
+    return inventoryFetchStarted() && !inventoryFetchCompleted();
 }
 
 bool LLInventoryModelBackgroundFetch::isEverythingFetched() const
@@ -258,35 +258,35 @@ bool LLInventoryModelBackgroundFetch::folderFetchActive() const
     return mFolderFetchActive;
 }
 
-void LLInventoryModelBackgroundFetch::addRequestAtFront(const LLUUID & id, bool recursive, bool is_category)
+void LLInventoryModelBackgroundFetch::addRequestAtFront(const LLUUID& id, bool recursive, bool is_category)
 {
     EFetchType recursion_type = recursive ? FT_RECURSIVE : FT_DEFAULT;
     if (is_category)
     {
-        mFetchFolderQueue.push_front(FetchQueueInfo(id, recursion_type, is_category));
+        mFetchFolderQueue.emplace_front(id, recursion_type, is_category);
     }
     else
     {
-        mFetchItemQueue.push_front(FetchQueueInfo(id, recursion_type, is_category));
+        mFetchItemQueue.emplace_front(id, recursion_type, is_category);
     }
 }
 
-void LLInventoryModelBackgroundFetch::addRequestAtBack(const LLUUID & id, bool recursive, bool is_category)
+void LLInventoryModelBackgroundFetch::addRequestAtBack(const LLUUID& id, bool recursive, bool is_category)
 {
     EFetchType recursion_type = recursive ? FT_RECURSIVE : FT_DEFAULT;
     if (is_category)
     {
-        mFetchFolderQueue.push_back(FetchQueueInfo(id, recursion_type, is_category));
+        mFetchFolderQueue.emplace_back(id, recursion_type, is_category);
     }
     else
     {
-        mFetchItemQueue.push_back(FetchQueueInfo(id, recursion_type, is_category));
+        mFetchItemQueue.emplace_back(id, recursion_type, is_category);
     }
 }
 
 void LLInventoryModelBackgroundFetch::start(const LLUUID& id, bool recursive)
 {
-    LLViewerInventoryCategory * cat(gInventory.getCategory(id));
+    LLViewerInventoryCategory* cat(gInventory.getCategory(id));
 
     if (cat || (id.isNull() && ! isEverythingFetched()))
     {
@@ -298,7 +298,7 @@ void LLInventoryModelBackgroundFetch::start(const LLUUID& id, bool recursive)
         EFetchType recursion_type = recursive ? FT_RECURSIVE : FT_DEFAULT;
         if (id.isNull())
         {
-            if (! mRecursiveInventoryFetchStarted)
+            if (!mRecursiveInventoryFetchStarted)
             {
                 mRecursiveInventoryFetchStarted |= recursive;
                 if (recursive && AISAPI::isAvailable())
@@ -306,19 +306,19 @@ void LLInventoryModelBackgroundFetch::start(const LLUUID& id, bool recursive)
                     // Not only root folder can be massive, but
                     // most system folders will be requested independently
                     // so request root folder and content separately
-                    mFetchFolderQueue.push_front(FetchQueueInfo(gInventory.getRootFolderID(), FT_FOLDER_AND_CONTENT));
+                    mFetchFolderQueue.emplace_front(gInventory.getRootFolderID(), FT_FOLDER_AND_CONTENT);
                 }
                 else
                 {
-                    mFetchFolderQueue.push_back(FetchQueueInfo(gInventory.getRootFolderID(), recursion_type));
+                    mFetchFolderQueue.emplace_back(gInventory.getRootFolderID(), recursion_type);
                 }
-                gIdleCallbacks.addFunction(&LLInventoryModelBackgroundFetch::backgroundFetchCB, NULL);
+                gIdleCallbacks.addFunction(&LLInventoryModelBackgroundFetch::backgroundFetchCB, nullptr);
             }
-            if (! mRecursiveLibraryFetchStarted)
+            if (!mRecursiveLibraryFetchStarted)
             {
                 mRecursiveLibraryFetchStarted |= recursive;
-                mFetchFolderQueue.push_back(FetchQueueInfo(gInventory.getLibraryRootFolderID(), recursion_type));
-                gIdleCallbacks.addFunction(&LLInventoryModelBackgroundFetch::backgroundFetchCB, NULL);
+                mFetchFolderQueue.emplace_back(gInventory.getLibraryRootFolderID(), recursion_type);
+                gIdleCallbacks.addFunction(&LLInventoryModelBackgroundFetch::backgroundFetchCB, nullptr);
             }
         }
         else if (recursive && cat && cat->getPreferredType() == LLFolderType::FT_MARKETPLACE_LISTINGS)
@@ -328,13 +328,13 @@ void LLInventoryModelBackgroundFetch::start(const LLUUID& id, bool recursive)
                 if (recursive && AISAPI::isAvailable())
                 {
                     // Request marketplace folder and content separately
-                    mFetchFolderQueue.push_front(FetchQueueInfo(id, FT_FOLDER_AND_CONTENT));
+                    mFetchFolderQueue.emplace_front(id, FT_FOLDER_AND_CONTENT);
                 }
                 else
                 {
-                    mFetchFolderQueue.push_front(FetchQueueInfo(id, recursion_type));
+                    mFetchFolderQueue.emplace_front(id, recursion_type);
                 }
-                gIdleCallbacks.addFunction(&LLInventoryModelBackgroundFetch::backgroundFetchCB, NULL);
+                gIdleCallbacks.addFunction(&LLInventoryModelBackgroundFetch::backgroundFetchCB, nullptr);
                 mRecursiveMarketplaceFetchStarted = true;
             }
         }
@@ -346,15 +346,15 @@ void LLInventoryModelBackgroundFetch::start(const LLUUID& id, bool recursive)
                 {
                     // On AIS make sure root goes to the top and follow up recursive
                     // fetches, not individual requests
-                    mFetchFolderQueue.push_back(FetchQueueInfo(id, recursion_type));
-                    gIdleCallbacks.addFunction(&LLInventoryModelBackgroundFetch::backgroundFetchCB, NULL);
+                    mFetchFolderQueue.emplace_back(id, recursion_type);
+                    gIdleCallbacks.addFunction(&LLInventoryModelBackgroundFetch::backgroundFetchCB, nullptr);
                 }
             }
             else if (mFetchFolderQueue.empty() || mFetchFolderQueue.front().mUUID != id)
             {
-                    // Specific folder requests go to front of queue.
-                    mFetchFolderQueue.push_front(FetchQueueInfo(id, recursion_type));
-                    gIdleCallbacks.addFunction(&LLInventoryModelBackgroundFetch::backgroundFetchCB, NULL);
+                // Specific folder requests go to front of queue.
+                mFetchFolderQueue.emplace_front(id, recursion_type);
+                gIdleCallbacks.addFunction(&LLInventoryModelBackgroundFetch::backgroundFetchCB, nullptr);
             }
 
             if (id == gInventory.getLibraryRootFolderID())
@@ -367,9 +367,9 @@ void LLInventoryModelBackgroundFetch::start(const LLUUID& id, bool recursive)
             }
         }
     }
-    else if (LLViewerInventoryItem * itemp = gInventory.getItem(id))
+    else if (LLViewerInventoryItem* itemp = gInventory.getItem(id))
     {
-        if (! itemp->mIsComplete)
+        if (!itemp->mIsComplete)
         {
             scheduleItemFetch(id);
         }
@@ -388,18 +388,18 @@ void LLInventoryModelBackgroundFetch::scheduleFolderFetch(const LLUUID& cat_id, 
             // check if already requested
             if (mForceFetchSet.find(cat_id) == mForceFetchSet.end())
             {
-                mForceFetchSet.insert(cat_id);
-                mFetchFolderQueue.emplace_front(FetchQueueInfo(cat_id, FT_FORCED));
+                mForceFetchSet.emplace(cat_id);
+                mFetchFolderQueue.emplace_front(cat_id, FT_FORCED);
             }
         }
         else
         {
             // Specific folder requests go to front of queue.
-            // version presence acts as dupplicate prevention for normal fetches
-            mFetchFolderQueue.emplace_front(FetchQueueInfo(cat_id, FT_DEFAULT));
+            // version presence acts as duplicate prevention for normal fetches
+            mFetchFolderQueue.emplace_front(cat_id, FT_DEFAULT);
         }
 
-        gIdleCallbacks.addFunction(&LLInventoryModelBackgroundFetch::backgroundFetchCB, NULL);
+        gIdleCallbacks.addFunction(&LLInventoryModelBackgroundFetch::backgroundFetchCB, nullptr);
     }
 }
 
@@ -413,17 +413,17 @@ void LLInventoryModelBackgroundFetch::scheduleItemFetch(const LLUUID& item_id, b
             // check if already requested
             if (mForceFetchSet.find(item_id) == mForceFetchSet.end())
             {
-                mForceFetchSet.insert(item_id);
-                mFetchItemQueue.emplace_front(FetchQueueInfo(item_id, FT_FORCED, false));
+                mForceFetchSet.emplace(item_id);
+                mFetchItemQueue.emplace_front(item_id, FT_FORCED, false);
             }
         }
         else
         {
-            // 'isFinished' being set acts as dupplicate prevention for normal fetches
-            mFetchItemQueue.emplace_front(FetchQueueInfo(item_id, FT_DEFAULT, false));
+            // 'isFinished' being set acts as duplicate prevention for normal fetches
+            mFetchItemQueue.emplace_front(item_id, FT_DEFAULT, false);
         }
 
-        gIdleCallbacks.addFunction(&LLInventoryModelBackgroundFetch::backgroundFetchCB, NULL);
+        gIdleCallbacks.addFunction(&LLInventoryModelBackgroundFetch::backgroundFetchCB, nullptr);
     }
 }
 
@@ -436,7 +436,7 @@ void LLInventoryModelBackgroundFetch::fetchFolderAndLinks(const LLUUID& cat_id, 
         cat->setFetching(LLViewerInventoryCategory::FETCH_RECURSIVE);
     }
     incrFetchFolderCount(1);
-    mExpectedFolderIds.push_back(cat_id);
+    mExpectedFolderIds.emplace_back(cat_id);
 
     // Assume that we have no relevant cache. Fetch folder, and items folder's links point to.
     AISAPI::FetchCategoryLinks(cat_id,
@@ -453,7 +453,7 @@ void LLInventoryModelBackgroundFetch::fetchFolderAndLinks(const LLUUID& cat_id, 
     // start idle loop to track completion
     mBackgroundFetchActive = true;
     mFolderFetchActive = true;
-    gIdleCallbacks.addFunction(&LLInventoryModelBackgroundFetch::backgroundFetchCB, NULL);
+    gIdleCallbacks.addFunction(&LLInventoryModelBackgroundFetch::backgroundFetchCB, nullptr);
 }
 
 void LLInventoryModelBackgroundFetch::fetchCOF(nullary_func_t callback)
@@ -466,7 +466,7 @@ void LLInventoryModelBackgroundFetch::fetchCOF(nullary_func_t callback)
         cat->setFetching(LLViewerInventoryCategory::FETCH_RECURSIVE);
     }
     incrFetchFolderCount(1);
-    mExpectedFolderIds.push_back(cat_id);
+    mExpectedFolderIds.emplace_back(cat_id);
     // For reliability assume that we have no relevant cache, so
     // fetch cof along with items cof's links point to.
     AISAPI::FetchCOF([callback](const LLUUID& id)
@@ -479,15 +479,15 @@ void LLInventoryModelBackgroundFetch::fetchCOF(nullary_func_t callback)
     // start idle loop to track completion
     mBackgroundFetchActive = true;
     mFolderFetchActive = true;
-    gIdleCallbacks.addFunction(&LLInventoryModelBackgroundFetch::backgroundFetchCB, NULL);
+    gIdleCallbacks.addFunction(&LLInventoryModelBackgroundFetch::backgroundFetchCB, nullptr);
 }
 
 void LLInventoryModelBackgroundFetch::findLostItems()
 {
     mBackgroundFetchActive = true;
     mFolderFetchActive = true;
-    mFetchFolderQueue.push_back(FetchQueueInfo(LLUUID::null, FT_RECURSIVE));
-    gIdleCallbacks.addFunction(&LLInventoryModelBackgroundFetch::backgroundFetchCB, NULL);
+    mFetchFolderQueue.emplace_back(LLUUID::null, FT_RECURSIVE);
+    gIdleCallbacks.addFunction(&LLInventoryModelBackgroundFetch::backgroundFetchCB, nullptr);
 }
 
 void LLInventoryModelBackgroundFetch::setAllFoldersFetched()
@@ -517,7 +517,7 @@ boost::signals2::connection LLInventoryModelBackgroundFetch::setFetchCompletionC
     return mFoldersFetchedSignal.connect(cb);
 }
 
-void LLInventoryModelBackgroundFetch::backgroundFetchCB(void *)
+void LLInventoryModelBackgroundFetch::backgroundFetchCB(void*)
 {
     LLInventoryModelBackgroundFetch::instance().backgroundFetch();
 }
@@ -568,7 +568,7 @@ void LLInventoryModelBackgroundFetch::backgroundFetch()
             mTimelyFetchPending = false;
         }
 
-        while(1)
+        while (1)
         {
             if (mFetchFolderQueue.empty())
             {
@@ -627,7 +627,7 @@ void LLInventoryModelBackgroundFetch::backgroundFetch()
                          it != categories->end();
                          ++it)
                     {
-                        mFetchFolderQueue.push_back(FetchQueueInfo((*it)->getUUID(),info.mFetchType));
+                        mFetchFolderQueue.emplace_back((*it)->getUUID(), info.mFetchType);
                     }
 
                     // We received a response in less than the fast time.
@@ -651,7 +651,7 @@ void LLInventoryModelBackgroundFetch::backgroundFetch()
                     if (mNumFetchRetries++ < MAX_FETCH_RETRIES)
                     {
                         // push on back of queue
-                        mFetchFolderQueue.push_back(info);
+                        mFetchFolderQueue.emplace_back(info);
                     }
                     mTimelyFetchPending = false;
                     mFetchTimer.reset();
@@ -683,7 +683,7 @@ void LLInventoryModelBackgroundFetch::backgroundFetch()
                 }
                 else if (mFetchTimer.getElapsedTimeF32() > mMaxTimeBetweenFetches)
                 {
-                    mFetchFolderQueue.push_back(info);
+                    mFetchFolderQueue.emplace_back(info);
                     mFetchTimer.reset();
                     mTimelyFetchPending = false;
                 }
@@ -731,7 +731,7 @@ void LLInventoryModelBackgroundFetch::onAISContentCalback(
     const LLUUID& response_id,
     EFetchType fetch_type)
 {
-    // Don't push_front on failure - there is a chance it was fired from inside bulkFetchViaAis
+    // Don't emplace_front on failure - there is a chance it was fired from inside bulkFetchViaAis
     incrFetchFolderCount(-1);
 
     uuid_vec_t::const_iterator folder_iter = content_ids.begin();
@@ -752,7 +752,7 @@ void LLInventoryModelBackgroundFetch::onAISContentCalback(
         if (response_id.isNull())
         {
             // Failed to fetch, get it individually
-            mFetchFolderQueue.push_back(FetchQueueInfo(*folder_iter, FT_RECURSIVE));
+            mFetchFolderQueue.emplace_back(*folder_iter, FT_RECURSIVE);
         }
         else
         {
@@ -766,7 +766,7 @@ void LLInventoryModelBackgroundFetch::onAISContentCalback(
                      it != categories->end();
                      ++it)
                 {
-                    mFetchFolderQueue.push_back(FetchQueueInfo((*it)->getUUID(), FT_RECURSIVE));
+                    mFetchFolderQueue.emplace_back(FetchQueueInfo((*it)->getUUID(), FT_RECURSIVE));
                 }
             }
         }
@@ -778,12 +778,12 @@ void LLInventoryModelBackgroundFetch::onAISContentCalback(
     {
         mBackgroundFetchActive = true;
         mFolderFetchActive = true;
-        gIdleCallbacks.addFunction(&LLInventoryModelBackgroundFetch::backgroundFetchCB, NULL);
+        gIdleCallbacks.addFunction(&LLInventoryModelBackgroundFetch::backgroundFetchCB, nullptr);
     }
 }
-void LLInventoryModelBackgroundFetch::onAISFolderCalback(const LLUUID &request_id, const LLUUID &response_id, EFetchType fetch_type)
+void LLInventoryModelBackgroundFetch::onAISFolderCalback(const LLUUID& request_id, const LLUUID& response_id, EFetchType fetch_type)
 {
-    // Don't push_front on failure - there is a chance it was fired from inside bulkFetchViaAis
+    // Don't emplace_front on failure - there is a chance it was fired from inside bulkFetchViaAis
     incrFetchFolderCount(-1);
     std::list<LLUUID>::const_iterator found = std::find(mExpectedFolderIds.begin(), mExpectedFolderIds.end(), request_id);
     if (found != mExpectedFolderIds.end())
@@ -799,7 +799,7 @@ void LLInventoryModelBackgroundFetch::onAISFolderCalback(const LLUUID &request_i
 
     if (request_id.isNull())
     {
-        // orhans, no other actions needed
+        // orphans, no other actions needed
         return;
     }
 
@@ -812,12 +812,12 @@ void LLInventoryModelBackgroundFetch::onAISFolderCalback(const LLUUID &request_i
         {
             // A full recursive request failed.
             // Try requesting folder and nested content separately
-            mFetchFolderQueue.push_back(FetchQueueInfo(request_id, FT_FOLDER_AND_CONTENT));
+            mFetchFolderQueue.emplace_back(request_id, FT_FOLDER_AND_CONTENT);
         }
         else if (fetch_type == FT_FOLDER_AND_CONTENT)
         {
             LL_WARNS() << "Failed to download folder: " << request_id << " Requesting known content separately" << LL_ENDL;
-            mFetchFolderQueue.push_back(FetchQueueInfo(request_id, FT_CONTENT_RECURSIVE));
+            mFetchFolderQueue.emplace_back(request_id, FT_CONTENT_RECURSIVE);
 
             // set folder's version to prevent viewer from trying to request folder indefinetely
             LLViewerInventoryCategory* cat(gInventory.getCategory(request_id));
@@ -843,7 +843,7 @@ void LLInventoryModelBackgroundFetch::onAISFolderCalback(const LLUUID &request_i
         else if (fetch_type == FT_FOLDER_AND_CONTENT)
         {
             // readd folder for content request
-            mFetchFolderQueue.push_front(FetchQueueInfo(request_id, FT_CONTENT_RECURSIVE));
+            mFetchFolderQueue.emplace_front(request_id, FT_CONTENT_RECURSIVE);
         }
         else
         {
@@ -863,7 +863,7 @@ void LLInventoryModelBackgroundFetch::onAISFolderCalback(const LLUUID &request_i
                  it != categories->end();
                  ++it)
             {
-                mFetchFolderQueue.push_back(FetchQueueInfo((*it)->getUUID(), FT_RECURSIVE));
+                mFetchFolderQueue.emplace_back((*it)->getUUID(), FT_RECURSIVE);
             }
         }
     }
@@ -872,11 +872,11 @@ void LLInventoryModelBackgroundFetch::onAISFolderCalback(const LLUUID &request_i
     {
         mBackgroundFetchActive = true;
         mFolderFetchActive = true;
-        gIdleCallbacks.addFunction(&LLInventoryModelBackgroundFetch::backgroundFetchCB, NULL);
+        gIdleCallbacks.addFunction(&LLInventoryModelBackgroundFetch::backgroundFetchCB, nullptr);
     }
 
     // done
-    LLViewerInventoryCategory * cat(gInventory.getCategory(request_id));
+    LLViewerInventoryCategory* cat(gInventory.getCategory(request_id));
     if (cat)
     {
         cat->setFetching(new_state);
@@ -914,7 +914,7 @@ void LLInventoryModelBackgroundFetch::bulkFetchViaAis()
 
     while (!mFetchFolderQueue.empty() && (U32)mFetchCount < max_concurrent_fetches && curent_time < end_time)
     {
-        const FetchQueueInfo & fetch_info(mFetchFolderQueue.front());
+        const FetchQueueInfo& fetch_info(mFetchFolderQueue.front());
         bulkFetchViaAis(fetch_info);
         mFetchFolderQueue.pop_front();
         curent_time = LLTimer::getTotalSeconds();
@@ -980,7 +980,7 @@ void LLInventoryModelBackgroundFetch::bulkFetchViaAis()
             const LLUUID& marketplacelistings_id = gInventory.findCategoryUUIDForType(LLFolderType::FT_MARKETPLACE_LISTINGS);
             if (marketplacelistings_id.notNull())
             {
-                mFetchFolderQueue.push_front(FetchQueueInfo(marketplacelistings_id, FT_FOLDER_AND_CONTENT));
+                mFetchFolderQueue.emplace_front(marketplacelistings_id, FT_FOLDER_AND_CONTENT);
             }
             else
             {
@@ -1000,11 +1000,11 @@ void LLInventoryModelBackgroundFetch::bulkFetchViaAis(const FetchQueueInfo& fetc
 {
     if (fetch_info.mIsCategory)
     {
-        const LLUUID & cat_id(fetch_info.mUUID);
+        const LLUUID& cat_id(fetch_info.mUUID);
         if (cat_id.isNull())
         {
             incrFetchFolderCount(1);
-            mExpectedFolderIds.push_back(cat_id);
+            mExpectedFolderIds.emplace_back(cat_id);
             // Lost and found
             // Should it actually be recursive?
             AISAPI::FetchOrphans([](const LLUUID& response_id)
@@ -1016,7 +1016,7 @@ void LLInventoryModelBackgroundFetch::bulkFetchViaAis(const FetchQueueInfo& fetc
         }
         else
         {
-            LLViewerInventoryCategory * cat(gInventory.getCategory(cat_id));
+            LLViewerInventoryCategory* cat(gInventory.getCategory(cat_id));
             if (cat)
             {
                 if (fetch_info.mFetchType == FT_CONTENT_RECURSIVE)
@@ -1051,8 +1051,8 @@ void LLInventoryModelBackgroundFetch::bulkFetchViaAis(const FetchQueueInfo& fetc
                             continue;
                         }
 
-                        children.push_back(child_cat->getUUID());
-                        mExpectedFolderIds.push_back(child_cat->getUUID());
+                        children.emplace_back(child_cat->getUUID());
+                        mExpectedFolderIds.emplace_back(child_cat->getUUID());
                         child_cat->setFetching(target_state);
 
                         if (children.size() >= batch_limit)
@@ -1095,14 +1095,14 @@ void LLInventoryModelBackgroundFetch::bulkFetchViaAis(const FetchQueueInfo& fetc
                             LLViewerInventoryCategory* child_cat = (*it);
                             if (LLViewerInventoryCategory::VERSION_UNKNOWN != child_cat->getVersion())
                             {
-                                mFetchFolderQueue.push_back(FetchQueueInfo(child_cat->getUUID(), FT_RECURSIVE));
+                                mFetchFolderQueue.emplace_back(child_cat->getUUID(), FT_RECURSIVE);
                             }
                         }
                     }
                     else
                     {
                         // send it back to get the rest
-                        mFetchFolderQueue.push_back(FetchQueueInfo(cat_id, FT_CONTENT_RECURSIVE));
+                        mFetchFolderQueue.emplace_back(cat_id, FT_CONTENT_RECURSIVE);
                     }
                 }
                 else if (LLViewerInventoryCategory::VERSION_UNKNOWN == cat->getVersion()
@@ -1119,7 +1119,7 @@ void LLInventoryModelBackgroundFetch::bulkFetchViaAis(const FetchQueueInfo& fetc
                         // increment before call in case of immediate callback
                         incrFetchFolderCount(1);
                         cat->setFetching(target_state);
-                        mExpectedFolderIds.push_back(cat_id);
+                        mExpectedFolderIds.emplace_back(cat_id);
 
                         EFetchType type = fetch_info.mFetchType;
                         LLUUID cat_cb_id = cat_id;
@@ -1143,15 +1143,15 @@ void LLInventoryModelBackgroundFetch::bulkFetchViaAis(const FetchQueueInfo& fetc
                     if (fetch_info.mFetchType == FT_RECURSIVE
                         || fetch_info.mFetchType == FT_FOLDER_AND_CONTENT)
                     {
-                        LLInventoryModel::cat_array_t * categories(NULL);
-                        LLInventoryModel::item_array_t * items(NULL);
+                        LLInventoryModel::cat_array_t* categories(NULL);
+                        LLInventoryModel::item_array_t* items(NULL);
                         gInventory.getDirectDescendentsOf(cat_id, categories, items);
                         for (LLInventoryModel::cat_array_t::const_iterator it = categories->begin();
                             it != categories->end();
                             ++it)
                         {
-                            // not push_front to not cause an infinite loop
-                            mFetchFolderQueue.push_back(FetchQueueInfo((*it)->getUUID(), FT_RECURSIVE));
+                            // not emplace_front to not cause an infinite loop
+                            mFetchFolderQueue.emplace_back((*it)->getUUID(), FT_RECURSIVE);
                         }
                     }
                 }
@@ -1160,7 +1160,7 @@ void LLInventoryModelBackgroundFetch::bulkFetchViaAis(const FetchQueueInfo& fetc
     }
     else
     {
-        LLViewerInventoryItem * itemp(gInventory.getItem(fetch_info.mUUID));
+        LLViewerInventoryItem* itemp(gInventory.getItem(fetch_info.mUUID));
 
         if (itemp)
         {
@@ -1198,7 +1198,7 @@ void LLInventoryModelBackgroundFetch::bulkFetch()
     //Background fetch is called from gIdleCallbacks in a loop until background fetch is stopped.
     //If there are items in mFetchQueue, we want to check the time since the last bulkFetch was
     //sent.  If it exceeds our retry time, go ahead and fire off another batch.
-    LLViewerRegion * region(gAgent.getRegion());
+    LLViewerRegion* region(gAgent.getRegion());
     if (! region || gDisconnected || LLApp::isExiting())
     {
         return;
@@ -1242,7 +1242,7 @@ void LLInventoryModelBackgroundFetch::bulkFetch()
     // *TODO:  Think I'd like to get a shared pointer to this and share it
     // among all the folder requests.
     uuid_vec_t recursive_cats;
-    uuid_vec_t all_cats; // dupplicate avoidance
+    uuid_vec_t all_cats; // duplicate avoidance
 
     LLSD folder_request_body;
     LLSD folder_request_body_lib;
@@ -1252,10 +1252,10 @@ void LLInventoryModelBackgroundFetch::bulkFetch()
     while (! mFetchFolderQueue.empty()
             && (item_count + folder_count) < max_batch_size)
     {
-        const FetchQueueInfo & fetch_info(mFetchFolderQueue.front());
+        const FetchQueueInfo& fetch_info(mFetchFolderQueue.front());
         if (fetch_info.mIsCategory)
         {
-            const LLUUID & cat_id(fetch_info.mUUID);
+            const LLUUID& cat_id(fetch_info.mUUID);
             if (cat_id.isNull()) //DEV-17797 Lost and found
             {
                 LLSD folder_sd;
@@ -1269,7 +1269,7 @@ void LLInventoryModelBackgroundFetch::bulkFetch()
             }
             else
             {
-                const LLViewerInventoryCategory * cat(gInventory.getCategory(cat_id));
+                const LLViewerInventoryCategory* cat(gInventory.getCategory(cat_id));
                 if (cat)
                 {
                     if (LLViewerInventoryCategory::VERSION_UNKNOWN == cat->getVersion())
@@ -1297,33 +1297,30 @@ void LLInventoryModelBackgroundFetch::bulkFetch()
                             folder_count++;
                         }
                     }
-#ifdef OPENSIM
-                    if (LLViewerInventoryCategory::VERSION_UNKNOWN != cat->getVersion() || !LLGridManager::getInstance()->isInSecondLife())
-#else
-                    else
-#endif
+                    // <FS/> [FIRE-34403] Removing the else here allows the inventory to do a full fetch
+                    //else
+                    //{
+                    // May already have this folder, but append child folders to list.
+                    if (fetch_info.mFetchType >= FT_CONTENT_RECURSIVE)
                     {
-                        // May already have this folder, but append child folders to list.
-                        if (fetch_info.mFetchType >= FT_CONTENT_RECURSIVE)
+                        LLInventoryModel::cat_array_t* categories(NULL);
+                        LLInventoryModel::item_array_t* items(NULL);
+                        gInventory.getDirectDescendentsOf(cat_id, categories, items);
+                        for (LLInventoryModel::cat_array_t::const_iterator it = categories->begin();
+                            it != categories->end();
+                            ++it)
                         {
-                            LLInventoryModel::cat_array_t * categories(NULL);
-                            LLInventoryModel::item_array_t * items(NULL);
-                            gInventory.getDirectDescendentsOf(cat_id, categories, items);
-                            for (LLInventoryModel::cat_array_t::const_iterator it = categories->begin();
-                                it != categories->end();
-                                ++it)
-                            {
-                                mFetchFolderQueue.push_back(FetchQueueInfo((*it)->getUUID(), fetch_info.mFetchType));
-                            }
+                            mFetchFolderQueue.emplace_back((*it)->getUUID(), fetch_info.mFetchType);
                         }
                     }
+                    //}
                 }
             }
             if (fetch_info.mFetchType >= FT_CONTENT_RECURSIVE)
             {
-                recursive_cats.push_back(cat_id);
+                recursive_cats.emplace_back(cat_id);
             }
-            all_cats.push_back(cat_id);
+            all_cats.emplace_back(cat_id);
         }
 
         mFetchFolderQueue.pop_front();
@@ -1333,9 +1330,9 @@ void LLInventoryModelBackgroundFetch::bulkFetch()
     while (!mFetchItemQueue.empty()
         && (item_count + folder_count) < max_batch_size)
     {
-        const FetchQueueInfo & fetch_info(mFetchItemQueue.front());
+        const FetchQueueInfo& fetch_info(mFetchItemQueue.front());
 
-        LLViewerInventoryItem * itemp(gInventory.getItem(fetch_info.mUUID));
+        LLViewerInventoryItem* itemp(gInventory.getItem(fetch_info.mUUID));
 
         if (itemp)
         {
@@ -1423,13 +1420,13 @@ void LLInventoryModelBackgroundFetch::bulkFetch()
     }
 }
 
-bool LLInventoryModelBackgroundFetch::fetchQueueContainsNoDescendentsOf(const LLUUID & cat_id) const
+bool LLInventoryModelBackgroundFetch::fetchQueueContainsNoDescendentsOf(const LLUUID& cat_id) const
 {
     for (fetch_queue_t::const_iterator it = mFetchFolderQueue.begin();
          it != mFetchFolderQueue.end();
          ++it)
     {
-        const LLUUID & fetch_id = (*it).mUUID;
+        const LLUUID& fetch_id = (*it).mUUID;
         if (gInventory.isObjectDescendentOf(fetch_id, cat_id))
             return false;
     }
@@ -1437,7 +1434,7 @@ bool LLInventoryModelBackgroundFetch::fetchQueueContainsNoDescendentsOf(const LL
         it != mFetchItemQueue.end();
         ++it)
     {
-        const LLUUID & fetch_id = (*it).mUUID;
+        const LLUUID& fetch_id = (*it).mUUID;
         if (gInventory.isObjectDescendentOf(fetch_id, cat_id))
             return false;
     }
@@ -1566,7 +1563,7 @@ void BGFolderHttpHandler::processData(LLSD & content, LLCore::HttpResponse * res
 
                         LLInventoryModel::update_list_t update;
                         LLInventoryModel::LLCategoryUpdate new_folder(lost_uuid, 1);
-                        update.push_back(new_folder);
+                        update.emplace_back(new_folder);
                         gInventory.accountForUpdate(update);
 
                         titem->setParent(lost_uuid);
@@ -1702,7 +1699,7 @@ void BGFolderHttpHandler::processFailure(LLCore::HttpStatus status, LLCore::Http
                 LLUUID folder_id = iter->get("folder_id").asUUID();
                 if (std::find(mRecursiveCatUUIDs.begin(), mRecursiveCatUUIDs.end(), folder_id) != mRecursiveCatUUIDs.end())
                 {
-                    recursive_cats.push_back(folder_id);
+                    recursive_cats.emplace_back(folder_id);
                 }
                 if (folders.size() == (size / 2))
                 {

--- a/indra/newview/llinventorymodelbackgroundfetch.h
+++ b/indra/newview/llinventorymodelbackgroundfetch.h
@@ -81,8 +81,8 @@ public:
     typedef boost::function<void()> folders_fetched_callback_t;
     boost::signals2::connection setFetchCompletionCallback(folders_fetched_callback_t cb);
 
-    void addRequestAtFront(const LLUUID & id, bool recursive, bool is_category);
-    void addRequestAtBack(const LLUUID & id, bool recursive, bool is_category);
+    void addRequestAtFront(const LLUUID& id, bool recursive, bool is_category);
+    void addRequestAtBack(const LLUUID& id, bool recursive, bool is_category);
 
 protected:
     bool isFolderFetchProcessingComplete() const;
@@ -108,8 +108,8 @@ protected:
     };
     typedef std::deque<FetchQueueInfo> fetch_queue_t;
 
-    void onAISContentCalback(const LLUUID& request_id, const uuid_vec_t &content_ids, const LLUUID& response_id, EFetchType fetch_type);
-    void onAISFolderCalback(const LLUUID &request_id, const LLUUID &response_id, EFetchType fetch_type);
+    void onAISContentCalback(const LLUUID& request_id, const uuid_vec_t& content_ids, const LLUUID& response_id, EFetchType fetch_type);
+    void onAISFolderCalback(const LLUUID& request_id, const LLUUID& response_id, EFetchType fetch_type);
     void bulkFetchViaAis();
     void bulkFetchViaAis(const FetchQueueInfo& fetch_info);
     void bulkFetch();


### PR DESCRIPTION
[[FIRE-34403]](https://jira.firestormviewer.org/browse/FIRE-34403)

Fixes the problems mentioned in the JIRA issue.
(As talked about in the JIRA issue, an alternative and more direct approach to fixing the issues mentioned might be more appropriate than what I propose in this PR)