### PR TITLE
Revert to the main viewer's method of generating exp_min and exp_max.

### DIFF
--- a/indra/newview/pipeline.cpp
+++ b/indra/newview/pipeline.cpp
@@ -7219,37 +7219,18 @@ void LLPipeline::generateExposure(LLRenderTarget* src, LLRenderTarget* dst, bool
         LLSettingsSky::ptr_t sky = LLEnvironment::instance().getCurrentSky();
 
         F32 probe_ambiance = LLEnvironment::instance().getCurrentSky()->getReflectionProbeAmbiance(should_auto_adjust);
+        F32 exp_min = sky->getHDRMin();
+        F32 exp_max = sky->getHDRMax();
 
-        F32 exp_min = 1.f;
-        F32 exp_max = 1.f;
-
-        static LLCachedControl<bool> use_exposure_sky_settings(gSavedSettings, "RenderUseExposureSkySettings", false);
-
-        if (use_exposure_sky_settings)
+        if (dynamic_exposure_enabled)
         {
-            if (dynamic_exposure_enabled)
-            {
-                exp_min = sky->getHDROffset() - sky->getHDRMin();
-                exp_max = sky->getHDROffset() + sky->getHDRMax();
-            }
-            else
-            {
-                exp_min = sky->getHDROffset();
-                exp_max = sky->getHDROffset();
-            }
+            exp_min = sky->getHDROffset() - exp_min;
+            exp_max = sky->getHDROffset() + exp_max;
         }
-        else if (dynamic_exposure_enabled)
+        else
         {
-            if (probe_ambiance > 0.f)
-            {
-                F32 hdr_scale = sqrtf(LLEnvironment::instance().getCurrentSky()->getGamma()) * 2.f;
-
-                if (hdr_scale > 1.f)
-                {
-                    exp_min = 1.f / hdr_scale;
-                    exp_max = hdr_scale;
-                }
-            }
+            exp_min = sky->getHDROffset();
+            exp_max = sky->getHDROffset();
         }
 
         shader->uniform1f(dt, gFrameIntervalSeconds);


### PR DESCRIPTION
**Never** calculate exp_min and exp_max the old way using sky gamma.

Those values were attempting to overload the sky gamma parameter in a way it shouldn't have.  Instead, understand what exp_min and exp_max do here, and do the following:
- If you want locked exposure, these two values should be the same.
- If you want V7.0-ish dynamic exposure, see the defaults we return on PBR skies in llsettingssky.cpp.  At best using sky gamma is janky, at worst your numbers will be straight up wrong.

The new dynamic exposure works off of an EV min/max/offset style setup.  On the CPU we start with the offset, and add or subtract from it to calculate exp_min and exp_max.  In this way, offset acts as a pivot.

If you want to support viewer-side overrides of these values, I suggest adding new debug settings to drive min/max/offset instead.