### PR TITLE
FIRE-35074 - XML Issue with updated starlight skin main inventory - dummy_panel

### DIFF
--- a/indra/newview/skins/starlight/xui/en/panel_main_inventory.xml
+++ b/indra/newview/skins/starlight/xui/en/panel_main_inventory.xml
@@ -488,7 +488,7 @@
       <panel
        follows="top|left|right"
        height="25"
-       left_pad="168"
+       left_pad="200"
        right="-33"
        layout="topleft"
        name="dummy_panel">


### PR DESCRIPTION
Needed to add 32 pixels to the dumm_panel lef_pad to make room for the new filter button. 
Minor fix.

Issue:
![Starlight_inv_issue](https://github.com/user-attachments/assets/d1bfeb6f-0769-402e-8d9a-acca707c24a8)

Fixed:
![Starlight_inv_fix](https://github.com/user-attachments/assets/ddf9517b-61f8-4a63-b1d2-4c6883832cdb)


