### PR TITLE
Backport fix for secondlife/viewer#1856

### DIFF
--- a/indra/newview/app_settings/settings.xml
+++ b/indra/newview/app_settings/settings.xml
@@ -10484,6 +10484,17 @@ Change of this parameter will affect the layout of buttons in notification toast
       <key>Value</key>
       <integer>0</integer>
     </map>
+    <key>RenderCanUseGLTFPBROpaqueShaders</key>
+    <map>
+        <key>Comment</key>
+        <string>Hardware has support for GLTF scene shaders</string>
+        <key>Persist</key>
+        <integer>0</integer>
+        <key>Type</key>
+        <string>Boolean</string>
+        <key>Value</key>
+        <integer>1</integer>
+    </map>
   <key>RenderClass1MemoryBandwidth</key>
   <map>
     <key>Comment</key>

--- a/indra/newview/gltfscenemanager.cpp
+++ b/indra/newview/gltfscenemanager.cpp
@@ -44,6 +44,7 @@
 #include "llfloaterperms.h"
 #include "llagentbenefits.h"
 #include "llfilesystem.h"
+#include "llviewercontrol.h"
 #include "boost/json.hpp"
 
 #define GLTF_SIM_SUPPORT 1
@@ -596,6 +597,13 @@ void GLTFSceneManager::render(U8 variant)
 void GLTFSceneManager::render(Asset& asset, U8 variant)
 {
     LL_PROFILE_ZONE_SCOPED_CATEGORY_GLTF;
+
+    static LLCachedControl<bool> can_use_shaders(gSavedSettings, "RenderCanUseGLTFPBROpaqueShaders", true);
+    if (!can_use_shaders)
+    {
+        // user should already have been notified of unsupported hardware
+        return;
+    }
 
     for (U32 ds = 0; ds < 2; ++ds)
     {

--- a/indra/newview/llviewermenu.cpp
+++ b/indra/newview/llviewermenu.cpp
@@ -4014,7 +4014,9 @@ bool enable_os_exception()
 bool enable_gltf()
 {
     static LLCachedControl<bool> enablegltf(gSavedSettings, "GLTFEnabled", false);
-    return enablegltf;
+    static LLCachedControl<bool> can_use(gSavedSettings, "RenderCanUseGLTFPBROpaqueShaders", true);
+
+    return enablegltf && can_use;
 }
 
 bool enable_gltf_save_as()
@@ -10102,7 +10104,16 @@ class LLAdvancedClickGLTFOpen: public view_listener_t
 {
     bool handleEvent(const LLSD& userdata)
     {
-        LL::GLTFSceneManager::instance().load();
+        static LLCachedControl<bool> can_use_shaders(gSavedSettings, "RenderCanUseGLTFPBROpaqueShaders", true);
+        if (can_use_shaders)
+        {
+            LL::GLTFSceneManager::instance().load();
+        }
+        else
+        {
+            LLNotificationsUtil::add("NoSupportGLTFShader");
+        }
+
         return true;
     }
 };

--- a/indra/newview/llviewershadermgr.cpp
+++ b/indra/newview/llviewershadermgr.cpp
@@ -1344,7 +1344,14 @@ bool LLViewerShaderMgr::loadShadersDeferred()
 
         success = make_gltf_variants(gGLTFPBRMetallicRoughnessProgram, use_sun_shadow);
 
-        llassert(success);
+        //llassert(success);
+        if (!success)
+        {
+            LL_WARNS() << "Failed to create GLTF PBR Metallic Roughness Shader, disabling!" << LL_ENDL;
+            gSavedSettings.setBOOL("RenderCanUseGLTFPBROpaqueShaders", false);
+            // continue as if this shader never happened
+            success = true;
+        }
     }
 
     if (success)

--- a/indra/newview/skins/default/xui/en/notifications.xml
+++ b/indra/newview/skins/default/xui/en/notifications.xml
@@ -14474,6 +14474,16 @@ This will replace the items in the selected outfit with the items you are wearin
       yestext="OK"/>
   </notification>
 
+  <notification
+   icon="alertmodal.tga"
+   name="NoSupportGLTFShader"
+   type="notify">
+     GLTF scenes are not yet supported on your graphics hardware.
+     <tag>fail</tag>
+     <usetemplate
+       name="okbutton"
+       yestext="OK"/>
+  </notification>
 
   <notification
    icon="alertmodal.tga"


### PR DESCRIPTION
Backport fixes for secondlife/viewer#1856

Add error handling for intel crashes from GLTF Scene shader (secondlife/viewer#2456)

#### Testing
more details can be found in secondlife/viewer#1856, but systems based on Intel integrated HD 4000 series and 5000 series GPU would crash on startup before reaching the login screen