### PR TITLE
[FIRE-35037] AO UI scroll list bold/highlight fix.

### DIFF
--- a/indra/newview/ao.cpp
+++ b/indra/newview/ao.cpp
@@ -203,6 +203,16 @@ void FloaterAO::updateList()
     }
 }
 
+void FloaterAO::updateScrollListData()
+{
+    auto animationListData = mAnimationList->getAllData();
+    for (auto index = 0; index < mSelectedState->mAnimations.size(); ++index)
+    {
+        LLScrollListItem* item = animationListData[index];
+        item->setUserdata(&mSelectedState->mAnimations[index].mInventoryUUID);
+    }
+}
+
 bool FloaterAO::postBuild()
 {
     LLPanel* aoPanel = getChild<LLPanel>("animation_overrider_outer_panel");
@@ -674,6 +684,7 @@ void FloaterAO::onClickMoveUp()
     if (AOEngine::instance().swapWithPrevious(mSelectedState, currentIndex))
     {
         mAnimationList->swapWithPrevious(currentIndex);
+        updateScrollListData();
     }
 }
 
@@ -699,6 +710,7 @@ void FloaterAO::onClickMoveDown()
     if (AOEngine::instance().swapWithNext(mSelectedState, currentIndex))
     {
         mAnimationList->swapWithNext(currentIndex);
+        updateScrollListData();
     }
 }
 

--- a/indra/newview/ao.h
+++ b/indra/newview/ao.h
@@ -55,6 +55,7 @@ class FloaterAO
         virtual void onOpen(const LLSD& key);
         virtual void onClose(bool app_quitting);
         void updateList();
+        void updateScrollListData();
         void updateSetParameters();
         void updateAnimationList();
 


### PR DESCRIPTION
> If user clicks on up/down buttons from AO UI to change animation order in the list then clicks on the next/previous animation buttons that will bold/highlight the wrong current playing animation in the AO UI list.
> 
> Here are the steps to reproduce:
> 
> Create a new AO set then drag and drop at least 2 animations, then click on the up/down buttons to change its order in the list then click on the next/previous buttons to change animations, you will notice the bold/highlighted animation is not actually the one being played by the avatar.

That happens because the scroll list item userdata is only updated during `FloaterAO::onSelectState` so when clicking on up/down(`FloaterAO::onClickMoveUp()`/`FloaterAO::onClickMoveDown()`) buttons, every `LLScrollListItem` is not being updated with the correct animation id then at `FloaterAO::onAnimationChanged(const LLUUID& animation)`:
```
for (auto item : mAnimationList->getAllData())
{
    LLUUID* id = (LLUUID*)item->getUserdata(); // Since it was only set from FloaterAO::onSelectState it will get the animation id which was set at that time ending up with the wrong one.

    if (id == &animation)
    {
        mCurrentBoldItem = item; // Then it reassigns with the item containing old animation id.

        ((LLScrollListIcon*)mCurrentBoldItem->getColumn(0))->setValue("FSAO_Animation_Playing");
        ((LLScrollListText*)mCurrentBoldItem->getColumn(1))->setFontStyle(LLFontGL::BOLD); // Bolds the wrong animation.

        return;
    }
}
```
as you can see the scroll list item bears the old animation id therefore it bolds/highlights the wrong animation in the scroll list of the AO UI. So I provided a fix `FloaterAO::updateScrollListData()` to update the scroll list data every time `FloaterAO::onClickMoveUp()` or `FloaterAO::onClickMoveDown()` is called hence it fixes the problem.