### PR TITLE
FIRE-35083 - Floater_stats.xml has incorrect stat_view setting for materials

### DIFF
--- a/indra/newview/app_settings/settings.xml
+++ b/indra/newview/app_settings/settings.xml
@@ -9242,6 +9242,20 @@ Change of this parameter will affect the layout of buttons in notification toast
       <key>Value</key>
       <integer>1</integer>
     </map>
+    <!-- <FS:minerjr> [FIRE-35083] Floater_stats.xml has in correct stat_view setting for materials -->
+    <!-- Missing boolean flag for remembering the open/close state of the Materials stat_view of the floater_stats.xml file -->
+    <key>OpenDebugStatMaterials</key>
+    <map>
+        <key>Comment</key>
+        <string>Expand Materials performance stats display</string>
+        <key>Persist</key>
+        <integer>1</integer>
+        <key>Type</key>
+        <string>Boolean</string>
+        <key>Value</key>
+        <integer>1</integer>
+    </map>
+    <!-- </FS:minerjr> [FIRE-35083] -->
     <key>OpenDebugStatTexture</key>
     <map>
       <key>Comment</key>

--- a/indra/newview/skins/default/xui/en/floater_stats.xml
+++ b/indra/newview/skins/default/xui/en/floater_stats.xml
@@ -155,13 +155,18 @@
                     stat="glboundmemstat"
                     setting="DebugStatModeBoundMem"/>
         </stat_view>
+          <!-- <FS:minerjr> [FIRE-35083] Floater_stats.xml has in correct stat_view setting for materials -->
+          <!-- The material stat_view had the incorrect setting, which was causing and convert_from_llsd warning and a bugsplat in Debug mode -->
+          <!-- It also prevented the material count of the floater_stats from remembering its open/close state -->
        <stat_view name="material"
                   label="Material"
-                  setting="DebugStatModeMaterials">
+                  setting="OpenDebugStatMaterials">
          <stat_bar name="nummaterials"
                    label="Count"
-                   stat="nummaterials"/>
+                   stat="nummaterials"
+                   setting="DebugStatModeMaterials"/>
        </stat_view>
+          <!-- </FS:minerjr> [FIRE-35083] -->
         <stat_view name="network"
                    label="Network"
                    setting="OpenDebugStatNet">


### PR DESCRIPTION

The issue was caused by the incorrect setting being applied to the material stat_view and child stat_bar. Added the correct named setting for the open/close state of the material stat_view and updated the float_stats.xml to have the correct settings applied. This prevents the warning and also allows the materials stat_view to have its own/close state saved correctly.

Stats menu option
![float_stats_menu](https://github.com/user-attachments/assets/595fca07-63f6-41fa-9355-0b891e75e1d0)

Just opening the Statistics Panel in debug caused the following bug splat:
![float_stats](https://github.com/user-attachments/assets/ff5c7ac7-d16f-4ac7-bb69-d169c9b73349)

In VS in release you can see there is a warning being generated and returns false
![float_stats_vs](https://github.com/user-attachments/assets/9436fc66-db87-4c23-897d-a04ad0d1006a)

Which causes the stat_view for materials to always be close upon opening the window
![float_stats_window](https://github.com/user-attachments/assets/523663c8-efdc-451c-8612-ce17d3829530)

Corrected the issue by correcting the float_stats.xml to use a proper boolean settings.xml OpenDebugStatMaterials flag for the state of the window, as well as properly use the DebugStatModeMaterials to the settings of the child stat_bar.

Now restores the material view open upon opening the Statistics floater window now.
![float_stats_vs_fixed](https://github.com/user-attachments/assets/542af363-818b-4bfb-8e4e-e8526154daf6)

![float_stats_window_fixed](https://github.com/user-attachments/assets/f3776025-7270-4582-8708-c4c5401e38d1)




