### PR TITLE
FIRE-35019 Add LLHUBNameTag background to floating text and hover highlights

### DIFF
--- a/indra/cmake/Python.cmake
+++ b/indra/cmake/Python.cmake
@@ -13,7 +13,7 @@ elseif (WINDOWS)
   foreach(hive HKEY_CURRENT_USER HKEY_LOCAL_MACHINE)
     # prefer more recent Python versions to older ones, if multiple versions
     # are installed
-    foreach(pyver 3.12 3.11 3.10 3.9 3.8 3.7)
+    foreach(pyver 3.13 3.12 3.11 3.10 3.9 3.8 3.7)
       list(APPEND regpaths "[${hive}\\SOFTWARE\\Python\\PythonCore\\${pyver}\\InstallPath]")
     endforeach()
   endforeach()

--- a/indra/newview/app_settings/settings.xml
+++ b/indra/newview/app_settings/settings.xml
@@ -25106,6 +25106,28 @@ Change of this parameter will affect the layout of buttons in notification toast
       <key>SanityComment</key>
       <string>This value needs to be greater than 0 for a fading effect.</string>
     </map>
+    <key>FSHudTextShowBackground</key>
+    <map>
+        <key>Comment</key>
+        <string>Displays a black/white background behind the HUD text to make the text more readable</string>
+        <key>Persist</key>
+        <integer>1</integer>
+        <key>Type</key>
+        <string>S32</string>
+        <key>Value</key>
+        <integer>0</integer>
+    </map>
+    <key>FSHudTextUseHoverHighlight</key>
+    <map>
+        <key>Comment</key>
+        <string>When an object is being hovered over, highlight the HUD text by moving to the foreground and disable alpha</string>
+        <key>Persist</key>
+        <integer>1</integer>
+        <key>Type</key>
+        <string>Boolean</string>
+        <key>Value</key>
+        <integer>0</integer>
+    </map>    
     <key>FSStartupClearBrowserCache</key>
     <map>
       <key>Comment</key>

--- a/indra/newview/llhudobject.cpp
+++ b/indra/newview/llhudobject.cpp
@@ -52,6 +52,19 @@ struct hud_object_further_away
 
 bool hud_object_further_away::operator()(const LLPointer<LLHUDObject>& lhs, const LLPointer<LLHUDObject>& rhs) const
 {
+    // <FS:minerjr> FIRE-35019 Add LLHUBNameTag background to floating text and hover highlights
+    if (lhs->getUseHoverHighlight() || rhs->getUseHoverHighlight())
+    {
+        if (lhs->getIsHighlighted())
+        {
+            return false;
+        }
+        else if (rhs->getIsHighlighted())
+        {
+            return true;
+        }
+    }
+    // </FS:minerjr> FIRE-35019 
     return lhs->getDistance() > rhs->getDistance();
 }
 
@@ -64,6 +77,10 @@ LLHUDObject::LLHUDObject(const U8 type) :
     mVisible = true;
     mType = type;
     mDead = false;
+    // <FS:minerjr> FIRE-35019 Add LLHUBNameTag background to floating text and hover highlights
+    mbIsHighlighted     = false;
+    mbUseHoverHighlight = false;
+    // </FS:minerjr> FIRE-35019 
 }
 
 LLHUDObject::~LLHUDObject()

--- a/indra/newview/llhudobject.h
+++ b/indra/newview/llhudobject.h
@@ -59,7 +59,12 @@ public:
     void setPositionAgent(const LLVector3 &position_agent);
 
     bool isVisible() const { return mVisible; }
-
+    // <FS:minerjr> FIRE-35019 Add LLHUBNameTag background to floating text and hover highlights
+    void setIsHighlighted(bool isHighlighted) { mbIsHighlighted = isHighlighted; }
+    bool getIsHighlighted() const { return mbIsHighlighted; }
+    void setUseHoverHighlight(bool useHoverHighlight) { mbUseHoverHighlight = useHoverHighlight; }
+    bool getUseHoverHighlight() const { return mbUseHoverHighlight; }
+    // </FS:minerjr>
     U8 getType() const { return mType; }
 
     LLVector3d getPositionGlobal() const { return mPositionGlobal; }
@@ -111,6 +116,10 @@ protected:
     U8              mType;
     bool            mDead;
     bool            mVisible;
