### PR TITLE
FIRE-34629 Add an "eye" button on the login screen allowing visible password text

### DIFF
--- a/indra/newview/fspanellogin.cpp
+++ b/indra/newview/fspanellogin.cpp
@@ -191,6 +191,7 @@ FSPanelLogin::FSPanelLogin(const LLRect &rect,
     setBackgroundOpaque(true);
 
     mPasswordModified = false;
+    mShowPassword     = false;
 
     sInstance = this;
 
@@ -315,6 +316,10 @@ FSPanelLogin::FSPanelLogin(const LLRect &rect,
     username_combo->setCommitCallback(boost::bind(&FSPanelLogin::onSelectUser, this));
     username_combo->setFocusLostCallback(boost::bind(&FSPanelLogin::onSelectUser, this));
     mPreviousUsername = username_combo->getValue().asString();
+
+    childSetAction("password_show_btn", onShowHidePasswordClick, this);
+    childSetAction("password_hide_btn", onShowHidePasswordClick, this);
+    syncShowHidePasswordButton();
 
     mInitialized = true;
 }
@@ -1057,6 +1062,37 @@ void FSPanelLogin::onClickForgotPassword(void*)
         LLWeb::loadURLExternal(sInstance->getString( "forgot_password_url" ));
     }
 }
+
+// static
+void FSPanelLogin::onShowHidePasswordClick(void*)
+{
+    if (sInstance)
+    {  // mShowPassword is not saved between sessions, it's just for short-term use
+        sInstance->mShowPassword = !sInstance->mShowPassword;
+        LL_INFOS("AppInit") << "Showing password text now " << (sInstance->mShowPassword ? "on" : "off") << LL_ENDL;
+
+        sInstance->syncShowHidePasswordButton();
+    }
+}
+
+
+void FSPanelLogin::syncShowHidePasswordButton()
+{   // Show or hide the two 'eye' buttons for password visibility
+    LLButton* show_password_btn = sInstance->findChild<LLButton>("password_show_btn");
+    if (show_password_btn)
+    {
+        show_password_btn->setVisible(!mShowPassword);
+    }
+    LLButton* hide_password_btn = sInstance->findChild<LLButton>("password_hide_btn");
+    if (hide_password_btn)
+    {
+        hide_password_btn->setVisible(mShowPassword);
+    }
+
+    // Update the edit field to replace password text with dots ... or not.  Will redraw
+    sInstance->getChild<LLLineEditor>("password_edit")->setDrawAsterixes(!mShowPassword);
+}
+
 
 //static
 void FSPanelLogin::onClickHelp(void*)

--- a/indra/newview/fspanellogin.h
+++ b/indra/newview/fspanellogin.h
@@ -98,6 +98,7 @@ private:
     void onSelectServer();
     void onLocationSLURL();
     void onUsernameTextChanged();
+    void syncShowHidePasswordButton();          // Update which button is shown based on mShowPassword
 
     static void onClickConnect(void*);
     static void onClickNewAccount(void*);
@@ -110,6 +111,7 @@ private:
     static void onRemoveCallback(const LLSD& notification, const LLSD& response);
     static void onClickGridMgrHelp(void*);
     static void onClickGridBuilder(void*);
+    static void onShowHidePasswordClick(void*);
     static std::string credentialName();
 
 private:
@@ -121,6 +123,8 @@ private:
     void*           mCallbackData;
 
     bool            mPasswordModified;
+    bool            mShowPassword;  // Show password in normal text vs. hidden by dots
+
     bool            mShowFavorites;
 
     static FSPanelLogin* sInstance;

--- a/indra/newview/skins/default/xui/en/panel_fs_login.xml
+++ b/indra/newview/skins/default/xui/en/panel_fs_login.xml
@@ -274,6 +274,30 @@
           top_pad="1"
           name="remember_check"
           width="145" />
+      <button
+          name="password_show_btn"
+          tool_tip="Show password text"
+          follows="left|bottom"
+          left="256"
+          bottom_delta="0"
+          height="20"
+          width="20"
+          image_pressed="Profile_Group_Visibility_Off_Pressed"
+          image_unselected="Profile_Group_Visibility_Off"
+          tab_stop="false"
+          visible="true"  />
+        <button
+          name="password_hide_btn"
+          tool_tip="Hide password text"
+          follows="left|bottom"
+          left="256"
+          bottom_delta="0"
+          height="20"
+          width="20"
+          image_pressed="Profile_Group_Visibility_On_Pressed"
+          image_unselected="Profile_Group_Visibility_On"
+          tab_stop="false"
+          visible="false"  />
     </layout_panel>
     <layout_panel
         tab_stop="false"

--- a/indra/newview/skins/default/xui/en/panel_fs_nui_login.xml
+++ b/indra/newview/skins/default/xui/en/panel_fs_nui_login.xml
@@ -184,6 +184,30 @@
       top_pad="10"
       name="remember_check"
       width="204" />
+    <button
+      name="password_show_btn"
+      tool_tip="Show password text"
+      follows="left|bottom"
+      left="194"
+      bottom_delta="0"
+      height="20"
+      width="20"
+      image_pressed="Profile_Group_Visibility_Off_Pressed"
+      image_unselected="Profile_Group_Visibility_Off"
+      tab_stop="false"
+      visible="true"  />
+    <button
+      name="password_hide_btn"
+      tool_tip="Hide password text"
+      follows="left|bottom"
+      left="194"
+      bottom_delta="0"
+      height="20"
+      width="20"
+      image_pressed="Profile_Group_Visibility_On_Pressed"
+      image_unselected="Profile_Group_Visibility_On"
+      tab_stop="false"
+      visible="false"  />
     </layout_panel> <!-- password_container -->
     <layout_panel
       auto_resize="false"


### PR DESCRIPTION
Add an "eye" button on the login screens allowing visible password text

See https://jira.firestormviewer.org/browse/FIRE-34629 for what this looks like.

This re-uses an existing "eye" button graphic from group permissions.   To be perfectly neat and clean, either this feature should have it's own button graphics, or the existing ones should be renamed to be something more generic.  That said, it works and has minimal disruption of other code and doesn't add more files and data to the download.   It didn't seem worth the effort.

I did not touch the Linden login files since I assume that would be better left alone and might do a patch for that viewer someday
