### PR TITLE
Add key bindings for Camera Roll

### DIFF
--- a/indra/newview/app_settings/key_bindings.xml
+++ b/indra/newview/app_settings/key_bindings.xml
@@ -35,6 +35,10 @@
     <binding key="E" mask="NONE" command="jump"/>
     <binding key="C" mask="NONE" command="push_down"/>
 
+<!-- <FS:Chanayane> Camera roll key bindings -->
+    <binding key="R" mask="NONE" command="roll_left"/>
+    <binding key="T" mask="NONE" command="roll_right"/>
+<!-- </FS:Chanayane> -->
     <binding key="F" mask="NONE" command="toggle_fly"/>
 
     <binding key="SPACE" mask="NONE" command="stop_moving"/>
@@ -120,6 +124,11 @@
     <binding key="S" mask="NONE" command="move_backward_sitting"/>
     <binding key="E" mask="NONE" command="spin_over_sitting"/>
     <binding key="C" mask="NONE" command="spin_under_sitting"/>
+
+<!-- <FS:Chanayane> Camera roll key bindings -->
+    <binding key="R" mask="NONE" command="roll_left" />
+    <binding key="T" mask="NONE" command="roll_right" />
+<!-- </FS:Chanayane> -->
 
     <binding key="LEFT" mask="NONE" command="spin_around_cw_sitting"/>
     <binding key="RIGHT" mask="NONE" command="spin_around_ccw_sitting"/>

--- a/indra/newview/llkeyconflict.cpp
+++ b/indra/newview/llkeyconflict.cpp
@@ -813,6 +813,10 @@ void LLKeyConflictHandler::generatePlaceholders(ESourceMode load_mode)
         registerTemporaryControl("pan_out");
         registerTemporaryControl("spin_around_ccw");
         registerTemporaryControl("spin_around_cw");
+// <FS:Chanayane> Camera roll key bindings
+        registerTemporaryControl("roll_left");
+        registerTemporaryControl("roll_right");
+// </FS:Chanayane>
 
         // control_table_contents_editing.xml
         registerTemporaryControl("edit_avatar_spin_ccw");

--- a/indra/newview/llviewerinput.cpp
+++ b/indra/newview/llviewerinput.cpp
@@ -586,6 +586,24 @@ bool camera_pan_out( EKeystate s )
     return true;
 }
 
+// <FS:Chanayane> Camera roll key bindings
+bool camera_roll_left( EKeystate s )
+{
+    if( KEYSTATE_UP == s  ) return true;
+    gAgentCamera.unlockView();
+    gAgentCamera.setRollLeftKey(get_orbit_rate());
+    return true;
+}
+
+bool camera_roll_right( EKeystate s )
+{
+    if( KEYSTATE_UP == s  ) return true;
+    gAgentCamera.unlockView();
+    gAgentCamera.setRollRightKey(get_orbit_rate());
+    return true;
+}
+// </FS:Chanayane>
+
 bool camera_move_forward_fast( EKeystate s )
 {
     if( KEYSTATE_UP == s  ) return true;
@@ -1040,6 +1058,10 @@ REGISTER_KEYBOARD_ACTION("pan_left", camera_pan_left);
 REGISTER_KEYBOARD_ACTION("pan_right", camera_pan_right);
 REGISTER_KEYBOARD_ACTION("pan_in", camera_pan_in);
 REGISTER_KEYBOARD_ACTION("pan_out", camera_pan_out);
+// <FS:Chanayane> Camera roll key bindings
+REGISTER_KEYBOARD_ACTION("roll_left", camera_roll_left);
+REGISTER_KEYBOARD_ACTION("roll_right", camera_roll_right);
+// </FS:Chanayane>
 REGISTER_KEYBOARD_ACTION("move_forward_fast", camera_move_forward_fast);
 REGISTER_KEYBOARD_ACTION("move_backward_fast", camera_move_backward_fast);
 REGISTER_KEYBOARD_ACTION("edit_avatar_spin_ccw", edit_avatar_spin_ccw);

--- a/indra/newview/skins/default/xui/en/control_table_contents_camera.xml
+++ b/indra/newview/skins/default/xui/en/control_table_contents_camera.xml
@@ -175,6 +175,30 @@
          tool_tip="Camera spin around clockwise"
          value="Clockwise" />
     </rows>
+<!-- <FS:Chanayane> Camera roll key bindings -->
+    <rows
+     name="roll_left"
+     value="roll_left">
+        <columns
+         column="lst_action"
+         font="SansSerif"
+         halign="left"
+         name="lst_action"
+         tool_tip="Camera roll left"
+         value="Roll left" />
+    </rows>
+    <rows
+     name="roll_right"
+     value="roll_right">
+        <columns
+         column="lst_action"
+         font="SansSerif"
+         halign="left"
+         name="lst_action"
+         tool_tip="Camera roll right"
+         value="Roll right" />
+    </rows>
+<!-- </FS:Chanayane> -->
     <rows
      name="move_forward_sitting"
      value="move_forward_sitting">


### PR DESCRIPTION
Adds key bindings for the new Camera Roll feature that got accepted a few weeks ago. I think this will make the camera roll feature more useful for people who use keyboard shortcuts to control the camera.

By default, I chose the following keys:
- R (roll left)
- T (roll right)

I couldn't find any other use for these keys so I think it's alright without any modifier, and also convenient. Easy to remember as R is for Roll.

You might have to define the keys yourself or reset key bindings to defaults after an update for this to work, at least I had to do it on my computer.

You can see the new key bindings in Preferences > Controls > When in third person or When sitting, under the Camera section.

![special-FirestormOS-AyaneStorm_HoYzZEMLY5](https://github.com/user-attachments/assets/eaa11e04-555f-4eac-9065-f9b31d4215fd)
