### PR TITLE
FIRE-35006 - Python 3.13 support - Building master branch

### DIFF
--- a/indra/cmake/Python.cmake
+++ b/indra/cmake/Python.cmake
@@ -13,7 +13,7 @@ elseif (WINDOWS)
   foreach(hive HKEY_CURRENT_USER HKEY_LOCAL_MACHINE)
     # prefer more recent Python versions to older ones, if multiple versions
     # are installed
-    foreach(pyver 3.12 3.11 3.10 3.9 3.8 3.7)
+    foreach(pyver 3.13 3.12 3.11 3.10 3.9 3.8 3.7) # <FS:minerjr/> [FIRE-35006] Added latest stable version of Python 3.13 to the list
       list(APPEND regpaths "[${hive}\\SOFTWARE\\Python\\PythonCore\\${pyver}\\InstallPath]")
     endforeach()
   endforeach()


### PR DESCRIPTION
Added latest stable version of Python 3.13 to the list of Python versions to look for on Windows in the Python.cmake file.

When running configure on the master branch with the latest version of Python 3.13 installed, the following error appears:
**autobuild configure -A 64 -c ReleaseFS_open**
![Python313error](https://github.com/user-attachments/assets/720213a6-9f45-49e5-9645-f16eee2c0259)

After the linked modification to the Python.cmake file is done, the configuration completes successfully.
![Python313fixed](https://github.com/user-attachments/assets/ec94edb5-24cd-4f11-b28c-d5a3ee77513e)


## Firestorm Pull Request Checklist
Thank you for contributing to the Phoenix Firestorm Project.
We will endeavour to review you changes and accept/reject/request changes as soon as possible. 
Please read and follow the [Firestorm Pull Request Guidelines](https://github.com/firestormviewer/phoenix-firestorm/blob/master/FS_PR_GUIDELINES.md) to reduce the likelihood that we need to ask for "Bureaucratic" changes to make the code comply with our workflows.
