### PR TITLE
Added preview buttons in profile panel

### DIFF
--- a/indra/llui/lltexteditor.cpp
+++ b/indra/llui/lltexteditor.cpp
@@ -345,6 +345,20 @@ void LLTextEditor::setText(const LLStringExplicit &utf8str, const LLStyle::Param
     resetDirty();
 }
 
+// <AS:Chanayane> Preview button
+void LLTextEditor::reparseText(const LLStringExplicit &utf8str, const LLStyle::Params& input_params)
+{
+    mParseOnTheFly = false;
+    LLTextBase::setText(utf8str, input_params);
+    mParseOnTheFly = true;
+}
+
+void LLTextEditor::reparseValue(const LLSD& value)
+{
+    reparseText(value.asString());
+}
+// </AS:Chanayane>
+
 // [SL:KB] - Patch: UI-FloaterSearchReplace | Checked: 2013-12-30 (Catznip-3.6)
 std::string LLTextEditor::getSelectionString() const
 {

--- a/indra/llui/lltexteditor.h
+++ b/indra/llui/lltexteditor.h
@@ -187,6 +187,11 @@ public:
     // Non-undoable
     void            setText(const LLStringExplicit &utf8str, const LLStyle::Params& input_params = LLStyle::Params());
 
+    // <AS:Chanayane> Preview button
+    void            reparseText(const LLStringExplicit &utf8str, const LLStyle::Params& input_params = LLStyle::Params());
+    void            reparseValue(const LLSD& value);
+    // </AS:Chanayane>
+
 
     // Removes text from the end of document
     // Does not change highlight or cursor position.

--- a/indra/newview/llpanelprofile.h
+++ b/indra/newview/llpanelprofile.h
@@ -203,6 +203,9 @@ private:
     void onAvatarNameCacheSetName(const LLUUID& id, const LLAvatarName& av_name);
 
     void setDescriptionText(const std::string &text);
+    // <AS:Chanayane> Preview button
+    void reparseDescriptionText(const std::string& text);
+    // </AS:Chanayane>
     void onSetDescriptionDirty();
     void onShowInSearchCallback();
     void onHideAgeCallback();
@@ -266,6 +269,7 @@ private:
     LLButton*           mIMButton;
     LLMenuButton*       mOverflowButton;
     // </FS:Ansariel>
+    LLButton*           mPreviewButton; // <AS:Chanayane> Preview button
 
     LLHandle<LLFloater> mFloaterPermissionsHandle;
     LLHandle<LLFloater> mFloaterProfileTextureHandle;
@@ -275,8 +279,10 @@ private:
     bool                mVoiceStatus;
     bool                mWaitingForImageUpload;
     bool                mAllowPublish;
+    bool                mPreview; // <AS:Chanayane> Preview button
     bool                mHideAge;
     std::string         mDescriptionText;
+    std::string         mOriginalDescriptionText; // <AS:Chanayane> Preview button
     LLUUID              mImageId;
 
     boost::signals2::connection mAvatarNameCacheConnection;
@@ -366,9 +372,13 @@ protected:
     void onFirstLifePicChanged();   // <FS:Zi> Allow proper texture swatch handling
     void onCommitPhoto(const LLUUID& id);
     void setDescriptionText(const std::string &text);
+    // <AS:Chanayane> Preview button
+    void reparseDescriptionText(const std::string& text);
+    // </AS:Chanayane>
     void onSetDescriptionDirty();
     void onSaveDescriptionChanges();
     void onDiscardDescriptionChanges();
+    void onClickPreview(); // <AS:Chanayane> Preview button
 
     LLTextEditor*   mDescriptionEdit;
     // <FS:Zi> Allow proper texture swatch handling
@@ -380,12 +390,17 @@ protected:
     LLButton* mRemovePhoto;
     LLButton* mSaveChanges;
     LLButton* mDiscardChanges;
+    LLButton* mPreviewButton; // <AS:Chanayane> Preview button
 
     LLHandle<LLFloater> mFloaterTexturePickerHandle;
 
     std::string     mCurrentDescription;
     LLUUID          mImageId;
     bool            mHasUnsavedChanges;
+// <AS:Chanayane> Preview button
+    bool            mPreview;
+    std::string     mOriginalDescription;
+// </AS:Chanayane>
 };
 
 /**

--- a/indra/newview/llpanelprofilepicks.cpp
+++ b/indra/newview/llpanelprofilepicks.cpp
@@ -543,6 +543,9 @@ LLPanelProfilePick::LLPanelProfilePick()
  , mIsEditing(false)
  , mRegionCallbackConnection()
  , mParcelCallbackConnection()
+// <AS:Chanayane> Preview button
+ , mPreview(false)
+// </AS:Chanayane>
 {
 }
 
@@ -622,6 +625,11 @@ void LLPanelProfilePick::setAvatarId(const LLUUID& avatar_id)
 
     resetDirty();
 
+// <AS:Chanayane> Preview button
+    mPreviewButton->setVisible(getSelfProfile());
+    mPreviewButton->setEnabled(getSelfProfile());
+// </AS:Chanayane>
+
     if (getSelfProfile())
     {
         mPickName->setEnabled(true);
@@ -645,6 +653,7 @@ bool LLPanelProfilePick::postBuild()
     mCreateButton = getChild<LLButton>("create_changes_btn");
     mCancelButton = getChild<LLButton>("cancel_changes_btn");
     mSetCurrentLocationButton = getChild<LLButton>("set_to_curr_location_btn"); // <FS:Ansariel> Keep set location button
+    mPreviewButton = getChild<LLButton>("btn_preview"); // <AS:Chanayane> Preview button
 
     mSnapshotCtrl = getChild<LLTextureCtrl>("pick_snapshot");
     mSnapshotCtrl->setCommitCallback(boost::bind(&LLPanelProfilePick::onSnapshotChanged, this));
@@ -658,6 +667,9 @@ bool LLPanelProfilePick::postBuild()
     mCreateButton->setCommitCallback(boost::bind(&LLPanelProfilePick::onClickSave, this));
     mCancelButton->setCommitCallback(boost::bind(&LLPanelProfilePick::onClickCancel, this));
     mSetCurrentLocationButton->setCommitCallback(boost::bind(&LLPanelProfilePick::onClickSetLocation, this)); // <FS:Ansariel> Keep set location button
+    // <AS:Chanayane> Preview button
+    mPreviewButton->setCommitCallback(boost::bind(&LLPanelProfilePick::onClickPreview, this));
+    // </AS:Chanayane>
 
     mPickName->setKeystrokeCallback(boost::bind(&LLPanelProfilePick::onPickChanged, this, _1), NULL);
     mPickName->setEnabled(false);
@@ -751,6 +763,13 @@ void LLPanelProfilePick::setPickDesc(const std::string& desc)
 {
     mPickDescription->setValue(desc);
 }
+
+// <AS:Chanayane> Preview button
+void LLPanelProfilePick::reparseDescription(const std::string& desc)
+{
+    mPickDescription->reparseValue(desc);
+}
+// </AS:Chanayane>
 
 void LLPanelProfilePick::setPickLocation(const std::string& location)
 {
@@ -847,6 +866,28 @@ void LLPanelProfilePick::onClickSetLocation()
     enableSaveButton(true);
 }
 // </FS:Ansariel>
+
+// <AS:Chanayane> Preview button
+void LLPanelProfilePick::onClickPreview()
+{
+    mPreview = !mPreview;
+
+    if (mPreview) { // Then we switch to preview mode
+        mPreviewButton->setImageOverlay("Profile_Group_Visibility_Off");
+        mOriginalPickText = mPickDescription->getValue().asString();
+        mPickDescription->setEnabled(!mPreview);
+        mPickDescription->setParseHTML(mPreview);
+        reparseDescription(mOriginalPickText);
+        enableSaveButton(false);
+    } else { // we switch to edit mode, restoring the dirty state if necessary
+        mPreviewButton->setImageOverlay("Profile_Group_Visibility_On");
+        mPickDescription->setEnabled(!mPreview);
+        mPickDescription->setParseHTML(mPreview);
+        reparseDescription(mOriginalPickText);
+        enableSaveButton(isDirty()); // re-check if whole pick is dirty
+    }
+}
+// </AS:Chanayane>
 
 void LLPanelProfilePick::onClickSave()
 {

--- a/indra/newview/llpanelprofilepicks.h
+++ b/indra/newview/llpanelprofilepicks.h
@@ -173,6 +173,9 @@ public:
      */
     virtual void setSnapshotId(const LLUUID& id);
     virtual void setPickDesc(const std::string& desc);
