### PR TITLE
[FIRE 35011] Weird patterned extreme CPU usage when using more than 6gb vram on 10g card - WIP Test

### DIFF
--- a/indra/newview/app_settings/settings.xml
+++ b/indra/newview/app_settings/settings.xml
@@ -2,6 +2,17 @@
 <llsd xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:noNamespaceSchemaLocation="llsd.xsd">
 <map>
+    <key>FSTextureNewBiasAdjustments</key>
+    <map>
+        <key>Comment</key>
+        <string>Enable New Texture Bias Adjustments</string>
+        <key>Persist</key>
+        <integer>1</integer>
+        <key>Type</key>
+        <string>Boolean</string>
+        <key>Value</key>
+        <integer>1</integer>
+    </map>
   <key>FSLandmarkCreatedNotification</key>
   <map>
     <key>Comment</key>

--- a/indra/newview/app_settings/settings.xml
+++ b/indra/newview/app_settings/settings.xml
@@ -2,6 +2,9 @@
 <llsd xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:noNamespaceSchemaLocation="llsd.xsd">
 <map>
+    <!-- <FS:minerjr> [FIRE-35011] Weird patterned extreme CPU usage when using more than 6gb vram on 10g card -->
+    <!-- Added new flag to turn on the new bias adjustments - Can be enabled in the Preferences->Graphics->Hardware Settings -->
+    <!-- Checkbox labeled "Enable New Texture Bias Adjustments" -->
     <key>FSTextureNewBiasAdjustments</key>
     <map>
         <key>Comment</key>
@@ -11,8 +14,9 @@
         <key>Type</key>
         <string>Boolean</string>
         <key>Value</key>
-        <integer>1</integer>
+        <integer>0</integer>
     </map>
+    <!-- </FS:minerjr> [FIRE-35011] -->
   <key>FSLandmarkCreatedNotification</key>
   <map>
     <key>Comment</key>

--- a/indra/newview/llviewertexture.h
+++ b/indra/newview/llviewertexture.h
@@ -196,6 +196,7 @@ public:
         RECOVERY_DELAY          = 8  // Recovery delay after VRAM_OVERAGE_DELETED or VRAM_SCALED_DOWN is true
     };
 
+    void setTextureState(ETextureStates newState);
     mutable U8 mTextureState; // Bitfield which represents the texture's current state
     mutable U8 mPreviousTextureState; // Bitfield which represents the texture's current state
     F32 mDelayToNormalUseAfterOverBudget; // Time to wait for returning to normal texture adjustments for larger resolution requests after
@@ -375,11 +376,12 @@ public:
 
     void destroyTexture() ;
 
+    virtual void processTextureStats() ;
     // <FS:minerjr> [FIRE-35011] Weird patterned extreme CPU usage when using more than 6gb vram on 10g card
     // New behavior for handling low memory for the ProcessTextureStats method for both Fetch and LOD textures
     // Returns true if the the 
     bool handleMemoryOverageForProcessTextureStats();
-    virtual void processTextureStats() ;    
+    
 
     bool needsAux() const { return mNeedsAux; }
 

--- a/indra/newview/llviewertexture.h
+++ b/indra/newview/llviewertexture.h
@@ -226,6 +226,11 @@ public:
     static S32 sAuxCount;
     static LLFrameTimer sEvaluationTimer;
     static F32 sDesiredDiscardBias;
+    // <FS:minerjr>
+    static F32 sPreviousDesiredDiscardBias; // Static value of the previous Desired Discard Bias (Used to determine if the desired discard bias is increasing, decreasing, or staying the same
+    static F32 sOverMemoryBudgetStartTime;  // Static value stores the mCurrentTime when the viewer first went over budget of RAM (sDesiredDiscardBias > 1.0)
+    static F32 sOverMemoryBudgetEndTime;    // Static value stores the mCurrentTime when the viewer first exists over budget of RAM (sDesiredDiscardBias == 1.0)
+    // <//FS:minerjr>
     static S32 sMaxSculptRez ;
     static U32 sMinLargeImageSize ;
     static U32 sMaxSmallImageSize ;

--- a/indra/newview/llviewertexture.h
+++ b/indra/newview/llviewertexture.h
@@ -191,9 +191,10 @@ public:
     {
         NORMAL                  = 0, // Normal state
         DELETED                 = 1, // Normal Delete
-        VRAM_OVERAGE_DELETED    = 2, // Deleted during VRAM overage
-        VRAM_SCALED_DOWN        = 4, // Scaled down during VRAM overage
-        RECOVERY_DELAY          = 8  // Recovery delay after VRAM_OVERAGE_DELETED or VRAM_SCALED_DOWN is true
+        SCALED_DOWN             = 2, // Normal Scaled Down
+        VRAM_OVERAGE_DELETED    = 4, // Deleted during VRAM overage
+        VRAM_SCALED_DOWN        = 8, // Scaled down during VRAM overage
+        RECOVERY_DELAY          = 16  // Recovery delay after VRAM_OVERAGE_DELETED or VRAM_SCALED_DOWN is true
     };
 
     void setTextureState(ETextureStates newState);
