### PR TITLE
[Fire-35019] Add LLHUDNameTag background to floating text and hover highlights

### DIFF
--- a/indra/newview/app_settings/settings.xml
+++ b/indra/newview/app_settings/settings.xml
@@ -25106,6 +25106,41 @@ Change of this parameter will affect the layout of buttons in notification toast
       <key>SanityComment</key>
       <string>This value needs to be greater than 0 for a fading effect.</string>
     </map>
+    <!-- <FS:minerjr> [FIRE-35019] Add LLHUBNameTag background to floating text and hover highlights -->
+    <key>FSHudTextShowBackground</key>
+    <map>
+        <key>Comment</key>
+        <string>Displays a black/white background behind the prim floating text to make the text more readable</string>
+        <key>Persist</key>
+        <integer>1</integer>
+        <key>Type</key>
+        <string>S32</string>
+        <key>Value</key>
+        <integer>0</integer>
+    </map>
+    <key>FSHudTextBackgroundOpacity</key>
+    <map>
+        <key>Comment</key>
+        <string>Opacity of floating text background (0.0 = completely transparent, 1.0 = completely opaque)</string>
+        <key>Persist</key>
+        <integer>1</integer>
+        <key>Type</key>
+        <string>F32</string>
+        <key>Value</key>
+        <real>0.75</real>
+    </map>
+    <key>FSHudTextUseHoverHighlight</key>
+    <map>
+        <key>Comment</key>
+        <string>When an object is being hovered over, highlight the HUD text by moving to the foreground and disable alpha</string>
+        <key>Persist</key>
+        <integer>1</integer>
+        <key>Type</key>
+        <string>Boolean</string>
+        <key>Value</key>
+        <integer>0</integer>
+    </map>   
+    <!-- </FS:minerjr> [FIRE-35019] -->  
     <key>FSStartupClearBrowserCache</key>
     <map>
       <key>Comment</key>

--- a/indra/newview/app_settings/settings.xml
+++ b/indra/newview/app_settings/settings.xml
@@ -25106,7 +25106,7 @@ Change of this parameter will affect the layout of buttons in notification toast
       <key>SanityComment</key>
       <string>This value needs to be greater than 0 for a fading effect.</string>
     </map>
-    <!-- <FS:minerjr> [FIRE-35019] Add LLHUBNameTag background to floating text and hover highlights -->
+    <!-- <FS:minerjr> [FIRE-35019] Add LLHUDNameTag background to floating text and hover highlights -->
     <key>FSHudTextShowBackground</key>
     <map>
         <key>Comment</key>

--- a/indra/newview/llhudobject.cpp
+++ b/indra/newview/llhudobject.cpp
@@ -52,6 +52,25 @@ struct hud_object_further_away
 
 bool hud_object_further_away::operator()(const LLPointer<LLHUDObject>& lhs, const LLPointer<LLHUDObject>& rhs) const
 {
+    // <FS:minerjr> [FIRE-35019] Add LLHUBNameTag background to floating text and hover highlights
+    // This overrides distance comparision if either of the objects is highlighted.
+    // Get the FSHudTextUseHoverHighlight value from the saved settings and if it is enabled, then check if either object is highlighed	
+    static LLCachedControl<bool> mbUseHoverHighlight(*LLControlGroup::getInstance("Global"), "FSHudTextUseHoverHighlight");
+    if (mbUseHoverHighlight)
+    {
+        // If the left object is highlighted then return false to force it be closer to the screen.
+        if (lhs->getIsHighlighted())
+        {
+            return false;
+        }
+        // Else if the right object is highlighted, then return true to force it to be closer to the screen.
+        else if (rhs->getIsHighlighted())
+        {
+            return true;
+        }
+    }
+    // Otherwise, neither object is heighlighted, so fall back to the normal distance comparison.
+    // </FS:minerjr> [FIRE-35019] 
     return lhs->getDistance() > rhs->getDistance();
 }
 
@@ -64,6 +83,9 @@ LLHUDObject::LLHUDObject(const U8 type) :
     mVisible = true;
     mType = type;
     mDead = false;
+    // <FS:minerjr> [FIRE-35019] Add LLHUBNameTag background to floating text and hover highlights
+    mbIsHighlighted = false; // Default is off 
+    // </FS:minerjr> [FIRE-35019] 
 }
 
 LLHUDObject::~LLHUDObject()

--- a/indra/newview/llhudobject.cpp
+++ b/indra/newview/llhudobject.cpp
@@ -52,7 +52,7 @@ struct hud_object_further_away
 
 bool hud_object_further_away::operator()(const LLPointer<LLHUDObject>& lhs, const LLPointer<LLHUDObject>& rhs) const
 {
-    // <FS:minerjr> [FIRE-35019] Add LLHUBNameTag background to floating text and hover highlights
+    // <FS:minerjr> [FIRE-35019] Add LLHUDNameTag background to floating text and hover highlights
     // This overrides distance comparision if either of the objects is highlighted.
     // Get the FSHudTextUseHoverHighlight value from the saved settings and if it is enabled, then check if either object is highlighed	
     static LLCachedControl<bool> mbUseHoverHighlight(*LLControlGroup::getInstance("Global"), "FSHudTextUseHoverHighlight");
@@ -83,7 +83,7 @@ LLHUDObject::LLHUDObject(const U8 type) :
     mVisible = true;
     mType = type;
     mDead = false;
-    // <FS:minerjr> [FIRE-35019] Add LLHUBNameTag background to floating text and hover highlights
+    // <FS:minerjr> [FIRE-35019] Add LLHUDNameTag background to floating text and hover highlights
     mbIsHighlighted = false; // Default is off 
     // </FS:minerjr> [FIRE-35019] 
 }

--- a/indra/newview/llhudobject.h
+++ b/indra/newview/llhudobject.h
@@ -60,6 +60,11 @@ public:
 
     bool isVisible() const { return mVisible; }
 
+    // <FS:minerjr> [FIRE-35019] Add LLHUBNameTag background to floating text and hover highlights
+    // Accessor methods for indicating if the HUB object is highlighted
+    void setIsHighlighted(bool isHighlighted) { mbIsHighlighted = isHighlighted; }
+    bool getIsHighlighted() const { return mbIsHighlighted; }
+    // </FS:minerjr> [FIRE-35019]
     U8 getType() const { return mType; }
 
     LLVector3d getPositionGlobal() const { return mPositionGlobal; }
@@ -111,6 +116,9 @@ protected:
     U8              mType;
     bool            mDead;
     bool            mVisible;
+    // <FS:minerjr> [FIRE-35019] Add LLHUBNameTag background to floating text and hover highlights
+    bool            mbIsHighlighted; // Flag to determine if the object is currently highlighted by hover
+    // </FS:minerjr> [FIRE-35019]
     LLVector3d      mPositionGlobal;
     LLPointer<LLViewerObject> mSourceObject;
     LLPointer<LLViewerObject> mTargetObject;

--- a/indra/newview/llhudobject.h
+++ b/indra/newview/llhudobject.h
@@ -60,7 +60,7 @@ public:
 
     bool isVisible() const { return mVisible; }
 
-    // <FS:minerjr> [FIRE-35019] Add LLHUBNameTag background to floating text and hover highlights
+    // <FS:minerjr> [FIRE-35019] Add LLHUDNameTag background to floating text and hover highlights
     // Accessor methods for indicating if the HUB object is highlighted
     void setIsHighlighted(bool isHighlighted) { mbIsHighlighted = isHighlighted; }
     bool getIsHighlighted() const { return mbIsHighlighted; }
@@ -116,7 +116,7 @@ protected:
     U8              mType;
     bool            mDead;
     bool            mVisible;
-    // <FS:minerjr> [FIRE-35019] Add LLHUBNameTag background to floating text and hover highlights
+    // <FS:minerjr> [FIRE-35019] Add LLHUDNameTag background to floating text and hover highlights
     bool            mbIsHighlighted; // Flag to determine if the object is currently highlighted by hover
     // </FS:minerjr> [FIRE-35019]
     LLVector3d      mPositionGlobal;