+    // <AS:Chanayane> Preview button
+    virtual void reparseDescription(const std::string& desc);
+    // </AS:Chanayane>
     virtual void setPickLocation(const std::string& location);
 
     virtual void setPosGlobal(const LLVector3d& pos) { mPosGlobal = pos; }
@@ -215,6 +218,13 @@ public:
     void onClickSetLocation();
     // <FS:Ansariel>
 
+    // <AS:Chanayane> Preview button
+    /**
+     * Callback for "Preview" button click
+     */
+    void onClickPreview();
+    // </AS:Chanayane>
+
     /**
      * Callback for "Save" and "Create" button click
      */
@@ -241,6 +251,7 @@ protected:
     LLButton*           mSaveButton;
     LLButton*           mCreateButton;
     LLButton*           mCancelButton;
+    LLButton*           mPreviewButton; // <AS:Chanayane> Preview button
 
     LLVector3d mPosGlobal;
     LLUUID mParcelId;
@@ -254,6 +265,10 @@ protected:
     bool mLocationChanged;
     bool mNewPick;
     bool                mIsEditing;
+// <AS:Chanayane> Preview button
+    bool                mPreview;
+    std::string         mOriginalPickText;
+// </AS:Chanayane>
 
     void onDescriptionFocusReceived();
 };

