### PR TITLE
FIRE-35024 - Restore Always Run flag when logging in

### DIFF
--- a/indra/newview/app_settings/settings.xml
+++ b/indra/newview/app_settings/settings.xml
@@ -5612,6 +5612,32 @@
       <key>Backup</key>
       <integer>0</integer>
     </map>
+    <key>FSRestoreAlwaysRunAtExit</key>
+    <map>
+        <key>Comment</key>
+        <string>Should we restore the always run flag on login</string>
+        <key>Persist</key>
+        <integer>1</integer>
+        <key>Type</key>
+        <string>Boolean</string>
+        <key>Value</key>
+        <integer>0</integer>
+        <key>Backup</key>
+        <integer>0</integer>
+    </map>
+    <key>FSAlwaysRunAtExit</key>
+    <map>
+        <key>Comment</key>
+        <string>Was always running when last logged out, so always run when logging in</string>
+        <key>Persist</key>
+        <integer>1</integer>
+        <key>Type</key>
+        <string>Boolean</string>
+        <key>Value</key>
+        <integer>0</integer>
+        <key>Backup</key>
+        <integer>0</integer>
+    </map>    
     <key>FocusOffsetRearView</key>
     <map>
       <key>Comment</key>

--- a/indra/newview/llagent.cpp
+++ b/indra/newview/llagent.cpp
@@ -565,6 +565,20 @@ void LLAgent::init()
     {
         setFlying(is_flying);
     }
+    // <FS:minerjr> FIRE-35024 Store always run flag on exit and restore when logging in
+    // We are leaving it up to the user to choose in the Preferences->Move & View->Movement panel if they want to restore FSAlwaysRunAtExit flag
+    // using the "Restore always running on login" check box. 
+    static LLCachedControl<bool> restore_always_run(gSavedSettings, "FSRestoreAlwaysRunAtExit");    
+    if (restore_always_run)
+    {
+        // Use the same mechanics as saving and restoring the FlayingAtExit flag
+        bool is_always_run = gSavedSettings.getBOOL("FSAlwaysRunAtExit");
+        if (is_always_run)
+        {
+            setAlwaysRun();
+        }
+    }
+    // </FS:minerjr>
 
     *mEffectColor = LLUIColorTable::instance().getColor("EffectColor");
 

--- a/indra/newview/llappviewer.cpp
+++ b/indra/newview/llappviewer.cpp
@@ -3303,6 +3303,9 @@ bool LLAppViewer::initConfiguration()
         tempSetControl("SLURLPassToOtherInstance", "false");
         tempSetControl("RenderWater", "false");
         tempSetControl("FlyingAtExit", "false");
+        // <FS:minerjr> FIRE-35024 Store always run flag on exit and restore when logging in
+        tempSetControl("FSAlwaysRunAtExit", "false");
+        // </FS:minerjr>
         tempSetControl("WindowWidth", "1024");
         tempSetControl("WindowHeight", "200");
         LLError::setEnabledLogTypesMask(0);
@@ -6252,6 +6255,11 @@ void LLAppViewer::disconnectViewer()
 
     // Remember if we were flying
     gSavedSettings.setBOOL("FlyingAtExit", gAgent.getFlying() );
+
+    // <FS:minerjr> FIRE-35024 Store always run flag on exit and restore when logging in
+    // Remember if we were always running, save it even if the user is not using it
+    gSavedSettings.setBOOL("FSAlwaysRunAtExit", gAgent.getAlwaysRun());
+    // </FS:minerjr>
 
     // Un-minimize all windows so they don't get saved minimized
     if (gFloaterView)

--- a/indra/newview/skins/default/xui/en/panel_preferences_move.xml
+++ b/indra/newview/skins/default/xui/en/panel_preferences_move.xml
@@ -479,6 +479,17 @@
          width="237"
          top_pad="0"/>
         <check_box
+         control_name="FSRestoreAlwaysRunAtExit"
+         follows="left|top"
+         height="20"
+         label="Restore Always Run on login"
+         tool_tip="Restores the Always Run flag when logging back in similar to the Always Flying flag."
+         layout="topleft"
+         left="10"
+         name="FSRestoreAlwaysRunAtExit"
+         width="300"
+         top_pad="3"/>
+        <check_box
          control_name="AutomaticFly"
          follows="left|top"
          height="20"


### PR DESCRIPTION
Adds a check box in the Preferences->Move & View->Movement panel labeled as "Restore Always Run on login", which when enabled, restores the Always Run movement mode upon logging back into the viewer. Added saved settings values FSRestoreAlwaysRunAtExit and FSAlwaysRunAtExit. FSRestoreAlwaysRunAtExit: Flag to restore the Always Run At Exit value FSAlwaysRunAtExit: Stores the state of the Always Run flag on exit

## Firestorm Pull Request Checklist
Thank you for contributing to the Phoenix Firestorm Project.
We will endeavour to review you changes and accept/reject/request changes as soon as possible. 
Please read and follow the [Firestorm Pull Request Guidelines](https://github.com/firestormviewer/phoenix-firestorm/blob/master/FS_PR_GUIDELINES.md) to reduce the likelihood that we need to ask for "Bureaucratic" changes to make the code comply with our workflows.