+    // <FS:minerjr> FIRE-35019 Add LLHUBNameTag background to floating text and hover highlights
+    bool            mbIsHighlighted;
+    bool            mbUseHoverHighlight;
+    // </FS:minerjr>
     LLVector3d      mPositionGlobal;
     LLPointer<LLViewerObject> mSourceObject;
     LLPointer<LLViewerObject> mTargetObject;

--- a/indra/newview/llhudtext.h
+++ b/indra/newview/llhudtext.h
@@ -59,11 +59,28 @@ protected:
             mStyle(style),
             mText(text),
             mFont(font)
-        {}
+        {
+            // <FS:minerjr> FIRE-35019 Add LLHUBNameTag background to floating text and hover highlights
+            // Added a bool check to see if the current line is blank (empty, or has only a single space character stored.
+            // There are issues with users using "Hello World \n \n \n \n" as strings which would create a 4 text segments, but only 1 had actual text
+            // and the background would cover all 4, and would not look nice. So store a flag on each segment to see if it is blank, so we don't have to
+            // do the check every frame for every text segment.
+            if (text.length() == 0 || text.find_first_not_of(utf8str_to_wstring(" "), 0) == std::string::npos)
+            {
+                mbIsBlank = true;
+            }
+            else
+            {
+                mbIsBlank = false;
+            }
+            // </FS:minerjr>
+        }
         F32 getWidth(const LLFontGL* font);
         const LLWString& getText() const { return mText; }
         void clearFontWidthMap() { mFontWidthMap.clear(); }
-
+        // <FS:minerjr> FIRE-35019 Add LLHUBNameTag background to floating text and hover highlights
+        bool isBlank() { return mbIsBlank; }
+        // </FS:minerjr>
         LLColor4                mColor;
         LLFontGL::StyleFlags    mStyle;
         const LLFontGL*         mFont;
@@ -71,6 +88,9 @@ protected:
     private:
         LLWString               mText;
         std::map<const LLFontGL*, F32> mFontWidthMap;
+        // <FS:minerjr> FIRE-35019 Add LLHUBNameTag background to floating text and hover highlights
+        bool                           mbIsBlank;
+        // </FS:minerjr>
     };
 
 public:
@@ -136,6 +156,8 @@ public:
 
     // <FS:Ansariel> FIRE-17393: Control HUD text fading by options
     static void onFadeSettingsChanged();
+    // <FS: minerjr> : Control HUD text hover highlighting and background
+    static void onHighlightSettingsChanged();
 
 protected:
     LLHUDText(const U8 type);
@@ -177,7 +199,13 @@ private:
 // [RLVa:KB] - Checked: RLVa-1.0.0
     std::string     mObjText;
 // [/RLVa:KB]
-
+    // <FS:minerjr> FIRE-35019 Add LLHUBNameTag background to floating text and hover highlights    
+    LLPointer<LLUIImage> mRoundedRectImgp;// Added background rect image from LLHUBNameTag
+    S32             mShowBackground;//Show background values (0 - off, 1 - only highlighted prims, 2 - all prims)
+    F32             mBackgroundHeight;//Store the actual height of the background image (calculated from the visible text segments)
+    F32             mBackgroundOffsetY;//Store the offset of the top of the first visible text segment
+    F32             mLuminance;//Store the luminance of the text (used to determine if the background should be white or black for higher contrast)
+    // </FS:minerjr>
     static bool    sDisplayText ;
     static std::set<LLPointer<LLHUDText> > sTextObjects;
     static std::vector<LLPointer<LLHUDText> > sVisibleTextObjects;

