### PR TITLE
Allows to limit search to folders only in inventory

### DIFF
--- a/indra/newview/llinventoryfilter.cpp
+++ b/indra/newview/llinventoryfilter.cpp
@@ -702,17 +702,29 @@ bool LLInventoryFilter::checkAgainstSearchVisibility(const LLFolderViewModelItem
     if (!object)
         return true;
 
-    const bool is_link = object->getIsLinkType();
-    if (is_link && ((mFilterOps.mSearchVisibility & VISIBILITY_LINKS) == 0))
+// <AS:chanayane> Short circuit search optimisation
+    //const bool is_link = object->getIsLinkType();
+    //if (is_link && ((mFilterOps.mSearchVisibility & VISIBILITY_LINKS) == 0))
+    if (((mFilterOps.mSearchVisibility & VISIBILITY_LINKS) == 0) && object->getIsLinkType())
+// </AS:chanayane>
         return false;
 
-    if (listener->isItemInOutfits() && ((mFilterOps.mSearchVisibility & VISIBILITY_OUTFITS) == 0))
+// <AS:chanayane> Short circuit search optimisation
+    //if (listener->isItemInOutfits() && ((mFilterOps.mSearchVisibility & VISIBILITY_OUTFITS) == 0))
+    if (((mFilterOps.mSearchVisibility & VISIBILITY_OUTFITS) == 0) && listener->isItemInOutfits())
+// </AS:chanayane>
         return false;
 
-    if (listener->isItemInTrash() && ((mFilterOps.mSearchVisibility & VISIBILITY_TRASH) == 0))
+// <AS:chanayane> Short circuit search optimisation
+    //if (listener->isItemInTrash() && ((mFilterOps.mSearchVisibility & VISIBILITY_TRASH) == 0))
+    if (((mFilterOps.mSearchVisibility & VISIBILITY_TRASH) == 0) && listener->isItemInTrash())
+// </AS:chanayane>
         return false;
 
-    if (!listener->isAgentInventory() && ((mFilterOps.mSearchVisibility & VISIBILITY_LIBRARY) == 0))
+// <AS:chanayane> Short circuit search optimisation
+    //if (!listener->isAgentInventory() && ((mFilterOps.mSearchVisibility & VISIBILITY_LIBRARY) == 0))
+    if (((mFilterOps.mSearchVisibility & VISIBILITY_LIBRARY) == 0) && !listener->isAgentInventory())
+// </AS:chanayane>
         return false;
 
     return true;
@@ -1616,6 +1628,20 @@ const std::string& LLInventoryFilter::getFilterText()
         not_filtered_types +=  LLTrans::getString("Settings");
         filtered_by_all_types = false;
     }