--- a/indra/newview/llhudtext.cpp
+++ b/indra/newview/llhudtext.cpp
@@ -267,7 +267,7 @@ void LLHUDText::renderText()
     // Also, only show the background if it is show all is checked, or if on highlight, only if use hover highlight is enabled.
     if ((mShowBackground == SHOW_BACKGROUND_ALL ||
          mShowBackground == SHOW_BACKGROUND_ONLY_HIGHLIGHTED && mbIsHighlighted && mbUseHoverHighlight) &&
-        mSourceObject->getAttachmentState() == 0)
+        (mSourceObject.notNull() && mSourceObject->getAttachmentState() == 0))
     {
         LLRect screen_rect;
         screen_rect.setCenterAndSize(0, static_cast<S32>(lltrunc(-mBackgroundHeight / 2 + mOffsetY + mBackgroundOffsetY)),

--- a/indra/newview/llhudtext.cpp
+++ b/indra/newview/llhudtext.cpp
@@ -533,8 +533,8 @@ void LLHUDText::updateVisibility()
     // <FS:minerjr> [FIRE-35019] Add LLHUBNameTag background to floating text and hover highlights
     //if (!mTextSegments.size() || (mDoFade && (mLastDistance > mFadeDistance + mFadeRange)))
     // Use local do fade check to allow highlighed objects to force text to be visible	
-	if (!mTextSegments.size() || (doFade && (mLastDistance > mFadeDistance + mFadeRange)))
-	// </FS:minerjr> [FIRE-35019]
+    if (!mTextSegments.size() || (doFade && (mLastDistance > mFadeDistance + mFadeRange)))
+    // </FS:minerjr> [FIRE-35019]
     {
         mVisible = false;
         return;

--- a/indra/newview/llhudtext.cpp
+++ b/indra/newview/llhudtext.cpp
@@ -55,11 +55,11 @@ const F32 HORIZONTAL_PADDING = 15.f;
 const F32 VERTICAL_PADDING = 12.f;
 const F32 BUFFER_SIZE = 2.f;
 const F32 HUD_TEXT_MAX_WIDTH = 190.f;
-// <FS:minerjr> [FIRE-35019] Add LLHUBNameTag background to floating text and hover highlights
-const F32 LINE_PADDING = 3.f; // aka "leading" - Taken from LLHUBNameTag
-const S32 SHOW_BACKGROUND_NONE = 0; // Default value and disables the LLHUBText background
-const S32 SHOW_BACKGROUND_ONLY_HIGHLIGHTED = 1; // Only LLHUBText that is part of the highlighted prim will have a background
-const S32 SHOW_BACKGROUND_ALL = 2; // All prims that have a LLHUBText will have a background, but the highlighted prim will have a non-transparent background.
+// <FS:minerjr> [FIRE-35019] Add LLHUDNameTag background to floating text and hover highlights
+const F32 LINE_PADDING = 3.f; // aka "leading" - Taken from LLHUDNameTag
+const S32 SHOW_BACKGROUND_NONE = 0; // Default value and disables the LLHUDText background
+const S32 SHOW_BACKGROUND_ONLY_HIGHLIGHTED = 1; // Only LLHUDText that is part of the highlighted prim will have a background
+const S32 SHOW_BACKGROUND_ALL = 2; // All prims that have a LLHUDText will have a background, but the highlighted prim will have a non-transparent background.
 // </FS:minerjr> [FIRE-35019]
 const F32 HUD_TEXT_MAX_WIDTH_NO_BUBBLE = 1000.f;
 const F32 MAX_DRAW_DISTANCE = 300.f;
@@ -99,7 +99,7 @@ LLHUDText::LLHUDText(const U8 type) :
     mFadeDistance = gSavedSettings.getF32("FSHudTextFadeDistance");
     mFadeRange = gSavedSettings.getF32("FSHudTextFadeRange");
     // </FS:Ansariel>
-    // <FS:minerjr> [FIRE-35019] Add LLHUBNameTag background to floating text and hover highlights
+    // <FS:minerjr> [FIRE-35019] Add LLHUDNameTag background to floating text and hover highlights
     mLastDistance = 0.0f; // Just to get rid of a compiler warning
     // </FS:minerjr> [FIRE-35019]
     mZCompare = true;
@@ -107,8 +107,8 @@ LLHUDText::LLHUDText(const U8 type) :
     mRadius = 0.1f;
     LLPointer<LLHUDText> ptr(this);
     sTextObjects.insert(ptr);
-    // <FS:minerjr> [FIRE-35019] Add LLHUBNameTag background to floating text and hover highlights
-    mRoundedRectImgp = LLUI::getUIImage("Rounded_Rect"); // Taken from LLHUBNameTag, uses the existing art asset  
+    // <FS:minerjr> [FIRE-35019] Add LLHUDNameTag background to floating text and hover highlights
+    mRoundedRectImgp = LLUI::getUIImage("Rounded_Rect"); // Taken from LLHUDNameTag, uses the existing art asset  
     mBackgroundHeight = 0.0f; // Default background height to 0.0
     mBackgroundOffsetY = 0.0f; // Default background Y offset to 0.0
     mLuminance = 1.0f; // Default luminance is 1.0 as the default color is white (1.0, 1.0, 1.0, 1.0)
@@ -123,7 +123,7 @@ void LLHUDText::render()
 {
     if (!mOnHUDAttachment && sDisplayText)
     {
-        // <FS:minerjr> [FIRE-35019] Add LLHUBNameTag background to floating text and hover highlights
+        // <FS:minerjr> [FIRE-35019] Add LLHUDNameTag background to floating text and hover highlights
         //LLGLDepthTest gls_depth(GL_TRUE, GL_FALSE);
         // If the current text object is highighed and the use hover highlight feature is enabled, then 
         // disable writing to the depth buffer
@@ -157,7 +157,7 @@ void LLHUDText::renderText()
     LLColor4 shadow_color(0.f, 0.f, 0.f, 1.f);
     F32 alpha_factor = 1.f;
     LLColor4 text_color = mColor;
-    // <FS:minerjr> [FIRE-35019] Add LLHUBNameTag background to floating text and hover highlights	
+    // <FS:minerjr> [FIRE-35019] Add LLHUDNameTag background to floating text and hover highlights	
     //if (mDoFade)
     static LLCachedControl<bool> mbUseHoverHighlight(gSavedSettings, "FSHudTextUseHoverHighlight"); // Flag to indicate if hover highlight of prims is enabled
     static LLCachedControl<S32>  mShowBackground(gSavedSettings, "FSHudTextShowBackground"); // Show background values (0 - off, 1 - only highlighted prims, 2 - all prims)
@@ -178,7 +178,7 @@ void LLHUDText::renderText()
     {
         return;
     }
-    // <FS:minerjr> [FIRE-35019] Add LLHUBNameTag background to floating text and hover highlights
+    // <FS:minerjr> [FIRE-35019] Add LLHUDNameTag background to floating text and hover highlights
     //If there is only 1 string and it is blank, don't render as it could add a background on a prim with no text
     if ((S32)mTextSegments.size() == 1 && mTextSegments[0].isBlank())
     {
@@ -190,12 +190,12 @@ void LLHUDText::renderText()
     mOffsetY = lltrunc(mHeight * ((mVertAlignment == ALIGN_VERT_CENTER) ? 0.5f : 1.f));
 
     // *TODO: make this a per-text setting
-    // <FS:minerjr> [FIRE-35019] Add LLHUBNameTag background to floating text and hover highlights
+    // <FS:minerjr> [FIRE-35019] Add LLHUDNameTag background to floating text and hover highlights
     // static LLCachedControl<F32> bubble_opacity(gSavedSettings, "ChatBubbleOpacity");
     // static LLUIColor nametag_bg_color = LLUIColorTable::instance().getColor("ObjectBubbleColor");
     // LLColor4 bg_color = nametag_bg_color;
     // bg_color.setAlpha(bubble_opacity * alpha_factor);
-    // Use new background opacity value, independant of the LLHUBNameTag value
+    // Use new background opacity value, independant of the LLHUDNameTag value
     static LLCachedControl<F32> background_opacity(gSavedSettings, "FSHudTextBackgroundOpacity"); // Can be modified under Preferences->Colors->Floating Text tab
     LLColor4 bg_color = LLColor4::black; // Default the background to black color
     bg_color.setAlpha(background_opacity * alpha_factor);
@@ -262,7 +262,7 @@ void LLHUDText::renderText()
     F32 y_offset = (F32)mOffsetY;
 
     // Render label
-    // <FS:minerjr> [FIRE-35019] Add LLHUBNameTag background to floating text and hover highlights
+    // <FS:minerjr> [FIRE-35019] Add LLHUDNameTag background to floating text and hover highlights
     // Render text window background
     // Don't add if the parent object is attached (clothing on player avatar: as some cloths have blank text and render a background...)
     // Also, only show the background if it is show all is checked, or if on highlight, only if use hover highlight is enabled.
@@ -297,9 +297,9 @@ void LLHUDText::renderText()
              segment_iter != mTextSegments.end(); ++segment_iter )
         {
             const LLFontGL* fontp = segment_iter->mFont;
-            // <FS:minerjr> [FIRE-35019] Add LLHUBNameTag background to floating text and hover highlights
+            // <FS:minerjr> [FIRE-35019] Add LLHUDNameTag background to floating text and hover highlights
             //y_offset -= fontp->getLineHeight() - 1; // correction factor to match legacy font metrics            
-            y_offset -= fontp->getLineHeight(); // Match the same positioning as LLHUBNameTag as the windows don't line up otherwise.
+            y_offset -= fontp->getLineHeight(); // Match the same positioning as LLHUDNameTag as the windows don't line up otherwise.
             y_offset -= LINE_PADDING;
             // </FS:minerjr> [FIRE-35019]
 
@@ -314,8 +314,8 @@ void LLHUDText::renderText()
             else // ALIGN_LEFT
             {
                 x_offset = -0.5f * mWidth + (HORIZONTAL_PADDING / 2.f);
-                // <FS:minerjr> [FIRE-35019] Add LLHUBNameTag background to floating text and hover highlights
-                // *HACK -> borrowed from LLHUBNameTag to match
+                // <FS:minerjr> [FIRE-35019] Add LLHUDNameTag background to floating text and hover highlights
+                // *HACK -> borrowed from LLHUDNameTag to match
                 x_offset += 1;
                 // </FS:minerjr> [FIRE-35019]
             }
@@ -326,7 +326,7 @@ void LLHUDText::renderText()
                 text_color = linearColor4(text_color);
             }
             text_color.mV[VALPHA] *= alpha_factor;
-            // <FS:minerjr> [FIRE-35019] Add LLHUBNameTag background to floating text and hover highlights	
+            // <FS:minerjr> [FIRE-35019] Add LLHUDNameTag background to floating text and hover highlights	
             // If the text object is highlighted and use hover highlight is enabled, then reset the alpha factor (1.0f)
             if (mbUseHoverHighlight && mbIsHighlighted)
             {
@@ -429,7 +429,7 @@ void LLHUDText::setFont(const LLFontGL* font)
 void LLHUDText::setColor(const LLColor4 &color)
 {
     mColor = color;
-    // <FS:minerjr> [FIRE-35019] Add LLHUBNameTag background to floating text and hover highlights
+    // <FS:minerjr> [FIRE-35019] Add LLHUDNameTag background to floating text and hover highlights
     // Added luminance value for the text color to determine if the background should be white or black
     // Based upon https://stackoverflow.com/questions/596216/formula-to-determine-perceived-brightness-of-rgb-color
     // used Digital ITU BT.601 (gives more weight to the R and B components):
@@ -461,7 +461,7 @@ void LLHUDText::setDoFade(const bool do_fade)
 
 void LLHUDText::updateVisibility()
 {
-    // <FS:minerjr> [FIRE-35019] Add LLHUBNameTag background to floating text and hover highlights
+    // <FS:minerjr> [FIRE-35019] Add LLHUDNameTag background to floating text and hover highlights
     // Create local doFade flag based upon member doFade flag and overide it if the object is highlighted and hover highlight is enabled.
     bool doFade = mDoFade;
     static LLCachedControl<bool> mbUseHoverHighlight(gSavedSettings, "FSHudTextUseHoverHighlight");
@@ -530,7 +530,7 @@ void LLHUDText::updateVisibility()
 
     mLastDistance = (mPositionAgent - LLViewerCamera::getInstance()->getOrigin()).magVec();
 
-    // <FS:minerjr> [FIRE-35019] Add LLHUBNameTag background to floating text and hover highlights
+    // <FS:minerjr> [FIRE-35019] Add LLHUDNameTag background to floating text and hover highlights
     //if (!mTextSegments.size() || (mDoFade && (mLastDistance > mFadeDistance + mFadeRange)))
     // Use local do fade check to allow highlighed objects to force text to be visible	
     if (!mTextSegments.size() || (doFade && (mLastDistance > mFadeDistance + mFadeRange)))
@@ -636,7 +636,7 @@ void LLHUDText::updateSize()
     F32 height = 0.f;
     F32 width = 0.f;
 
-    // <FS:minerjr> [FIRE-35019] Add LLHUBNameTag background to floating text and hover highlights
+    // <FS:minerjr> [FIRE-35019] Add LLHUDNameTag background to floating text and hover highlights
     // We want to create a background that fits just the visible text area only, otherwise a llsetstring('Hello, World\n\n\n') will have a text
     // box that covers 4 lines, but only the top line is visible to the user.
     // Another example is llsetstring('\n\n\nHello, World'), which would also have a 4 line high window, but the text be visible only on the last line.
@@ -654,7 +654,7 @@ void LLHUDText::updateSize()
     while (iter != mTextSegments.end())
     {
         const LLFontGL* fontp = iter->mFont;
-        // <FS:minerjr> [FIRE-35019] Add LLHUBNameTag background to floating text and hover highlights
+        // <FS:minerjr> [FIRE-35019] Add LLHUDNameTag background to floating text and hover highlights
         //height += fontp->getLineHeight() - 1; // correction factor to match legacy font metrics
         //width = llmax(width, llmin(iter->getWidth(fontp), HUD_TEXT_MAX_WIDTH));
         
@@ -679,7 +679,7 @@ void LLHUDText::updateSize()
         ++iter;
     }
 
-    // <FS:minerjr> [FIRE-35019] Add LLHUBNameTag background to floating text and hover highlights
+    // <FS:minerjr> [FIRE-35019] Add LLHUDNameTag background to floating text and hover highlights
     // Don't want line spacing under the last line (Taken from LLHUBNameTa::UpdateSize)
     if (height > 0.f)
     {
@@ -701,7 +701,7 @@ void LLHUDText::updateSize()
     F32 u = 1.f;
     mWidth = llmax(width, lerp(mWidth, (F32)width, u));
     mHeight = llmax(height, lerp(mHeight, (F32)height, u));
-    // <FS:minerjr> [FIRE-35019] Add LLHUBNameTag background to floating text and hover highlights
+    // <FS:minerjr> [FIRE-35019] Add LLHUDNameTag background to floating text and hover highlights
     backgroundLastNoneBlankPosition += VERTICAL_PADDING; // Add the vertical padding to the last non-blank position
     mBackgroundOffsetY = backgroundFirstNoneBlankPosition; // Set the background Y offset to the top of the first blank
     mBackgroundHeight  = backgroundLastNoneBlankPosition - backgroundFirstNoneBlankPosition; // Set the background height to the difference between the top of the first non-blank, and bottom of the last non-blank line

--- a/indra/newview/llhudtext.cpp
+++ b/indra/newview/llhudtext.cpp
@@ -55,6 +55,12 @@ const F32 HORIZONTAL_PADDING = 15.f;
 const F32 VERTICAL_PADDING = 12.f;
 const F32 BUFFER_SIZE = 2.f;
 const F32 HUD_TEXT_MAX_WIDTH = 190.f;
+// <FS:minerjr> [FIRE-35019] Add LLHUBNameTag background to floating text and hover highlights
+const F32 LINE_PADDING = 3.f; // aka "leading" - Taken from LLHUBNameTag
+const S32 SHOW_BACKGROUND_NONE = 0; // Default value and disables the LLHUBText background
+const S32 SHOW_BACKGROUND_ONLY_HIGHLIGHTED = 1; // Only LLHUBText that is part of the highlighted prim will have a background
+const S32 SHOW_BACKGROUND_ALL = 2; // All prims that have a LLHUBText will have a background, but the highlighted prim will have a non-transparent background.
+// </FS:minerjr> [FIRE-35019]
 const F32 HUD_TEXT_MAX_WIDTH_NO_BUBBLE = 1000.f;
 const F32 MAX_DRAW_DISTANCE = 300.f;
 
@@ -93,11 +99,20 @@ LLHUDText::LLHUDText(const U8 type) :
     mFadeDistance = gSavedSettings.getF32("FSHudTextFadeDistance");
     mFadeRange = gSavedSettings.getF32("FSHudTextFadeRange");
     // </FS:Ansariel>
+    // <FS:minerjr> [FIRE-35019] Add LLHUBNameTag background to floating text and hover highlights
+    mLastDistance = 0.0f; // Just to get rid of a compiler warning
+    // </FS:minerjr> [FIRE-35019]
     mZCompare = true;
     mOffscreen = false;
     mRadius = 0.1f;
     LLPointer<LLHUDText> ptr(this);
     sTextObjects.insert(ptr);
+    // <FS:minerjr> [FIRE-35019] Add LLHUBNameTag background to floating text and hover highlights
+    mRoundedRectImgp = LLUI::getUIImage("Rounded_Rect"); // Taken from LLHUBNameTag, uses the existing art asset  
+    mBackgroundHeight = 0.0f; // Default background height to 0.0
+    mBackgroundOffsetY = 0.0f; // Default background Y offset to 0.0
+    mLuminance = 1.0f; // Default luminance is 1.0 as the default color is white (1.0, 1.0, 1.0, 1.0)
+    // </FS:minerjr> [FIRE-35019]
 }
 
 LLHUDText::~LLHUDText()
@@ -108,7 +123,21 @@ void LLHUDText::render()
 {
     if (!mOnHUDAttachment && sDisplayText)
     {
-        LLGLDepthTest gls_depth(GL_TRUE, GL_FALSE);
+        // <FS:minerjr> [FIRE-35019] Add LLHUBNameTag background to floating text and hover highlights
+        //LLGLDepthTest gls_depth(GL_TRUE, GL_FALSE);
+        // If the current text object is highighed and the use hover highlight feature is enabled, then 
+        // disable writing to the depth buffer
+        static LLCachedControl<bool> mbUseHoverHighlight(gSavedSettings, "FSHudTextUseHoverHighlight");
+        if (mbUseHoverHighlight && mbIsHighlighted)
+        {            
+            LLGLDepthTest gls_depth(GL_FALSE, GL_FALSE);
+        }
+        //Else, use the standard method of writing to the depth buffer for all other non-highlighted text objects
+        else
+        {
+            LLGLDepthTest gls_depth(GL_TRUE, GL_FALSE);
+        }
+        // </FS:minerjr> [FIRE-35019]		
         //LLGLDisable gls_stencil(GL_STENCIL_TEST);
         renderText();
     }
@@ -128,7 +157,13 @@ void LLHUDText::renderText()
     LLColor4 shadow_color(0.f, 0.f, 0.f, 1.f);
     F32 alpha_factor = 1.f;
     LLColor4 text_color = mColor;
-    if (mDoFade)
+    // <FS:minerjr> [FIRE-35019] Add LLHUBNameTag background to floating text and hover highlights	
+    //if (mDoFade)
+    static LLCachedControl<bool> mbUseHoverHighlight(gSavedSettings, "FSHudTextUseHoverHighlight"); // Flag to indicate if hover highlight of prims is enabled
+    static LLCachedControl<S32>  mShowBackground(gSavedSettings, "FSHudTextShowBackground"); // Show background values (0 - off, 1 - only highlighted prims, 2 - all prims)
+    // Support fading the text if the text is not highlighted and only if use hover highlight flag is set
+    if (mDoFade && (!mbUseHoverHighlight || (mbUseHoverHighlight && !mbIsHighlighted)))
+    // </FS:minerjr> [FIRE-35019]
     {
         // <FS:Ansariel> FIRE-17393: Control HUD text fading by options
         //if (mLastDistance > mFadeDistance)
@@ -143,16 +178,43 @@ void LLHUDText::renderText()
     {
         return;
     }
+    // <FS:minerjr> [FIRE-35019] Add LLHUBNameTag background to floating text and hover highlights
+    //If there is only 1 string and it is blank, don't render as it could add a background on a prim with no text
+    if ((S32)mTextSegments.size() == 1 && mTextSegments[0].isBlank())
+    {
+        return;
+    }
+    // </FS:minerjr> [FIRE-35019]
     shadow_color.mV[3] = text_color.mV[3];
 
     mOffsetY = lltrunc(mHeight * ((mVertAlignment == ALIGN_VERT_CENTER) ? 0.5f : 1.f));
 
     // *TODO: make this a per-text setting
-    static LLCachedControl<F32> bubble_opacity(gSavedSettings, "ChatBubbleOpacity");
-    static LLUIColor nametag_bg_color = LLUIColorTable::instance().getColor("ObjectBubbleColor");
-    LLColor4 bg_color = nametag_bg_color;
-    bg_color.setAlpha(bubble_opacity * alpha_factor);
-
+    // <FS:minerjr> [FIRE-35019] Add LLHUBNameTag background to floating text and hover highlights
+    // static LLCachedControl<F32> bubble_opacity(gSavedSettings, "ChatBubbleOpacity");
+    // static LLUIColor nametag_bg_color = LLUIColorTable::instance().getColor("ObjectBubbleColor");
+    // LLColor4 bg_color = nametag_bg_color;
+    // bg_color.setAlpha(bubble_opacity * alpha_factor);
+    // Use new background opacity value, independant of the LLHUBNameTag value
+    static LLCachedControl<F32> background_opacity(gSavedSettings, "FSHudTextBackgroundOpacity"); // Can be modified under Preferences->Colors->Floating Text tab
+    LLColor4 bg_color = LLColor4::black; // Default the background to black color
+    bg_color.setAlpha(background_opacity * alpha_factor);
+    // If the show background flag is set, so change the background color depending on the luminance
+    if (mShowBackground)
+    {
+        // If the luminance is below 40%, then use white background color
+        if (mLuminance <= 0.4f)
+        {
+            bg_color.set(LLColor3::white); // Set background color keep the alpha
+        }
+        // If hover highlight is enabled and the text object is highlighted then, change the alpha value (Background Opacity if only highlighted objects
+        // have a background, otherwise, use the alpha value (which should be 1.0))
+        if (mbUseHoverHighlight && mbIsHighlighted)
+        {
+            bg_color.setAlpha(mShowBackground == SHOW_BACKGROUND_ONLY_HIGHLIGHTED ? background_opacity : alpha_factor);
+        }        
+    }	
+    // </FS:minerjr> [FIRE-35019]
     const S32 border_height = 16;
     const S32 border_width = 16;
 
@@ -199,6 +261,21 @@ void LLHUDText::renderText()
     F32 y_offset = (F32)mOffsetY;
 
     // Render label
+    // <FS:minerjr> [FIRE-35019] Add LLHUBNameTag background to floating text and hover highlights
+    // Render text window background
+    // Don't add if the parent object is attached (clothing on player avatar: as some cloths have blank text and render a background...)
+    // Also, only show the background if it is show all is checked, or if on highlight, only if use hover highlight is enabled.
+    if ((mShowBackground == SHOW_BACKGROUND_ALL ||
+         mShowBackground == SHOW_BACKGROUND_ONLY_HIGHLIGHTED && mbIsHighlighted && mbUseHoverHighlight) &&
+        mSourceObject->getAttachmentState() == 0)
+    {
+        LLRect screen_rect;
+        screen_rect.setCenterAndSize(0, static_cast<S32>(lltrunc(-mBackgroundHeight / 2 + mOffsetY + mBackgroundOffsetY)),
+                                     static_cast<S32>(lltrunc(mWidth)),
+                                     static_cast<S32>(lltrunc(mBackgroundHeight)));
+        mRoundedRectImgp->draw3D(render_position, x_pixel_vec, y_pixel_vec, screen_rect, bg_color);
+    }
+    // </FS:minerjr> [FIRE-35019]
 
     // Render text
     {
@@ -219,8 +296,11 @@ void LLHUDText::renderText()
              segment_iter != mTextSegments.end(); ++segment_iter )
         {
             const LLFontGL* fontp = segment_iter->mFont;
-            y_offset -= fontp->getLineHeight() - 1; // correction factor to match legacy font metrics
-
+            // <FS:minerjr> [FIRE-35019] Add LLHUBNameTag background to floating text and hover highlights
+            //y_offset -= fontp->getLineHeight() - 1; // correction factor to match legacy font metrics            
+            y_offset -= fontp->getLineHeight(); // Match the same positioning as LLHUBNameTag as the windows don't line up otherwise.
+            y_offset -= LINE_PADDING;
+            // </FS:minerjr> [FIRE-35019]
             U8 style = segment_iter->mStyle;
             LLFontGL::ShadowType shadow = LLFontGL::DROP_SHADOW;
 
@@ -232,6 +312,10 @@ void LLHUDText::renderText()
             else // ALIGN_LEFT
             {
                 x_offset = -0.5f * mWidth + (HORIZONTAL_PADDING / 2.f);
+                // <FS:minerjr> [FIRE-35019] Add LLHUBNameTag background to floating text and hover highlights
+                // *HACK -> borrowed from LLHUBNameTag to match
+                x_offset += 1;
+                // </FS:minerjr> [FIRE-35019]
             }
 
             text_color = segment_iter->mColor;
@@ -240,6 +324,13 @@ void LLHUDText::renderText()
                 text_color = linearColor4(text_color);
             }
             text_color.mV[VALPHA] *= alpha_factor;
+            // <FS:minerjr> [FIRE-35019] Add LLHUBNameTag background to floating text and hover highlights	
+            // If the text object is highlighted and use hover highlight is enabled, then reset the alpha factor (1.0f)
+            if (mbUseHoverHighlight && mbIsHighlighted)
+            {
+                text_color.mV[VALPHA] = alpha_factor;
+            }
+            // </FS:minerjr> [FIRE-35019]
 
             hud_render_text(segment_iter->getText(), render_position, *fontp, style, shadow, x_offset, y_offset, text_color, mOnHUDAttachment);
         }
@@ -336,6 +427,13 @@ void LLHUDText::setFont(const LLFontGL* font)
 void LLHUDText::setColor(const LLColor4 &color)
 {
     mColor = color;
+    // <FS:minerjr> [FIRE-35019] Add LLHUBNameTag background to floating text and hover highlights
+    // Added luminance value for the text color to determine if the background should be white or black
+    // Based upon https://stackoverflow.com/questions/596216/formula-to-determine-perceived-brightness-of-rgb-color
+    // used Digital ITU BT.601 (gives more weight to the R and B components):
+    // Y = 0.299 R + 0.587 G + 0.114 B
+    mLuminance = 0.299f * mColor.mV[0] + 0.587f * mColor.mV[1] + 0.114f * mColor.mV[2];
+    // </FS:minerjr> [FIRE-35019]
     for (std::vector<LLHUDTextSegment>::iterator segment_iter = mTextSegments.begin();
          segment_iter != mTextSegments.end(); ++segment_iter )
     {
@@ -361,6 +459,15 @@ void LLHUDText::setDoFade(const bool do_fade)
 
 void LLHUDText::updateVisibility()
 {
+    // <FS:minerjr> [FIRE-35019] Add LLHUBNameTag background to floating text and hover highlights
+    // Create local doFade flag based upon member doFade flag and overide it if the object is highlighted and hover highlight is enabled.
+    bool doFade = mDoFade;
+    static LLCachedControl<bool> mbUseHoverHighlight(gSavedSettings, "FSHudTextUseHoverHighlight");
+    if (mbUseHoverHighlight && mbIsHighlighted)
+    {
+        doFade = false;
+    }
+    // </FS:minerjr> [FIRE-35019]
     if (mSourceObject)
     {
         mSourceObject->updateText();
@@ -421,7 +528,11 @@ void LLHUDText::updateVisibility()
 
     mLastDistance = (mPositionAgent - LLViewerCamera::getInstance()->getOrigin()).magVec();
 
-    if (!mTextSegments.size() || (mDoFade && (mLastDistance > mFadeDistance + mFadeRange)))
+    // <FS:minerjr> [FIRE-35019] Add LLHUBNameTag background to floating text and hover highlights
+    //if (!mTextSegments.size() || (mDoFade && (mLastDistance > mFadeDistance + mFadeRange)))
+    // Use local do fade check to allow highlighed objects to force text to be visible	
+	if (!mTextSegments.size() || (doFade && (mLastDistance > mFadeDistance + mFadeRange)))
+	// </FS:minerjr> [FIRE-35019]
     {
         mVisible = false;
         return;
@@ -522,7 +633,14 @@ void LLHUDText::updateSize()
 {
     F32 height = 0.f;
     F32 width = 0.f;
-
+    // <FS:minerjr> [FIRE-35019] Add LLHUBNameTag background to floating text and hover highlights
+    // We want to create a background that fits just the visible text area only, otherwise a llsetstring('Hello, World\n\n\n') will have a text
+    // box that covers 4 lines, but only the top line is visible to the user.
+    // Another example is llsetstring('\n\n\nHello, World'), which would also have a 4 line high window, but the text be visible only on the last line.
+    F32 backgroundFirstNoneBlankPosition = 0.0f; // Stores the position just above the first non blank line
+    F32 backgroundLastNoneBlankPosition = 0.0f; // Stores the position just below the last none blank line
+    bool firstNoneBlank = true; // Flag to determine that if the first blank line has been reached and to store the first none black position
+    // <FS:minerjr> [FIRE-35019] 
     S32 max_lines = getMaxLines();
 
     S32 start_segment;
@@ -533,11 +651,41 @@ void LLHUDText::updateSize()
     while (iter != mTextSegments.end())
     {
         const LLFontGL* fontp = iter->mFont;
-        height += fontp->getLineHeight() - 1; // correction factor to match legacy font metrics
-        width = llmax(width, llmin(iter->getWidth(fontp), HUD_TEXT_MAX_WIDTH));
+        // <FS:minerjr> [FIRE-35019] Add LLHUBNameTag background to floating text and hover highlights
+        //height += fontp->getLineHeight() - 1; // correction factor to match legacy font metrics
+        //width = llmax(width, llmin(iter->getWidth(fontp), HUD_TEXT_MAX_WIDTH));
+        
+        //If there is no blank on the current line, skip over it so that we don't make the window cover the empty space above or below a blank text box.
+        if (!iter->isBlank())
+        {
+            //If this is the first line without a blank, get the height above current line (0.0 for line 1, previous height if not the first line
+            if (firstNoneBlank)
+            {
+                backgroundFirstNoneBlankPosition = height;
+                firstNoneBlank = false;
+            }
+            //Always get the position below the non-blank line
+            backgroundLastNoneBlankPosition = height + fontp->getLineHeight() + LINE_PADDING;            
+        }
+        // </FS:minerjr> 
+        height += fontp->getLineHeight(); // Taken from LLHUBNameTa::UpdateSize
+        height += LINE_PADDING; // Taken from LLHUBNameTa::UpdateSize  
+        // The max width of the text is set to HUD_TEXT_MAX_WIDTH_NO_BUBBLE and not HUD_TEXT_MAX_WIDTH, so the window would be limited but the text could spill over...
+        width = llmax(width, llmin(iter->getWidth(fontp), HUD_TEXT_MAX_WIDTH_NO_BUBBLE));
+        // <FS:minerjr> [FIRE-35019]		
         ++iter;
     }
 
+    // <FS:minerjr> [FIRE-35019] Add LLHUBNameTag background to floating text and hover highlights
+    // Don't want line spacing under the last line (Taken from LLHUBNameTa::UpdateSize)
+    if (height > 0.f)
+    {
+        height -= LINE_PADDING;
+        // Also update the background last non blank position by the LINE_PADDING
+        backgroundLastNoneBlankPosition -= LINE_PADDING;
+    }
+    // <FS:minerjr> [FIRE-35019]
+	
     if (width == 0.f)
     {
         return;
@@ -550,6 +698,11 @@ void LLHUDText::updateSize()
     F32 u = 1.f;
     mWidth = llmax(width, lerp(mWidth, (F32)width, u));
     mHeight = llmax(height, lerp(mHeight, (F32)height, u));
+    // <FS:minerjr> [FIRE-35019] Add LLHUBNameTag background to floating text and hover highlights
+    backgroundLastNoneBlankPosition += VERTICAL_PADDING; // Add the vertical padding to the last non-blank position
+    mBackgroundOffsetY = backgroundFirstNoneBlankPosition; // Set the background Y offset to the top of the first blank
+    mBackgroundHeight  = backgroundLastNoneBlankPosition - backgroundFirstNoneBlankPosition; // Set the background height to the difference between the top of the first non-blank, and bottom of the last non-blank line
+    // <FS:minerjr> [FIRE-35019]
 }
 
 void LLHUDText::updateAll()

--- a/indra/newview/llhudtext.cpp
+++ b/indra/newview/llhudtext.cpp
@@ -215,6 +215,7 @@ void LLHUDText::renderText()
         }        
     }	
     // </FS:minerjr> [FIRE-35019]
+
     const S32 border_height = 16;
     const S32 border_width = 16;
 
@@ -301,6 +302,7 @@ void LLHUDText::renderText()
             y_offset -= fontp->getLineHeight(); // Match the same positioning as LLHUBNameTag as the windows don't line up otherwise.
             y_offset -= LINE_PADDING;
             // </FS:minerjr> [FIRE-35019]
+
             U8 style = segment_iter->mStyle;
             LLFontGL::ShadowType shadow = LLFontGL::DROP_SHADOW;
 
@@ -633,6 +635,7 @@ void LLHUDText::updateSize()
 {
     F32 height = 0.f;
     F32 width = 0.f;
+
     // <FS:minerjr> [FIRE-35019] Add LLHUBNameTag background to floating text and hover highlights
     // We want to create a background that fits just the visible text area only, otherwise a llsetstring('Hello, World\n\n\n') will have a text
     // box that covers 4 lines, but only the top line is visible to the user.

--- a/indra/newview/llhudtext.h
+++ b/indra/newview/llhudtext.h
@@ -199,6 +199,7 @@ private:
 // [RLVa:KB] - Checked: RLVa-1.0.0
     std::string     mObjText;
 // [/RLVa:KB]
+
     // <FS:minerjr> [FIRE-35019] Add LLHUBNameTag background to floating text and hover highlights   
     LLPointer<LLUIImage> mRoundedRectImgp; // Added background rect image from LLHUBNameTag
     F32             mBackgroundHeight; // Store the actual height of the background image (calculated from the visible text segments)

--- a/indra/newview/llhudtext.h
+++ b/indra/newview/llhudtext.h
@@ -59,11 +59,30 @@ protected:
             mStyle(style),
             mText(text),
             mFont(font)
-        {}
+        // <FS:minerjr> [FIRE-35019] Add LLHUBNameTag background to floating text and hover highlights
+        //{}        
+        {            
+            // Added a bool check to see if the current line is blank (empty, or has only a single space character stored.
+            // There are issues with users using "Hello World \n \n \n \n" as strings which would create a 4 text segments, but only 1 had actual text
+            // and the background would cover all 4, and would not look nice. So store a flag on each segment to see if it is blank, so we don't have to
+            // do the check every frame for every text segment.
+            if (text.length() == 0 || text.find_first_not_of(utf8str_to_wstring(" "), 0) == std::string::npos)
+            {
+                mbIsBlank = true;
+            }
+            else
+            {
+                mbIsBlank = false;
+            }            
+        }
+        // </FS:minerjr> [FIRE-35019]
         F32 getWidth(const LLFontGL* font);
         const LLWString& getText() const { return mText; }
         void clearFontWidthMap() { mFontWidthMap.clear(); }
 
+        // <FS:minerjr> [FIRE-35019] Add LLHUBNameTag background to floating text and hover highlights
+        bool isBlank() { return mbIsBlank; } // Accessor method for checking to see if the current Text Segment is blank
+        // </FS:minerjr> [FIRE-35019]
         LLColor4                mColor;
         LLFontGL::StyleFlags    mStyle;
         const LLFontGL*         mFont;
@@ -71,6 +90,9 @@ protected:
     private:
         LLWString               mText;
         std::map<const LLFontGL*, F32> mFontWidthMap;
+        // <FS:minerjr> [FIRE-35019] Add LLHUBNameTag background to floating text and hover highlights
+        bool                    mbIsBlank; // True if mText length is 0, or only contains " " characters, otherwise false
+        // <FS:minerjr> [FIRE-35019]
     };
 
 public:
@@ -177,7 +199,12 @@ private:
 // [RLVa:KB] - Checked: RLVa-1.0.0
     std::string     mObjText;
 // [/RLVa:KB]
-
+    // <FS:minerjr> [FIRE-35019] Add LLHUBNameTag background to floating text and hover highlights   
+    LLPointer<LLUIImage> mRoundedRectImgp; // Added background rect image from LLHUBNameTag
+    F32             mBackgroundHeight; // Store the actual height of the background image (calculated from the visible text segments)
+    F32             mBackgroundOffsetY; // Store the offset of the top of the first visible text segment
+    F32             mLuminance; // Store the luminance of the text (used to determine if the background should be white or black for higher contrast)
+    // </FS:minerjr> [FIRE-35019]
     static bool    sDisplayText ;
     static std::set<LLPointer<LLHUDText> > sTextObjects;
     static std::vector<LLPointer<LLHUDText> > sVisibleTextObjects;

--- a/indra/newview/llhudtext.h
+++ b/indra/newview/llhudtext.h
@@ -59,7 +59,7 @@ protected:
             mStyle(style),
             mText(text),
             mFont(font)
-        // <FS:minerjr> [FIRE-35019] Add LLHUBNameTag background to floating text and hover highlights
+        // <FS:minerjr> [FIRE-35019] Add LLHUDNameTag background to floating text and hover highlights
         //{}        
         {            
             // Added a bool check to see if the current line is blank (empty, or has only a single space character stored.
@@ -80,7 +80,7 @@ protected:
         const LLWString& getText() const { return mText; }
         void clearFontWidthMap() { mFontWidthMap.clear(); }
 
-        // <FS:minerjr> [FIRE-35019] Add LLHUBNameTag background to floating text and hover highlights
+        // <FS:minerjr> [FIRE-35019] Add LLHUDNameTag background to floating text and hover highlights
         bool isBlank() { return mbIsBlank; } // Accessor method for checking to see if the current Text Segment is blank
         // </FS:minerjr> [FIRE-35019]
         LLColor4                mColor;
@@ -90,7 +90,7 @@ protected:
     private:
         LLWString               mText;
         std::map<const LLFontGL*, F32> mFontWidthMap;
-        // <FS:minerjr> [FIRE-35019] Add LLHUBNameTag background to floating text and hover highlights
+        // <FS:minerjr> [FIRE-35019] Add LLHUDNameTag background to floating text and hover highlights
         bool                    mbIsBlank; // True if mText length is 0, or only contains " " characters, otherwise false
         // <FS:minerjr> [FIRE-35019]
     };
@@ -200,8 +200,8 @@ private:
     std::string     mObjText;
 // [/RLVa:KB]
 
-    // <FS:minerjr> [FIRE-35019] Add LLHUBNameTag background to floating text and hover highlights   
-    LLPointer<LLUIImage> mRoundedRectImgp; // Added background rect image from LLHUBNameTag
+    // <FS:minerjr> [FIRE-35019] Add LLHUDNameTag background to floating text and hover highlights   
+    LLPointer<LLUIImage> mRoundedRectImgp; // Added background rect image from LLHUDNameTag
     F32             mBackgroundHeight; // Store the actual height of the background image (calculated from the visible text segments)
     F32             mBackgroundOffsetY; // Store the offset of the top of the first visible text segment
     F32             mLuminance; // Store the luminance of the text (used to determine if the background should be white or black for higher contrast)

--- a/indra/newview/lltoolpie.cpp
+++ b/indra/newview/lltoolpie.cpp
@@ -848,6 +848,26 @@ void LLToolPie::selectionPropertiesReceived()
 bool LLToolPie::handleHover(S32 x, S32 y, MASK mask)
 {
     bool pick_rigged = false; //gSavedSettings.getBOOL("AnimatedObjectsAllowLeftClick");
+    // <FS:minerjr> [FIRE-35019] Add LLHUBNameTag background to floating text and hover highlights 
+    // We want to unhighlight the previous hover object's parent before we get the next hover pick and lose the reference
+    // (Possible optimization - check if the current object and previous ones are the same, and if so, don't set the text is highlighed flag to false)
+    LLViewerObject* oldObject = NULL;
+    LLViewerObject* oldParent = NULL; 
+    // If the previous mHoverPick object is valid, then try to set the Text Is Highlighted flag to false to clear it.
+    if (mHoverPick.isValid())
+    {
+        oldObject = mHoverPick.getObject();
+        if (oldObject)
+        {
+            oldParent = oldObject->getRootEdit();
+            if (oldParent)
+            {
+                // We want to set the parent object's flag to false, and it will recursively change until it finds a valid mText object.
+                oldParent->setTextIsHighlighted(false);
+            } 
+        }
+    }
+    // <FS:minerjr> [FIRE-35019]
     mHoverPick = gViewerWindow->pickImmediate(x, y, false, pick_rigged);
     LLViewerObject *parent = NULL;
     LLViewerObject *object = mHoverPick.getObject();
@@ -940,6 +960,17 @@ bool LLToolPie::handleHover(S32 x, S32 y, MASK mask)
     {
         LLViewerMediaFocus::getInstance()->clearHover();
     }
+    // <FS:minerjr> [FIRE-35019] Add LLHUBNameTag background to floating text and hover highlights
+    // If there is an object that was hovered over, set the root of the object to have the text highlighted.
+    // This will work if the parent does not have a LLHUBText object, but a child does.
+    else
+    {
+        if (parent)
+        {
+            parent->setTextIsHighlighted(true);
+        }
+    }    
+    // </FS:minerjr> [FIRE-35019]
 
     return true;
 }

--- a/indra/newview/lltoolpie.cpp
+++ b/indra/newview/lltoolpie.cpp
@@ -848,7 +848,7 @@ void LLToolPie::selectionPropertiesReceived()
 bool LLToolPie::handleHover(S32 x, S32 y, MASK mask)
 {
     bool pick_rigged = false; //gSavedSettings.getBOOL("AnimatedObjectsAllowLeftClick");
-    // <FS:minerjr> [FIRE-35019] Add LLHUBNameTag background to floating text and hover highlights 
+    // <FS:minerjr> [FIRE-35019] Add LLHUDNameTag background to floating text and hover highlights 
     // We want to unhighlight the previous hover object's parent before we get the next hover pick and lose the reference
     // (Possible optimization - check if the current object and previous ones are the same, and if so, don't set the text is highlighed flag to false)
     LLViewerObject* oldObject = NULL;
@@ -960,9 +960,9 @@ bool LLToolPie::handleHover(S32 x, S32 y, MASK mask)
     {
         LLViewerMediaFocus::getInstance()->clearHover();
     }
-    // <FS:minerjr> [FIRE-35019] Add LLHUBNameTag background to floating text and hover highlights
+    // <FS:minerjr> [FIRE-35019] Add LLHUDNameTag background to floating text and hover highlights
     // If there is an object that was hovered over, set the root of the object to have the text highlighted.
-    // This will work if the parent does not have a LLHUBText object, but a child does.
+    // This will work if the parent does not have a LLHUDText object, but a child does.
     else
     {
         if (parent)

--- a/indra/newview/llviewerobject.cpp
+++ b/indra/newview/llviewerobject.cpp
@@ -6141,14 +6141,14 @@ void LLViewerObject::updateText()
     }
 }
 
-// <FS:minerjr> [FIRE-35019] Add LLHUBNameTag background to floating text and hover highlights
+// <FS:minerjr> [FIRE-35019] Add LLHUDNameTag background to floating text and hover highlights
 // Method that sets the current viewer object's mText to be highlighted or the objects children if there is no mText.
 void LLViewerObject::setTextIsHighlighted(bool is_highlighted)
 {
     // If the object it not dead, try to set the highlight value
     if (!isDead())
     {
-        // Check to see if the current LLHUBText object is not null, most of the time the root object contains the floating text.
+        // Check to see if the current LLHUDText object is not null, most of the time the root object contains the floating text.
         if (mText.notNull())
         {
             mText->setIsHighlighted(is_highlighted);
@@ -6156,7 +6156,7 @@ void LLViewerObject::setTextIsHighlighted(bool is_highlighted)
         // But in case the current object does not, try to set all the children to use the flag
         else
         {
-            // Else, there may be children with the LLHUBText objects..
+            // Else, there may be children with the LLHUDText objects..
             for (child_list_t::const_iterator iter = mChildList.begin(); iter != mChildList.end(); iter++)
             {
                 LLViewerObject* child = *iter;

--- a/indra/newview/llviewerobject.cpp
+++ b/indra/newview/llviewerobject.cpp
@@ -6141,6 +6141,36 @@ void LLViewerObject::updateText()
     }
 }
 
+// <FS:minerjr> [FIRE-35019] Add LLHUBNameTag background to floating text and hover highlights
+// Method that sets the current viewer object's mText to be highlighted or the objects children if there is no mText.
+void LLViewerObject::setTextIsHighlighted(bool is_highlighted)
+{
+    // If the object it not dead, try to set the highlight value
+    if (!isDead())
+    {
+        // Check to see if the current LLHUBText object is not null, most of the time the root object contains the floating text.
+        if (mText.notNull())
+        {
+            mText->setIsHighlighted(is_highlighted);
+        }
+        // But in case the current object does not, try to set all the children to use the flag
+        else
+        {
+            // Else, there may be children with the LLHUBText objects..
+            for (child_list_t::const_iterator iter = mChildList.begin(); iter != mChildList.end(); iter++)
+            {
+                LLViewerObject* child = *iter;
+                // If the child is not an avatar, then try to set it's text is highlighed flag, which should recussivly get to all sub children. (Kind of hope not a lot of prims with this setup)
+                if (!child->isAvatar())
+                {
+                    child->setTextIsHighlighted(is_highlighted);                    
+                }
+            }
+        }
+    }
+}
+// </FS:minerjr> [FIRE-35019]
+
 bool LLViewerObject::isOwnerInMuteList(LLUUID id)
 {
     LLUUID owner_id = id.isNull() ? mOwnerID : id;

--- a/indra/newview/llviewerobject.h
+++ b/indra/newview/llviewerobject.h
@@ -498,6 +498,10 @@ public:
 
     void updatePositionCaches() const; // Update the global and region position caches from the object (and parent's) xform.
     void updateText(); // update text label position
+    // <FS:minerjr> [FIRE-35019] Add LLHUBNameTag background to floating text and hover highlights
+    // Method that sets the current viewer object's mText to be highlighted or the objects children if there is no mText.
+    void setTextIsHighlighted(bool is_highlighted);
+    // </FS:minerjr> [FIRE-35019]
     virtual void updateDrawable(bool force_damped); // force updates on static objects
 
     bool isOwnerInMuteList(LLUUID item_id = LLUUID());

--- a/indra/newview/llviewerobject.h
+++ b/indra/newview/llviewerobject.h
@@ -498,7 +498,7 @@ public:
 
     void updatePositionCaches() const; // Update the global and region position caches from the object (and parent's) xform.
     void updateText(); // update text label position
-    // <FS:minerjr> [FIRE-35019] Add LLHUBNameTag background to floating text and hover highlights
+    // <FS:minerjr> [FIRE-35019] Add LLHUDNameTag background to floating text and hover highlights
     // Method that sets the current viewer object's mText to be highlighted or the objects children if there is no mText.
     void setTextIsHighlighted(bool is_highlighted);
     // </FS:minerjr> [FIRE-35019]

--- a/indra/newview/skins/default/xui/en/panel_preferences_UI.xml
+++ b/indra/newview/skins/default/xui/en/panel_preferences_UI.xml
@@ -201,6 +201,21 @@
          width="80">
             seconds
         </text>
+	<!--<FS:minerjr> [FIRE-35019] Add LLHUBNameTag background to floating text and hover highlights -->
+	<!--Added new heading label for the Floating Text Options as there are now 4 -->
+        <text
+         type="string"
+         left="10"
+         top="130"
+         top_pad="15"
+         width="180"
+         follows="left|top"
+         height="16"
+         layout="topleft"
+         name="FSHudTextLabel">
+            Floating Text Options:
+        </text>
+        <!-- <FS:minerjr> Removed top="130" below as it was causing an issue with the new header text -->
         <slider
          control_name="FSHudTextFadeDistance"
          decimal_digits="2"
@@ -215,7 +230,7 @@
          min_val="0"
          max_val="64"
          name="FSHudTextFadeDistance"
-         top="130"
+
          width="481" />
         <slider
          control_name="FSHudTextFadeRange"
@@ -233,6 +248,52 @@
          name="FSHudTextFadeRange"
          top_pad="2"
          width="474" />
+	 <!-- Added new check box to disable the highlight floating text feature -->
+        <check_box
+        control_name="FSHudTextUseHoverHighlight"
+        name="FSHudTextUseHoverHighlight"
+        label="Hover over prim to highlight floating text:"
+        tool_tip="When an object is being hovered over, highlight the floating text (hovertext) by moving the text to the foreground and disable its alpha"
+        layout="topleft"
+        top_pad="5"
+        left_delta="0"
+        height="16"
+        width="350" />        
+        <text
+         type="string"
+         left="10"
+         top_pad="5"
+         width="180"
+         follows="left|top"
+         height="16"
+         layout="topleft"
+         name="FSHudTextShowBackgroundLabel">
+            Show floating text background:
+        </text>
+	<!-- Added combo box to control the background behavior for prims -->
+        <combo_box
+               control_name="FSHudTextShowBackground"
+               height="23"
+               layout="topleft"
+               left_pad="10"
+               top_delta="-5"  
+               name="FSHudTextShowBackgroundDropdown"
+               tool_tip="Displays a black/white background behind the floating text (hovertext) to make it more readable. The opacity can be changed under Colors->Floating Text"
+               width="180">
+            <combo_box.item
+             label="Off"
+             name="ScriptDialogOption_0"
+             value="0"/>
+            <combo_box.item
+             label="Only Highlighted Prim"
+             name="ScriptDialogOption_1"
+             value="1"/>
+            <combo_box.item
+             label="All Prims"
+             name="ScriptDialogOption_2"
+             value="2"/>            
+        </combo_box>
+	<!-- </FS:minerjr> [FIRE-35019] -->
     </panel>
 
     <!--2D Overlay-->

--- a/indra/newview/skins/default/xui/en/panel_preferences_UI.xml
+++ b/indra/newview/skins/default/xui/en/panel_preferences_UI.xml
@@ -201,7 +201,7 @@
          width="80">
             seconds
         </text>
-	<!--<FS:minerjr> [FIRE-35019] Add LLHUBNameTag background to floating text and hover highlights -->
+	<!--<FS:minerjr> [FIRE-35019] Add LLHUDNameTag background to floating text and hover highlights -->
 	<!--Added new heading label for the Floating Text Options as there are now 4 -->
         <text
          type="string"

--- a/indra/newview/skins/default/xui/en/panel_preferences_colors.xml
+++ b/indra/newview/skins/default/xui/en/panel_preferences_colors.xml
@@ -1202,7 +1202,7 @@
       </combo_box>
     </panel>
    </panel>
-     <!-- <FS:minerjr> [FIRE-35019] Add LLHUBNameTag background to floating text and hover highlights -->
+     <!-- <FS:minerjr> [FIRE-35019] Add LLHUDNameTag background to floating text and hover highlights -->
      <!-- Add new Floating Text panel as the Misc panel was full. Could go under Name Tag panel, but may have more options in the future for Floating Text -->
      <panel
 	  top_pad="5"
@@ -1212,7 +1212,7 @@
 	  follows="all"
 	  label="Floating Text"
 	  name="tab-chat" >
-         <!-- Add slider to change the opacity of the floating text background indendant of the LLHUBNameTag ChatBubbleOpacity -->
+         <!-- Add slider to change the opacity of the floating text background indendant of the LLHUDNameTag ChatBubbleOpacity -->
          <slider
           control_name="FSHudTextBackgroundOpacity"
           follows="left|top"

--- a/indra/newview/skins/default/xui/en/panel_preferences_colors.xml
+++ b/indra/newview/skins/default/xui/en/panel_preferences_colors.xml
@@ -1202,6 +1202,36 @@
       </combo_box>
     </panel>
    </panel>
+     <!-- <FS:minerjr> [FIRE-35019] Add LLHUBNameTag background to floating text and hover highlights -->
+     <!-- Add new Floating Text panel as the Misc panel was full. Could go under Name Tag panel, but may have more options in the future for Floating Text -->
+     <panel
+	  top_pad="5"
+	  bottom="-1"
+	  left="1"
+	  right="-1"
+	  follows="all"
+	  label="Floating Text"
+	  name="tab-chat" >
+         <!-- Add slider to change the opacity of the floating text background indendant of the LLHUBNameTag ChatBubbleOpacity -->
+         <slider
+          control_name="FSHudTextBackgroundOpacity"
+          follows="left|top"
+          height="16"
+          increment="0.05"
+          initial_value="0.75"
+          label="Floating text background opacity:"
+          layout="topleft"
+          left_pad="10"
+          left="30"
+          max_val="1.00"
+          min_val="0.00"          
+          label_width="180"
+          name="FSHudTextBackgroundOpacity"
+          tool_tip="Choose floating text background opacity"
+          top_pad="16"
+          width="450" />
+     </panel>
+     <!-- </FS:minerjr> [FIRE-35019] -->     
    <panel
      top_pad="5"
      bottom="-1"


### PR DESCRIPTION
This pull is to add support for in world floating text to have a background based on the LLHUBNameTag object. This also adds support for when a prim which has a floating text is hovered over. The text becomes opaque and changes its render order to appear over all other floating text, as well as the background pulled forward. This also disables the floating text fade on the highlighted text so that very far away objects can be checked.

This is designed support better contrast the text from other floating text that may be near. I play DFS with my wife and there tends to be a lot of floating text. With my color blindness I had a hard time reading some of the darker text as well as seeing what item I am hovering over.

This is an example of what the our sim looks like currently with no enhancement. 
Note the large amount of text on the objects to the left of my avatar.
Also note that far away objects, the text has faded away.
![FIRE-35019-01](https://github.com/user-attachments/assets/df02d918-7154-4108-975a-445cfbf26b9c)

Now with the hover over prim to highlight floating text check enabled, very far away text will appear only on objects highlighted
![FIRE-35019-02](https://github.com/user-attachments/assets/01fe3495-8b62-482e-9a2e-36fcb577128b)

Now once the Show floating text background is changed to "Only Highlighted Prim", a white or black transparent background will appear on the highlighted prim. You can now see the status of the prim and not have to re-position your camera or move your avatar.
![FIRE-35019-03](https://github.com/user-attachments/assets/303514cb-555a-4e94-9c06-32da0fbe59dd)

You can move the cursor to the next prim and see its status.
![FIRE-35019-04](https://github.com/user-attachments/assets/cfddda73-4bb8-4466-b5b0-d328e9d5eb53)

The user can also set the Show floating text background to "All Prims", which will have the background appear on all floating text.
![FIRE-35019-05](https://github.com/user-attachments/assets/b6b97986-6e90-40c1-bd8a-db18cd89ba87)

You can still hover over a prim and its text and background will move to the front and also become fully opaque to be able to read.
![FIRE-35019-06](https://github.com/user-attachments/assets/97b1fe47-31c7-4f4e-add3-fe081bec2da8)

In the preferences under Colors there is a new Floating Text tab, which has a slider to changing the opacity of the floating text. The default is 0.75
![FIRE-35019-07](https://github.com/user-attachments/assets/6ca7de0f-7a0f-4579-b462-f9aca4c89226)

But the user can turn it down if the default is too much. Example, setting to opacity to 40%.
![FIRE-35019-08](https://github.com/user-attachments/assets/8391bd5b-f1e3-4271-b93a-fe11834a55c8)

Overall changes listed below in this patch.

Added background image based upon the LLHUBNameTag background to LLHUBText.
Added flag to highlight LLHUBText attached to prims that is set when the user hovers the cursor over.
Added new value to track if user wants backgrounds on all floating text, only the one that is currently highlighted or none.
Added new Preferences->User Interface->3D World options to disable the Hover over prim to higlight floating text and Show floating text background options. Defaulted to off.
Added new Floating Text tab to the Preferences->Colors panel to control the opacity of the LLHUBText background, independent of the LLHUBNameTag value
Added three new persist values into the setting.xml file, FSHudTextShowBackground, FSHudTextBackgroundOpacity and FSHudTextUseHoverHighlight

Fixed up code commit to better follow the standards for Firestorm Viewer as well as re-factor the code to be cleaner and removed some unnecessary code. Thanks to @beqjanus for the initial feedback. 