--- a/indra/newview/lltoolpie.cpp
+++ b/indra/newview/lltoolpie.cpp
@@ -881,7 +881,7 @@ bool LLToolPie::handleHover(S32 x, S32 y, MASK mask)
     if (object)
     {
         parent = object->getRootEdit();
-    } 
+    }
 
     if (!handleMediaHover(mHoverPick)
         && !mMouseOutsideSlop

--- a/indra/newview/lltoolpie.cpp
+++ b/indra/newview/lltoolpie.cpp
@@ -848,6 +848,24 @@ void LLToolPie::selectionPropertiesReceived()
 bool LLToolPie::handleHover(S32 x, S32 y, MASK mask)
 {
     bool pick_rigged = false; //gSavedSettings.getBOOL("AnimatedObjectsAllowLeftClick");
+    // <FS:minerjr> FIRE-35019 Add LLHUBNameTag background to floating text and hover highlights 
+    // We want to unhighlight the previous hover object's parent before we get the next hover pick and lose the reference
+    // (Possible optimization - check if the current object and previous ones are the same, and if so, don't set the text is highlighed flag to false)
+    LLViewerObject* oldObject = NULL;
+    LLViewerObject* oldParent = NULL; 
+    if (mHoverPick.isValid())
+    {
+        oldObject = mHoverPick.getObject();
+        if (oldObject)
+        {
+            oldParent = oldObject->getRootEdit();
+            if (oldParent)
+            {
+                oldParent->setTextIsHighlighted(false);
+            } 
+        }
+    }
+    // </FS:minerjr>
     mHoverPick = gViewerWindow->pickImmediate(x, y, false, pick_rigged);
     LLViewerObject *parent = NULL;
     LLViewerObject *object = mHoverPick.getObject();
@@ -863,7 +881,7 @@ bool LLToolPie::handleHover(S32 x, S32 y, MASK mask)
     if (object)
     {
         parent = object->getRootEdit();
-    }
+    } 
 
     if (!handleMediaHover(mHoverPick)
         && !mMouseOutsideSlop
@@ -940,6 +958,17 @@ bool LLToolPie::handleHover(S32 x, S32 y, MASK mask)
     {
         LLViewerMediaFocus::getInstance()->clearHover();
     }
+    // <FS:minerjr> FIRE-35019 Add LLHUBNameTag background to floating text and hover highlights 
+    // If there is an object that was hovered over, set the root of the object to have the text highlight, as
+    // the root is responsible for the LLHUBText that appears as floating text.
+    else
+    {
+        if (parent)
+        {
+            parent->setTextIsHighlighted(true);
+        }
+    }    
+    // <FS:minerjr/>
 
     return true;
 }

--- a/indra/newview/llviewercontrol.cpp
+++ b/indra/newview/llviewercontrol.cpp
@@ -1501,6 +1501,9 @@ void settings_setup_listeners()
     // <FS:Ansariel> FIRE-17393: Control HUD text fading by options
     setting_setup_signal_listener(gSavedSettings, "FSHudTextFadeDistance", LLHUDText::onFadeSettingsChanged);
     setting_setup_signal_listener(gSavedSettings, "FSHudTextFadeRange", LLHUDText::onFadeSettingsChanged);
+    // <FS:minerjr> FIRE-35019 Add LLHUBNameTag background to floating text and hover highlights 
+    setting_setup_signal_listener(gSavedSettings, "FSHudTextShowBackground", LLHUDText::onHighlightSettingsChanged);
+    setting_setup_signal_listener(gSavedSettings, "FSHudTextUseHoverHighlight", LLHUDText::onHighlightSettingsChanged);
 
     //<FS:HG> FIRE-6340, FIRE-6567, FIRE-6809 - Setting Bandwidth issues
     setting_setup_signal_listener(gSavedSettings, "ThrottleBandwidthKBPS", handleBandwidthChanged);

--- a/indra/newview/llviewerobject.cpp
+++ b/indra/newview/llviewerobject.cpp
@@ -6141,6 +6141,35 @@ void LLViewerObject::updateText()
     }
 }
 