@@ -248,6 +249,28 @@ public:
     static F32 sPreviousDesiredDiscardBias; // Static value of the previous Desired Discard Bias (Used to determine if the desired discard bias is increasing, decreasing, or staying the same
     static F32 sOverMemoryBudgetStartTime;  // Static value stores the mCurrentTime when the viewer first went over budget of RAM (sDesiredDiscardBias > 1.0)
     static F32 sOverMemoryBudgetEndTime;    // Static value stores the mCurrentTime when the viewer first exists over budget of RAM (sDesiredDiscardBias == 1.0)
+    typedef union
+    {
+        U32 ClearState;
+        struct 
+        {
+            U32 Normal : 1;
+            U32 LowSystemRAM : 1;
+            U32 LowVRAM : 1;
+            U32 PreviousLowSystemRam : 1;
+            U32 PrevouusLowVRAM : 1;
+            U32 Overage_High : 1;
+            U32 Overage_Low : 1;
+            U32 No_Overage : 1;
+            U32 NormalHoldBias : 1;
+            U32 UseBias : 1;
+            U32 IncreaseBias : 1;
+            U32 DecreaseBias : 1;
+        } States;
+
+    } OverMemoryBudetStates_u;
+
+    static OverMemoryBudetStates_u sOverMemoryBudgetState; // State of the over memory budget
     // </FS:minerjr> [FIRE-35011]
     static S32 sMaxSculptRez ;
     static U32 sMinLargeImageSize ;

--- a/indra/newview/llviewertexture.h
+++ b/indra/newview/llviewertexture.h
@@ -185,7 +185,7 @@ public:
     typedef std::vector<MaterialEntry> material_list_t;
     material_list_t   mMaterialList;  // reverse pointer pointing to LL::GLTF::Materials using this image as texture
 