--- a/indra/newview/skins/default/xui/en/panel_profile_firstlife.xml
+++ b/indra/newview/skins/default/xui/en/panel_profile_firstlife.xml
@@ -43,7 +43,17 @@
      follows="top|left"
      layout="topleft"
      visible="false"/>
+<!-- [AS:chanayane] Preview button -->
     <button
+     name="fl_upload_image"
+     label="Upload Photo"
+     top="55"
+     left="285"
+     height="20"
+     width="120"
+     follows="top|left"
+     layout="topleft"/>
+    <!-- <button
      name="fl_upload_image"
      label="Upload Photo"
      top="80"
@@ -51,7 +61,8 @@
      height="20"
      width="120"
      follows="top|left"
-     layout="topleft"/>
+     layout="topleft"/> -->
+<!-- [AS:chanayane] Preview button -->
     <button
      name="fl_change_image"
      label="Change Photo"
@@ -70,6 +81,21 @@
      width="120"
      follows="top|left"
      layout="topleft"/>
+<!-- [AS:chanayane] Preview button -->
+    <button
+     name="btn_preview"
+     tool_tip="Toggle preview of your first life introduction"
+     top_pad="5"
+     left_delta="0"
+     height="20"
+     width="120"
+     follows="top|left"
+     layout="topleft"
+     image_overlay="Profile_Group_Visibility_On"
+     is_toggle="true"
+     enabled="false"
+     visible="false"/>
+<!-- [/AS:chanayane] -->
     <text_editor
      name="fl_description_edit"
      trusted_content="false"

--- a/indra/newview/skins/default/xui/en/panel_profile_pick.xml
+++ b/indra/newview/skins/default/xui/en/panel_profile_pick.xml
@@ -84,6 +84,21 @@
                 >
         Description:
       </text>
+<!-- [AS:chanayane] Preview button -->
+      <button
+       name="btn_preview"
+       tool_tip="Toggle preview of your pick description"
+       top_pad="-18"
+       left="280"
+       height="20"
+       width="20"
+       follows="top|right"
+       layout="topleft"
+       image_overlay="Profile_Group_Visibility_On"
+       is_toggle="true"
+       enabled="false"
+       visible="false"/>
+<!-- [/AS:chanayane] -->
       <text_editor
        name="pick_desc"
        trusted_content="false"

--- a/indra/newview/skins/default/xui/en/panel_profile_secondlife.xml
+++ b/indra/newview/skins/default/xui/en/panel_profile_secondlife.xml
@@ -601,8 +601,22 @@
      follows="left|top"
      layout="topleft"
      halign="right"/>
+<!-- [AS:chanayane] Preview button -->
+    <button
+     name="btn_preview"
+     tool_tip="Toggle preview of your profile 'about' section"
+     top_delta="20"
+     left="35"
+     height="20"
+     width="20"
+     follows="left|top"
+     layout="topleft"
+     image_overlay="Profile_Group_Visibility_On"
+     is_toggle="true"
+     enabled="false"
+     visible="false"/>
     <view_border
-     top_delta="-4"
+     top_delta="-24"
      left="59"
      right="-5"
      height="103"
@@ -610,6 +624,16 @@
      follows="all"
      name="info_border_sl_description_edit"
      bevel_style="in"/>
+    <!-- <view_border
+     top_delta="-4"
+     left="59"
+     right="-5"
+     height="103"
+     layout="topleft"
+     follows="all"
+     name="info_border_sl_description_edit"
+     bevel_style="in"/> -->
+<!-- [/AS:chanayane] -->
     <text_editor
      name="sl_description_edit"
      trusted_content="false"


### PR DESCRIPTION
Added preview buttons in profile panel to preview the About section, Picks and First Life introduction like others would see it, very useful to preview links with custom label for example.

I added the reparseValue and reparseText methods in LLTextEditor so that it doesn't remove the dirty state and undos when switching between edit mode and preview mode.

Here's what it looks like:

**About section:**
![FirestormOS-AyaneStorm_A1dktgNTbG](https://github.com/user-attachments/assets/ea5c8585-9c50-4fa0-94fb-2edc0da593fd)
![FirestormOS-AyaneStorm_gwMjgR2g82](https://github.com/user-attachments/assets/053eab15-1a03-4d0f-9c79-32ef8ecfe264)

**Picks:**
![FirestormOS-AyaneStorm_PES3Glx4fD](https://github.com/user-attachments/assets/a1af8f63-86a9-4a55-85ec-93e63941b2fc)
![FirestormOS-AyaneStorm_pxi2CMHcgh](https://github.com/user-attachments/assets/baaf0ec2-713e-4cba-81d7-65321731c15a)

**First Life:**
![FirestormOS-AyaneStorm_0VRSNp5EVJ](https://github.com/user-attachments/assets/fb328e7a-4eac-4a12-ad83-bc128fd184ad)
![FirestormOS-AyaneStorm_CjCxSHdXXi](https://github.com/user-attachments/assets/8398cbd0-7019-4137-aa63-9eeb5324f014)