+
+// <AS:chanayane> Search folders only
+    if (isFilterObjectTypesWith(LLInventoryType::IT_CATEGORY))
+    {
+        filtered_types +=  LLTrans::getString("Folders");
+        filtered_by_type = true;
+        num_filter_types++;
+    }
+    else
+    {
+        not_filtered_types +=  LLTrans::getString("Folders");
+        filtered_by_all_types = false;
+    }
+// </AS:chanayane>
 
     if (!LLInventoryModelBackgroundFetch::instance().folderFetchActive()
         && filtered_by_type

--- a/indra/newview/llpanelmaininventory.cpp
+++ b/indra/newview/llpanelmaininventory.cpp
@@ -224,6 +224,9 @@ LLPanelMainInventory::LLPanelMainInventory(const LLPanel::Params& p)
     mFilterMap["filter_type_snapshots"]     = 0x01 << LLInventoryType::IT_SNAPSHOT;
     mFilterMap["filter_type_settings"]      = 0x01 << LLInventoryType::IT_SETTINGS;
     mFilterMap["filter_type_materials"]     = 0x01 << LLInventoryType::IT_MATERIAL;
+// <AS:chanayane> Search folders only
+    mFilterMap["filter_type_folders"]       = 0x01 << LLInventoryType::IT_CATEGORY;
+// </AS:chanayane>
 
     // initialize empty filter mask
     mFilterMask = 0;

--- a/indra/newview/skins/ansastorm/xui/en/panel_main_inventory.xml
+++ b/indra/newview/skins/ansastorm/xui/en/panel_main_inventory.xml
@@ -738,6 +738,9 @@
         <combo_box.item value="filter_type_snapshots" label="Snapshots" />
         <combo_box.item value="filter_type_materials" label="Materials" />
         <combo_box.item value="filter_type_settings" label="Settings" />
+        <!-- [AS:Chanayane] Search folders only -->
+        <combo_box.item value="filter_type_folders" label="Folders" />
+        <!-- [/AS:Chanayane] -->
         <combo_box.item value="filter_separator" label="------------" enabled="false" />
         <combo_box.item value="filter_type_coalesced" label="Only Coalesced"/>
         <combo_box.item value="filter_separator" label="------------" enabled="false" />

--- a/indra/newview/skins/default/xui/en/panel_main_inventory.xml
+++ b/indra/newview/skins/default/xui/en/panel_main_inventory.xml
@@ -182,6 +182,9 @@
         <combo_box.item value="filter_type_snapshots" label="Snapshots" />
         <combo_box.item value="filter_type_materials" label="Materials" />
         <combo_box.item value="filter_type_settings" label="Settings" />
+        <!-- [AS:Chanayane] Search folders only -->
+        <combo_box.item value="filter_type_folders" label="Folders" />
+        <!-- [/AS:Chanayane] -->
         <combo_box.item value="filter_separator" label="------------" enabled="false" />
         <combo_box.item value="filter_type_coalesced" label="Only Coalesced"/>
         <combo_box.item value="filter_separator" label="------------" enabled="false" />

--- a/indra/newview/skins/default/xui/en/strings.xml
+++ b/indra/newview/skins/default/xui/en/strings.xml
@@ -927,6 +927,9 @@ If you continue to receive this message, please contact Second Life support for 
 	<string name="Textures"      value=" Textures," />
 	<string name="Settings"      value=" Settings," />
 	<string name="Snapshots"     value=" Snapshots," />
+	<!-- [AS:Chanayane] Search folders only -->
+	<string name="Folders"       value=" Folders," />
+	<!-- [/AS:Chanayane] -->
 	<string name="No Filters"    value="No " />
 	<string name="Since Logoff"  value=" - Since Logoff" />
 	<!-- <FS:Zi> FIRE-1175 - Filter Permissions Menu -->

--- a/indra/newview/skins/starlight/xui/en/panel_main_inventory.xml
+++ b/indra/newview/skins/starlight/xui/en/panel_main_inventory.xml
@@ -181,6 +181,9 @@
         <combo_box.item value="filter_type_snapshots" label="Snapshots" />
         <combo_box.item value="filter_type_materials" label="Materials" />
         <combo_box.item value="filter_type_settings" label="Settings" />
+        <!-- [AS:Chanayane] Search folders only -->
+        <combo_box.item value="filter_type_folders" label="Folders" />
+        <!-- [/AS:Chanayane] -->
         <!-- <FS:minerjr> [FIRE-35042] Inventory - Only Coalesced Filter - More accessible  -->
         <combo_box.item value="filter_separator" label="------------" enabled="false" />
         <!-- Add new custom filter to toggle Only Coalesced on and switch to filter_type_objects as only objects can be combined -->

--- a/indra/newview/skins/starlightcui/xui/en/panel_main_inventory.xml
+++ b/indra/newview/skins/starlightcui/xui/en/panel_main_inventory.xml
@@ -183,6 +183,9 @@
         <combo_box.item value="filter_type_snapshots" label="Snapshots" />
         <combo_box.item value="filter_type_materials" label="Materials" />
         <combo_box.item value="filter_type_settings" label="Settings" />
+        <!-- [AS:Chanayane] Search folders only -->
+        <combo_box.item value="filter_type_folders" label="Folders" />
+        <!-- [/AS:Chanayane] -->
         <!-- <FS:minerjr> [FIRE-35042] Inventory - Only Coalesced Filter - More accessible  -->
         <combo_box.item value="filter_separator" label="------------" enabled="false" />
         <!-- Add new custom filter to toggle Only Coalesced on and switch to filter_type_objects as only objects can be combined -->

--- a/indra/newview/skins/vintage/xui/en/panel_main_inventory.xml
+++ b/indra/newview/skins/vintage/xui/en/panel_main_inventory.xml
@@ -786,6 +786,9 @@
 		<combo_box.item value="filter_type_snapshots" label="Snapshots" />
         <combo_box.item value="filter_type_materials" label="Materials" />
 		<combo_box.item value="filter_type_settings" label="Settings" />
+		<!-- [AS:Chanayane] Search folders only -->
+		<combo_box.item value="filter_type_folders" label="Folders" />
+		<!-- [/AS:Chanayane] -->
 		<combo_box.item value="filter_separator" label="------------" enabled="false" />
 		<combo_box.item value="filter_type_coalesced" label="Only Coalesced"/>
 		<combo_box.item value="filter_separator" label="------------" enabled="false" />


### PR DESCRIPTION
This lets you limit your search to folders only. Very useful when you have a large inventory and you need to find a specific folder without the search getting drown with folder items.

It does not change the default behavior, if you uncheck "Include items" it will limit the search to folders only and show only folders.

Normal behavior, "Include items" checked
![FirestormOS-AyaneStorm_VM223Ybhq7](https://github.com/user-attachments/assets/8fbbaacc-2856-426d-9857-746bc74c3904)

"Include items" unchecked
![FirestormOS-AyaneStorm_hpCm82bHoh](https://github.com/user-attachments/assets/12b5dfdc-6159-4e9e-b1da-d4c2db9c214a)