-    // <FS:minerjr> FIRE-35011
+    // <FS:minerjr> [FIRE-35011] Weird patterned extreme CPU usage when using more than 6gb vram on 10g card
     // Create an enum bitfield for storing the various memory states
     enum ETextureStates
     {
@@ -200,7 +200,7 @@ public:
     mutable U8 mPreviousTextureState; // Bitfield which represents the texture's current state
     F32 mDelayToNormalUseAfterOverBudget; // Time to wait for returning to normal texture adjustments for larger resolution requests after
                                           // being over VRAM budget
-    // </FS:minerjr>
+    // </FS:minerjr> [FIRE-35011]
 
 protected:
     void cleanup() ;
@@ -243,11 +243,11 @@ public:
     static S32 sAuxCount;
     static LLFrameTimer sEvaluationTimer;
     static F32 sDesiredDiscardBias;
-    // <FS:minerjr> FIRE-35011
+    // <FS:minerjr> [FIRE-35011] Weird patterned extreme CPU usage when using more than 6gb vram on 10g card
     static F32 sPreviousDesiredDiscardBias; // Static value of the previous Desired Discard Bias (Used to determine if the desired discard bias is increasing, decreasing, or staying the same
     static F32 sOverMemoryBudgetStartTime;  // Static value stores the mCurrentTime when the viewer first went over budget of RAM (sDesiredDiscardBias > 1.0)
     static F32 sOverMemoryBudgetEndTime;    // Static value stores the mCurrentTime when the viewer first exists over budget of RAM (sDesiredDiscardBias == 1.0)
-    // </FS:minerjr> FIRE-35011
+    // </FS:minerjr> [FIRE-35011]
     static S32 sMaxSculptRez ;
     static U32 sMinLargeImageSize ;
     static U32 sMaxSmallImageSize ;
@@ -375,7 +375,7 @@ public:
 
     void destroyTexture() ;
 
-    // <FS:minerjr> FIRE-35011
+    // <FS:minerjr> [FIRE-35011] Weird patterned extreme CPU usage when using more than 6gb vram on 10g card
     // New behavior for handling low memory for the ProcessTextureStats method for both Fetch and LOD textures
     // Returns true if the the 
     bool handleMemoryOverageForProcessTextureStats();

--- a/indra/newview/llviewertexturelist.h
+++ b/indra/newview/llviewertexturelist.h
@@ -238,6 +238,7 @@ public:
 private:
     typedef std::map< LLTextureKey, LLPointer<LLViewerFetchedTexture> > uuid_map_t;
     uuid_map_t mUUIDMap;
+    uuid_map_t mUUIDDeleteMap;
     LLTextureKey mLastUpdateKey;
 
     image_list_t mImageList;

--- a/indra/newview/llviewertexturelist.h
+++ b/indra/newview/llviewertexturelist.h
@@ -238,7 +238,9 @@ public:
 private:
     typedef std::map< LLTextureKey, LLPointer<LLViewerFetchedTexture> > uuid_map_t;
     uuid_map_t mUUIDMap;
-    uuid_map_t mUUIDDeleteMap;
+    // <FS:minerjr> [FIRE-35011] Weird patterned extreme CPU usage when using more than 6gb vram on 10g card
+    uuid_map_t mUUIDDeleteMap; // New storage for Delete Textures (they now don't go away fully), fixing manuy performace issues
+    // <FS:minerjr> [FIRE-35011]
     LLTextureKey mLastUpdateKey;
 
     image_list_t mImageList;

--- a/indra/newview/skins/default/xui/en/panel_preferences_graphics1.xml
+++ b/indra/newview/skins/default/xui/en/panel_preferences_graphics1.xml
@@ -1230,6 +1230,8 @@ If you do not understand the distinction then leave this control alone."
          width="100">
             Second(s)
         </text>
+        <!-- <FS:minerjr> [FIRE-35011] Weird patterned extreme CPU usage when using more than 6gb vram on 10g card -->
+        <!-- Check box to enable the new texture bias adjustments -->
         <check_box
          control_name="FSTextureNewBiasAdjustments"
          height="16"
@@ -1240,6 +1242,7 @@ If you do not understand the distinction then leave this control alone."
          tool_tip=""
          top_delta="20"
          width="256" />
+        <!-- </FS:minerjr> [FIRE-35011] -->
     </panel>
 
 <!--Rendering-->

--- a/indra/newview/skins/default/xui/en/panel_preferences_graphics1.xml
+++ b/indra/newview/skins/default/xui/en/panel_preferences_graphics1.xml
@@ -1230,6 +1230,16 @@ If you do not understand the distinction then leave this control alone."
          width="100">
             Second(s)
         </text>
+        <check_box
+         control_name="FSTextureNewBiasAdjustments"
+         height="16"
+         label="Enable New Texture Bias Adjustments"
+         layout="topleft"
+         left="10"
+         name="FSTextureNewBiasAdjustments"
+         tool_tip=""
+         top_delta="20"
+         width="256" />
     </panel>
 
 <!--Rendering-->


### PR DESCRIPTION
Hi, so I have been looking into this issue [https://jira.firestormviewer.org/browse/FIRE-35011]( FIRE 35011 ) which is related to I think other user's performance issues that have been submitted.

I create a couple of videos walking though what the issue is and my solution. This is a work in progress but wanted to get some feedback on the approach.

[https://youtu.be/ulHrdk4Wc8A](FIRE 35011 Progress - Part 1) 
[https://youtu.be/NCqOwPDU-9Q](FIRE 35011 Progress - Part 2)) 


Showing the CPU not spiking from switching from High memory usage to lowered.
![FIRE-35011-Progress](https://github.com/user-attachments/assets/e18fd4fd-6959-4bac-aa12-8f6a7270da3c)


The issue stems from low "VRAM" status, where the Bias starts to increase and the system has an initial 1.5 spike that is designed to purge the off screen textures and 2.0 where in the 
void LLViewerTextureList::updateImageDecodePriority(LLViewerFetchedTexture* imagep, bool flush_images)
Method, the system then forces on screen textures to down scale.

Also, the system uses the bias to determine how many objects to work on. The higher the value the more textures it works on. Up to 80% of the entire texture pool in 1 frame is selected to be processed. This is what adds all the fetch's when the bias is greater then 2, even textures in camera get get downscaled.

Then the cycle begins. Now that the textures have been deleted, the bias decreases, and then now there is free memory and as in 
F32 LLViewerTextureList::updateImagesFetchTextures(F32 max_time), it does another update with all 40% of the textures and now they all at once get a request for higher texture memory size (mDesiredDiscard where 0 is the max resolution and 5 (MAX_DISCARD) is the upper limit, but in OpenGL the numbers are in reverse...

They all suddenly start creating new textures and trying to load from the various cashes and causes out of memory and once again the system then flushes them all down and rinse and repeat.

I have been trying a few various things and I came up with using a memory pool for the deleted objects. The biggest performance killer is newing/deleting memory and re-setting up the objects and connections. Instead of deleting like it does currently, in the function I move the texture to a new mUUIDDeleteMap object similar to the mUUIDMap already used by the LLViewerTextureList. I then update the find methods for any call which requests the textures to search the normal memory first and if not found, check the delete pool for the texture and if found, re-add it to the main texture pool. This in itself had a tremendous perforce uplift for my viewer.

I also made it so that the increase of checks only happens while the bias is increasing and not all the time.

I also changed it so that textures now have a mini state machine which tracks what happened to them in  their life time. This can be further used to refine the behaviors of what to do with deleted memory, how to handle edge cases and know if a texture was deleted just from regular use or from a memory overage event. I also add a delay for when a texture can be updated again to try to spread out the load more to quell the spikes.

When a texture is downscaled or deleted and brought back, they are delayed on how quickly they will try to up-res to try and help with the surging of the requests.


I also did a test of faking the amount of ram I had and doubled the report available RAM and it ran well.

