### PR TITLE
enable ime on xwayland

### DIFF
--- a/indra/newview/linux_tools/wrapper.sh
+++ b/indra/newview/linux_tools/wrapper.sh
@@ -103,6 +103,10 @@ echo "LIBGL_DRIVERS_PATH is ${LIBGL_DRIVERS_PATH}"
 if [ "$GTK_IM_MODULE" = "scim" ]; then
     export GTK_IM_MODULE=xim
 fi
+if [ "$XMODIFIERS" = "" ]; then
+    ## IME is valid only for fcitx, not when using ibus
+    export XMODIFIERS="@im=fcitx"
+fi
 
 ## - Automatically work around the ATI mouse cursor crash bug:
 ## (this workaround is disabled as most fglrx users do not see the bug)


### PR DESCRIPTION
This change fixes the IME to work even if the desktop environment is running on Wayland.

## Firestorm Pull Request Checklist
Thank you for contributing to the Phoenix Firestorm Project.
We will endeavour to review you changes and accept/reject/request changes as soon as possible. 
Please read and follow the [Firestorm Pull Request Guidelines](https://github.com/firestormviewer/phoenix-firestorm/blob/master/FS_PR_GUIDELINES.md) to reduce the likelihood that we need to ask for "Bureaucratic" changes to make the code comply with our workflows.
