### PR TITLE
[FIRE-35024] - Store always run flag on exit and restore when logging in

### DIFF
--- a/indra/newview/app_settings/settings.xml
+++ b/indra/newview/app_settings/settings.xml
@@ -5612,6 +5612,34 @@
       <key>Backup</key>
       <integer>0</integer>
     </map>
+    <!-- <FS:minerjr> [FIRE-35024] Store always run flag on exit and restore when logging in -->
+    <key>FSRestoreAlwaysRunAtExit</key>
+    <map>
+        <key>Comment</key>
+        <string>Should we restore the always run flag on login</string>
+        <key>Persist</key>
+        <integer>1</integer>
+        <key>Type</key>
+        <string>Boolean</string>
+        <key>Value</key>
+        <integer>0</integer>
+        <key>Backup</key>
+        <integer>0</integer>
+    </map>
+    <key>FSAlwaysRunAtExit</key>
+    <map>
+        <key>Comment</key>
+        <string>Was always running when last logged out, so always run when logging in</string>
+        <key>Persist</key>
+        <integer>1</integer>
+        <key>Type</key>
+        <string>Boolean</string>
+        <key>Value</key>
+        <integer>0</integer>
+        <key>Backup</key>
+        <integer>0</integer>
+    </map>  
+    <!-- </FS:minerjr> [FIRE-35024] -->      
     <key>FocusOffsetRearView</key>
     <map>
       <key>Comment</key>

--- a/indra/newview/llagent.cpp
+++ b/indra/newview/llagent.cpp
@@ -565,6 +565,20 @@ void LLAgent::init()
     {
         setFlying(is_flying);
     }
+    // <FS:minerjr> [FIRE-35024] Store always run flag on exit and restore when logging in
+    // Leaving it up to the user to choose in the Preferences->Move & View->Movement panel if they want to restore FSAlwaysRunAtExit flag
+    // using the "Restore always running on login" check box. 
+    static LLCachedControl<bool> restore_always_run(gSavedSettings, "FSRestoreAlwaysRunAtExit");    
+    if (restore_always_run)
+    {
+        // Use the same mechanics as saving and restoring the FlayingAtExit flag
+        bool is_always_run = gSavedSettings.getBOOL("FSAlwaysRunAtExit");
+        if (is_always_run)
+        {
+            setAlwaysRun();
+        }
+    }
+    // </FS:minerjr> [FIRE-35024]
 
     *mEffectColor = LLUIColorTable::instance().getColor("EffectColor");
 

--- a/indra/newview/llappviewer.cpp
+++ b/indra/newview/llappviewer.cpp
@@ -3303,6 +3303,9 @@ bool LLAppViewer::initConfiguration()
         tempSetControl("SLURLPassToOtherInstance", "false");
         tempSetControl("RenderWater", "false");
         tempSetControl("FlyingAtExit", "false");
+        // <FS:minerjr> [FIRE-35024] Store always run flag on exit and restore when logging in
+        tempSetControl("FSAlwaysRunAtExit", "false");
+        // </FS:minerjr> [FIRE-35024]
         tempSetControl("WindowWidth", "1024");
         tempSetControl("WindowHeight", "200");
         LLError::setEnabledLogTypesMask(0);
@@ -6252,6 +6255,11 @@ void LLAppViewer::disconnectViewer()
 
     // Remember if we were flying
     gSavedSettings.setBOOL("FlyingAtExit", gAgent.getFlying() );
+
+    // <FS:minerjr> [FIRE-35024] Store always run flag on exit and restore when logging in
+    // Save the Always Run flag, even if the user does not have the flag set to restore it.
+    gSavedSettings.setBOOL("FSAlwaysRunAtExit", gAgent.getAlwaysRun());
+    // </FS:minerjr> [FIRE-35024]
 
     // Un-minimize all windows so they don't get saved minimized
     if (gFloaterView)

--- a/indra/newview/llappviewer.cpp
+++ b/indra/newview/llappviewer.cpp
@@ -3304,7 +3304,7 @@ bool LLAppViewer::initConfiguration()
         tempSetControl("RenderWater", "false");
         tempSetControl("FlyingAtExit", "false");
         // <FS:minerjr> [FIRE-35024] Store always run flag on exit and restore when logging in
-        tempSetControl("FSAlwaysRunAtExit", "false");
+        tempSetControl("FSAlwaysRunAtExit", "false"); // Set a default value for the Always Run At Exit flag to false similar to the FlyingAtExit flag
         // </FS:minerjr> [FIRE-35024]
         tempSetControl("WindowWidth", "1024");
         tempSetControl("WindowHeight", "200");

--- a/indra/newview/skins/default/xui/en/panel_preferences_move.xml
+++ b/indra/newview/skins/default/xui/en/panel_preferences_move.xml
@@ -490,7 +490,7 @@
          name="FSRestoreAlwaysRunAtExit"
          width="300"
          top_pad="3"/>
-	 <!-- </FS:minerjr> [FIRE-35024] -->
+        <!-- </FS:minerjr> [FIRE-35024] -->
         <check_box
          control_name="AutomaticFly"
          follows="left|top"

--- a/indra/newview/skins/default/xui/en/panel_preferences_move.xml
+++ b/indra/newview/skins/default/xui/en/panel_preferences_move.xml
@@ -478,6 +478,19 @@
          name="tap_tap_hold_to_run"
          width="237"
          top_pad="0"/>
+        <!-- <FS:minerjr> [FIRE-35024] Store always run flag on exit and restore when logging in -->	 
+        <check_box
+         control_name="FSRestoreAlwaysRunAtExit"
+         follows="left|top"
+         height="20"
+         label="Restore Always Run on login"
+         tool_tip="Restores the Always Run flag when logging back in similar to the Always Flying flag."
+         layout="topleft"
+         left="10"
+         name="FSRestoreAlwaysRunAtExit"
+         width="300"
+         top_pad="3"/>
+	 <!-- </FS:minerjr> [FIRE-35024] -->
         <check_box
          control_name="AutomaticFly"
          follows="left|top"


### PR DESCRIPTION
Added new optional flag to restore the Always Run flag on login based on the value at exit. This is based on the existing Always Fly flag. 

Also added new checkbox to use the flag on login or not (Default) in the Preferences->Move & View->Movement panel labeled "Restore Always Run on login" and store the value in as an additional flag in the settings.xml file.

Showing the new checkbox option. Now when you have Always Run enabled at logout, when you login again, it is set.
![FIRE-35024-Flag Enabled](https://github.com/user-attachments/assets/5bb8b05a-292f-486f-9ed0-8ff1550e8dd4)

Change Summary:

Added two new persist values to settings.xml, FSRestoreAlwaysRunAtExit and FSAlwaysRunAtExit. 
Added new checkbox to panel_preferences_move.xml FSRestoreAlwaysRunAtExit, used to enable/disable the use of the AlwaysRunAtExit setting. 
Updated llappviewer to save the current always run value on disconnectviewer and to default to false on NonInteractive init.
Updated llagent to restore the always run flag only if the FSRestoreAlwaysRunAtExit flag is set by the user.