### PR TITLE
Double click on animation in AO

### DIFF
--- a/indra/newview/ao.cpp
+++ b/indra/newview/ao.cpp
@@ -282,6 +282,10 @@ bool FloaterAO::postBuild()
     mPreviousButtonSmall->setCommitCallback(boost::bind(&FloaterAO::onClickPrevious, this));
     mNextButtonSmall->setCommitCallback(boost::bind(&FloaterAO::onClickNext, this));
 
+// <AS:Chanayane> Double click on animation in AO
+    mAnimationList->setDoubleClickCallback(boost::bind(&FloaterAO::onDoubleClick, this));
+// </AS:Chanayane>
+
     updateSmart();
 
     AOEngine::instance().setReloadCallback(boost::bind(&FloaterAO::updateList, this));
@@ -779,6 +783,34 @@ void FloaterAO::onClickNext()
 {
     AOEngine::instance().cycle(AOEngine::CycleNext);
 }
+
+// <AS:Chanayane> Double click on animation in AO
+void FloaterAO::onDoubleClick()
+{
+    LLScrollListItem* item = mAnimationList->getFirstSelected();
+    if (!item)
+    {
+        return;
+    }
+    LLUUID* animUUID = (LLUUID*)item->getUserdata();
+    if (!animUUID)
+    {
+        return;
+    }
+
+    // activate AO set if necessary
+    if (AOEngine::instance().getCurrentSet() != mSelectedSet)
+    {
+        // sync small set selector with main set selector
+        mSetSelectorSmall->selectNthItem(mSetSelector->getCurrentIndex());
+
+        LL_DEBUGS("AOEngine") << "Set activated: " << mSetSelector->getSelectedItemLabel() << LL_ENDL;
+        AOEngine::instance().selectSet(mSelectedSet);
+    }
+
+    AOEngine::instance().playAnimation(*animUUID);
+}
+// </AS:Chanayane>
 
 void FloaterAO::onClickMore()
 {

--- a/indra/newview/ao.h
+++ b/indra/newview/ao.h
@@ -91,6 +91,10 @@ class FloaterAO
         void onClickMore();
         void onClickLess();
 
+// <AS:Chanayane> Double click on animation in AO
+        void onDoubleClick();
+// </AS:Chanayane>
+
         void onAnimationChanged(const LLUUID& animation);
 
         void reloading(bool reload);

--- a/indra/newview/aoengine.cpp
+++ b/indra/newview/aoengine.cpp
@@ -960,6 +960,112 @@ void AOEngine::cycle(eCycleMode cycleMode)
     }
 }
 
+// <AS:Chanayane> Double click on animation in AO
+void AOEngine::playAnimation(const LLUUID& animation)
+{
+    if (!mEnabled)
+    {
+        return;
+    }
+
+    if (!mCurrentSet)
+    {
+        LL_DEBUGS("AOEngine") << "cycle without set." << LL_ENDL;
+        return;
+    }
+
+    // do not cycle if we're sitting and sit-override is off
+    if (mLastMotion == ANIM_AGENT_SIT && !mCurrentSet->getSitOverride())
+    {
+        return;
+    }
+    // do not cycle if we're standing and mouselook stand override is disabled while being in mouselook
+    else if (mLastMotion == ANIM_AGENT_STAND && mCurrentSet->getMouselookStandDisable() && mInMouselook)
+    {
+        return;
+    }
+
+    AOSet::AOState* state = mCurrentSet->getStateByRemapID(mLastMotion);
+    if (!state)
+    {
+        LL_DEBUGS("AOEngine") << "cycle without state." << LL_ENDL;
+        return;
+    }
+
+    if (!state->mAnimations.size())
+    {
+        LL_DEBUGS("AOEngine") << "cycle without animations in state." << LL_ENDL;
+        return;
+    }
+
+    LLViewerInventoryItem* item = gInventory.getItem(animation);
+    AOSet::AOAnimation anim;
+    anim.mName = item->LLInventoryItem::getName();
+    anim.mInventoryUUID = item->getUUID();
+    anim.mOriginalUUID = item->getLinkedUUID();
+    anim.mAssetUUID = LLUUID::null;
+
+    // if we can find the original animation already right here, save its asset ID, otherwise this will
+    // be tried again in AOSet::getAnimationForState() and/or AOEngine::cycle()
+    if (item->getLinkedItem())
+    {
+        anim.mAssetUUID = item->getAssetUUID();
+    }
+
+    LLUUID newAnimation = anim.mAssetUUID;
+    LLUUID oldAnimation = state->mCurrentAnimationID;
+
+    // don't do anything if the animation didn't change
+    if (newAnimation == oldAnimation)
+    {
+        return;
+    }
+
+    mAnimationChangedSignal(LLUUID::null);
+
+    // Searches for the index of the animation
+    U32 idx = -1;
+    for (U32 i = 0; i < state->mAnimations.size(); i++)
+    {
+        LLUUID* id = &(state->mAnimations[i].mAssetUUID);
+        if (*id == newAnimation)
+        {
+            idx = i;
+            break;
+        }
+    }
+    if (idx < 0)
+    {
+        idx = 0;
+    }
+
+    state->mCurrentAnimation = idx;
+    state->mCurrentAnimationID = newAnimation;
+    if (newAnimation.notNull())
+    {
+        LL_DEBUGS("AOEngine") << "requesting animation start for motion " << gAnimLibrary.animationName(mLastMotion) << ": " << newAnimation << LL_ENDL;
+        gAgent.sendAnimationRequest(newAnimation, ANIM_REQUEST_START);
+        mAnimationChangedSignal(state->mAnimations[state->mCurrentAnimation].mInventoryUUID);
+    }
+    else
+    {
+        LL_DEBUGS("AOEngine") << "overrider came back with NULL animation for motion " << gAnimLibrary.animationName(mLastMotion) << "." << LL_ENDL;
+    }
+
+    if (oldAnimation.notNull())
+    {
+        LL_DEBUGS("AOEngine") << "Cycling state " << state->mName << " - stopping animation " << oldAnimation << LL_ENDL;
+        gAgent.sendAnimationRequest(oldAnimation, ANIM_REQUEST_STOP);
+        gAgentAvatarp->LLCharacter::stopMotion(oldAnimation);
+    }
+}
+
+const AOSet* AOEngine::getCurrentSet() const
+{
+    return mCurrentSet;
+}
+// </AS:Chanayane>
+
 void AOEngine::updateSortOrder(AOSet::AOState* state)
 {
     for (U32 index = 0; index < state->mAnimations.size(); ++index)

--- a/indra/newview/aoengine.h
+++ b/indra/newview/aoengine.h
@@ -123,6 +123,11 @@ class AOEngine
         void cycleTimeout(const AOSet* set);
         void cycle(eCycleMode cycleMode);
 
+// <AS:Chanayane> Double click on animation in AO
+        void playAnimation(const LLUUID& animation);
+        const AOSet* getCurrentSet() const;
+// </AS:Chanayane>
+
         void inMouselook(bool mouselook);
         void selectSet(AOSet* set);
         AOSet* selectSetByName(const std::string& name);


### PR DESCRIPTION
This PR adds the ability to double-click on an animation in the AO panel, and it will play it directly. This is more convenient than clicking many times on the Previous, Next or Reload buttons.

If the AO set is not enabled while double-clicking an animation, it will get enabled automatically.

Here's a little demo of what it does:
https://github.com/user-attachments/assets/c57d040a-ca96-4a49-b62e-7d3a3dfc49e6

