### PR TITLE
Add teleport here button

### DIFF
--- a/indra/newview/llviewermenu.cpp
+++ b/indra/newview/llviewermenu.cpp
@@ -5796,6 +5796,23 @@ class LLLandCanSit : public view_listener_t
     }
 };
 
+// <FS:makidoll> Add teleport here button
+class LLLandTeleportHere : public view_listener_t
+{
+    bool handleEvent(const LLSD& userdata)
+    {
+        LLPickInfo pick = LLToolPie::getInstance()->getPick();
+
+        LLVector3d pos = pick.mPosGlobal;
+        pos.mdV[VZ] += gAgentAvatarp->getPelvisToFoot();
+
+        gAgent.teleportViaLocationLookAt(pos);
+        
+        return true;
+    }
+};
+// </FS:makidoll>
+
 //-------------------------------------------------------------------
 // Help menu functions
 //-------------------------------------------------------------------
@@ -8133,6 +8150,24 @@ void handle_look_at_selection(const LLSD& param)
         }
     }
 }
+
+// <FS:makidoll> Add teleport here button
+void handle_object_teleport_here()
+{
+    LLPickInfo pick = LLToolPie::getInstance()->getPick();
+    LLViewerObject *object = pick.getObject();
+
+    if (!object || pick.mPickType == LLPickInfo::PICK_FLORA)
+    {
+        return;
+    }
+
+    LLVector3d pos = pick.mPosGlobal;
+    pos.mdV[VZ] += gAgentAvatarp->getPelvisToFoot();
+
+    gAgent.teleportViaLocationLookAt(pos);
+}
+// </FS:makidoll>
 
 // <FS:Ansariel> Option to try via exact position
 //void handle_zoom_to_object(LLUUID object_id)
@@ -13060,6 +13095,7 @@ void initialize_menus()
     enable.add("Object.EnableUnmute", boost::bind(&enable_object_unmute));
     enable.add("Object.EnableBuy", boost::bind(&enable_buy_object));
     commit.add("Object.ZoomIn", boost::bind(&handle_look_at_selection, "zoom"));
+    commit.add("Object.TeleportHere", boost::bind(&handle_object_teleport_here)); // <FS:makidoll> Add teleport here button
     enable.add("Object.EnableScriptInfo", boost::bind(&enable_script_info));    // <FS:CR>
     enable.add("Object.EnableShowOriginal", boost::bind(&enable_object_show_original)); // <FS:Ansariel> Disable if prevented by RLVa
 
@@ -13077,6 +13113,7 @@ void initialize_menus()
     view_listener_t::addMenu(new LLLandBuild(), "Land.Build");
     view_listener_t::addMenu(new LLLandSit(), "Land.Sit");
     view_listener_t::addMenu(new LLLandCanSit(), "Land.CanSit");
+    view_listener_t::addMenu(new LLLandTeleportHere(), "Land.TeleportHere"); // <FS:makidoll> Add teleport here button
     view_listener_t::addMenu(new LLLandBuyPass(), "Land.BuyPass");
     view_listener_t::addMenu(new LLLandEdit(), "Land.Edit");
 

--- a/indra/newview/llviewermenu.h
+++ b/indra/newview/llviewermenu.h
@@ -116,6 +116,7 @@ void handle_buy();
 void handle_take(bool take_separate = false);
 void handle_take_copy();
 void handle_look_at_selection(const LLSD& param);
+void handle_object_teleport_here(); // <FS:makidoll> Add teleport here button
 void handle_script_info();
 // <FS:Ansariel> Option to try via exact position
 //void handle_zoom_to_object(LLUUID object_id);

--- a/indra/newview/skins/default/xui/en/menu_land.xml
+++ b/indra/newview/skins/default/xui/en/menu_land.xml
@@ -26,6 +26,14 @@
         <menu_item_call.on_click
          function="Land.Sit" />
     </menu_item_call>
+    <!-- <FS:makidoll> Add teleport here button -->
+    <menu_item_call
+     label="Teleport Here"
+     name="Teleport Here">
+        <menu_item_call.on_click
+         function="Land.TeleportHere" />
+    </menu_item_call>
+    <!-- </FS:makidoll> -->
     <menu_item_separator
      layout="topleft" />
         <menu_item_call

--- a/indra/newview/skins/default/xui/en/menu_object.xml
+++ b/indra/newview/skins/default/xui/en/menu_object.xml
@@ -178,6 +178,14 @@
     <menu_item_call.on_click
         function="Object.ZoomIn" />
   </menu_item_call>
+  <!-- <FS:makidoll> Add teleport here button -->
+  <menu_item_call
+      label="Teleport here"
+      name="Teleport here">
+    <menu_item_call.on_click
+        function="Object.TeleportHere" />
+  </menu_item_call>
+  <!-- </FS:makidoll> -->
   <menu_item_call
       label="Show in Region Objects"
       name="show_in_linksets">


### PR DESCRIPTION
This PR adds a button that lets you teleport using the context menu. I find this a better option than the double click teleport because some of the scripts I interact with  causes an accidental teleport from clicking too fast.

I updated the land context menu and object context menu. This doesn't show up in the pie menu.

![Screenshot From 2024-10-17 05-00-10](https://github.com/user-attachments/assets/53fba4a7-f6c6-4cde-930c-edc477f242ff)

![Screenshot From 2024-10-17 05-00-19](https://github.com/user-attachments/assets/5b9926cf-ab84-4bdf-9885-0cadbf2eff55)