+// <FS:minerjr> FIRE-35019 Add LLHUBNameTag background to floating text and hover highlights
+void LLViewerObject::setTextIsHighlighted(bool is_highlighted)
+{
+    //If the object it not dead, try to set the highlight value
+    if (!isDead())
+    {
+        //Check to see if the current LLHUBText object is not null, most of the time the root object contains the floating text.
+        if (mText.notNull())
+        {
+            mText->setIsHighlighted(is_highlighted);
+        }
+        // But incase the current object does not, try to set all the children to use the flag
+        else
+        {
+            //Else, there may be children with the LLHUBText objects..
+            for (child_list_t::const_iterator iter = mChildList.begin(); iter != mChildList.end(); iter++)
+            {
+                LLViewerObject* child = *iter;
+                //If the child is not an avatar, then try to set it's text is highlighed flag, which should recussivly get to all sub children. (Kind of hope not a lot of prims with this setup)
+                if (!child->isAvatar())
+                {
+                    child->setTextIsHighlighted(is_highlighted);                    
+                }
+            }
+        }
+    }
+}
+// </FS:minerjr>
+
 bool LLViewerObject::isOwnerInMuteList(LLUUID id)
 {
     LLUUID owner_id = id.isNull() ? mOwnerID : id;

--- a/indra/newview/llviewerobject.h
+++ b/indra/newview/llviewerobject.h
@@ -498,6 +498,9 @@ public:
 
     void updatePositionCaches() const; // Update the global and region position caches from the object (and parent's) xform.
     void updateText(); // update text label position
+    // <FS:minerjr> FIRE-35019 Add LLHUBNameTag background to floating text and hover highlights
+    void setTextIsHighlighted(bool is_highlighted);
+    // </FS:minerjr>
     virtual void updateDrawable(bool force_damped); // force updates on static objects
 
     bool isOwnerInMuteList(LLUUID item_id = LLUUID());

--- a/indra/newview/skins/default/xui/en/panel_preferences_UI.xml
+++ b/indra/newview/skins/default/xui/en/panel_preferences_UI.xml
@@ -201,6 +201,18 @@
          width="80">
             seconds
         </text>
+        <text
+         type="string"
+         left="10"
+         top="130"
+         top_pad="15"
+         width="180"
+         follows="left|top"
+         height="16"
+         layout="topleft"
+         name="FSHudTextLabel">
+            Floating Text Options:
+        </text>
         <slider
          control_name="FSHudTextFadeDistance"
          decimal_digits="2"
@@ -215,7 +227,6 @@
          min_val="0"
          max_val="64"
          name="FSHudTextFadeDistance"
-         top="130"
          width="481" />
         <slider
          control_name="FSHudTextFadeRange"
@@ -233,6 +244,62 @@
          name="FSHudTextFadeRange"
          top_pad="2"
          width="474" />
+        <check_box
+        control_name="FSHudTextUseHoverHighlight"
+        name="FSHudTextUseHoverHighlight"
+        label="Hover over prim to highlight floating text:"
+        tool_tip="When an object is being hovered over, highlight the HUD text by moving to the foreground and disable alpha"
+        layout="topleft"
+        top_pad="5"
+        left_delta="0"
+        height="16"
+        width="350" />        
+        <text
+         type="string"
+         left="10"
+         top_pad="5"
+         width="180"
+         follows="left|top"
+         height="16"
+         layout="topleft"
+         name="FSHudTextShowBackgroundLabel">
+            Show floating text background:
+        </text>
+        <combo_box
+               control_name="FSHudTextShowBackground"
+               height="23"
+               layout="topleft"
+               left_pad="10"
+               top_delta="-5"  
+               name="FSHudTextShowBackgroundDropdown"
+               tool_tip="Displays a black/white background behind the HUD text to make the text more readable"
+               width="180">
+            <combo_box.item
+             label="Off"
+             name="ScriptDialogOption_0"
+             value="0"/>
+            <combo_box.item
+             label="Only Highlighted Prim"
+             name="ScriptDialogOption_1"
+             value="1"/>
+            <combo_box.item
+             label="All Prims"
+             name="ScriptDialogOption_2"
+             value="2"/>            
+        </combo_box>
+        <!--
+        <check_box
+        control_name="FSHudTextShowBackground"
+        name="FSHudTextShowBackground"
+        label="Show floating text background:"
+        tool_tip="Displays a black/white background behind the HUD text to make the text more readable"
+        layout="topleft"
+        top_pad="5"
+        left_delta="0"
+        height="16"
+        width="350" />
+        -->
+
     </panel>
 
     <!--2D Overlay-->


### PR DESCRIPTION
Added new feature for allowing backgrounds behind floating prim text as well as supporting highlighting the text by changing render order as well as disabling transparency. User is able to enable/disable feature in preferences and supports a few options.

## Firestorm Pull Request Checklist
Thank you for contributing to the Phoenix Firestorm Project.
We will endeavour to review you changes and accept/reject/request changes as soon as possible. 
Please read and follow the [Firestorm Pull Request Guidelines](https://github.com/firestormviewer/phoenix-firestorm/blob/master/FS_PR_GUIDELINES.md) to reduce the likelihood that we need to ask for "Bureaucratic" changes to make the code comply with our workflows.
