### PR TITLE
FIRE-31508: check folder limit before attaching all the things in a f…

### DIFF
--- a/indra/newview/llinventorybridge.cpp
+++ b/indra/newview/llinventorybridge.cpp
@@ -5376,9 +5376,6 @@ void LLFolderBridge::createWearable(LLFolderBridge* bridge, LLWearableType::ETyp
 //<FS:AR> FIRE-31508: refactored from void LLFolderBridge::modifyOutfit(BOOL append)
 bool LLFolderBridge::modifyOutfitExceedsWearFolderLimit()
 {
-    LLInventoryModel *model = getInventoryModel();
-    if (!model)
-        return false;
     LLViewerInventoryCategory *cat = getCategory();
     if (!cat)
         return false;
@@ -5404,10 +5401,12 @@ bool LLFolderBridge::modifyOutfitExceedsWearFolderLimit()
 
 void LLFolderBridge::modifyOutfit(BOOL append)
 {
-    LLInventoryModel* model = getInventoryModel();
-    if(!model) return;
-    LLViewerInventoryCategory* cat = getCategory();
-    if(!cat) return;
+    // <FS:AR> FIRE-31508: Commented out for slight efficiency.
+    // LLInventoryModel* model = getInventoryModel();
+    // if(!model) return;
+    // LLViewerInventoryCategory* cat = getCategory();
+    // if(!cat) return;
+    // <FS:AR/> FIRE-31508
 
     //<FS:AR> FIRE-31508: refactored to bool modifyOutfitExceedsWearFolderLimit(), rather than duplicating code
     //// checking amount of items to wear
@@ -5429,6 +5428,10 @@ void LLFolderBridge::modifyOutfit(BOOL append)
     //    return;
     //}
     if (modifyOutfitExceedsWearFolderLimit())
+        return;
+
+    LLViewerInventoryCategory *cat = getCategory();
+    if (!cat)
         return;
     //</FS:AR> FIRE-31508
 

--- a/indra/newview/llinventorybridge.h
+++ b/indra/newview/llinventorybridge.h
@@ -389,6 +389,7 @@ protected:
 
     BOOL checkFolderForContentsOfType(LLInventoryModel* model, LLInventoryCollectFunctor& typeToCheck);
 
+    bool modifyOutfitExceedsWearFolderLimit(); //<FS:AR> FIRE-31508
     void modifyOutfit(BOOL append);
     void copyOutfitToClipboard();
     void determineFolderType();


### PR DESCRIPTION
Hi there.

Picked a case that's gotten my goat several times: accidentally attaching all the things in the root of all my clothes or hair...

It appears to be a a regression from "ReplaceWornItemsOnly", no case ID, and I didn't look it up.

To solve it, I elected to refactor rather than duplicate code, is that okay? Do you prefer keeping original?