### PR TITLE
FIRE-35011 - Weird patterned extreme CPU usage when using more than 6gb vram on 10g card

### DIFF
--- a/indra/newview/app_settings/settings.xml
+++ b/indra/newview/app_settings/settings.xml
@@ -15229,6 +15229,17 @@ Change of this parameter will affect the layout of buttons in notification toast
       <key>Backup</key>
       <integer>0</integer>
     </map>
+    <key>FSPerformanceAdditions</key>
+    <map>
+        <key>Comment</key>
+        <string>Stores the state of the performance additions for validating</string>
+        <key>Persist</key>
+        <integer>1</integer>
+        <key>Type</key>
+        <string>U32</string>
+        <key>Value</key>
+        <integer>0</integer>
+    </map>   
     <key>TextureDecodeDisabled</key>
     <map>
       <key>Comment</key>

--- a/indra/newview/lltexturefetch.h
+++ b/indra/newview/lltexturefetch.h
@@ -140,6 +140,10 @@ public:
     // Threads:  T*
     S32 getLastFetchState(const LLUUID& id, S32& requested_discard, S32 &decoded_discard, bool &decoded);
 
+    // <FS:minerjr> [FIRE-35011] Weird patterned extreme CPU usage when using more than 6gb vram on 10g card
+    // Replaces the two above commands with a single one to reduce the number of mutex locks by 1.. this is causing issues. and will be replaced soon
+    S32 getLastFetchState(const LLUUID& id, S32& requested_discard, S32& decoded_discard, bool& decoded, LLPointer<LLImageRaw>& raw, LLPointer<LLImageRaw>& aux);
+    // </FS:minerjr> [FIRE-35011]
     // @return  Fetch last raw image
     // Threads:  T*
     S32 getLastRawImage(const LLUUID& id, LLPointer<LLImageRaw>& raw, LLPointer<LLImageRaw>& aux);

--- a/indra/newview/llviewertexture.h
+++ b/indra/newview/llviewertexture.h
@@ -415,6 +415,9 @@ public:
     bool        isRawImageValid()const { return mIsRawImageValid ; }
     void        forceToSaveRawImage(S32 desired_discard = 0, F32 kept_time = 0.f) ;
 
+    // <FS:minerjr> [FIRE-35011] Weird patterned extreme CPU usage when using more than 6gb vram on 10g card
+    bool        tryToClearRawImages(); // Try to clear the raw images every 30 seconds (Can be made to be variable to allow users control over time frame)
+    // </FS:minerjr> [FIRE-35011]
     // readback the raw image from OpenGL if mRawImage is not valid
     void        readbackRawImage();
 
@@ -508,6 +511,14 @@ protected:
     F32             mLastCallBackActiveTime;
 
     LLPointer<LLImageRaw> mRawImage;
+    // <FS:minerjr> [FIRE-35011] Weird patterned extreme CPU usage when using more than 6gb vram on 10g card  
+    // Replace the single raw iamge with a array of raw iamges (Sized to MAX_DISCARD_LEVEL)
+    std::array<LLPointer<LLImageRaw>, MAX_DISCARD_LEVEL> mRawImages;
+    // Store the last time a Raw image was accessed
+    F32 mLastRawImageAccess;
+    // Replace the raw aux image with a array of raw images (Sized to the MAX_DISCARD_LEVEL)    
+    std::array<LLPointer<LLImageRaw>, MAX_DISCARD_LEVEL> mAuxRawImages;
+    // </FS:minerjr> [FIRE-35011]
     S32 mRawDiscardLevel = -1;
 
     // Used ONLY for cloth meshes right now.  Make SURE you know what you're

--- a/indra/newview/llviewertexturelist.cpp
+++ b/indra/newview/llviewertexturelist.cpp
@@ -1037,6 +1037,17 @@ void LLViewerTextureList::updateImageDecodePriority(LLViewerFetchedTexture* imag
         // still referenced outside of image list, reset timer
         imagep->getLastReferencedTimer()->reset();
 
+        // <FS:minerjr> [FIRE-35011] Weird patterned extreme CPU usage when using more than 6gb vram on 10g card
+        // Try to clear the raw images that were built up
+        imagep->tryToClearRawImages();
+        /*
+        if (imagep->tryToClearRawImages())
+        {
+            // Succeceded (This is just to see if it cleared.
+            //LL_INFOS() << "Image  " << imagep->getID() << " just cleared it's Raw buffers" << LL_ENDL ;
+        }
+        */
+        // </FS:minerjr> [FIRE-35011] 
         if (imagep->hasSavedRawImage())
         {
             if (imagep->getElapsedLastReferencedSavedRawImageTime() > max_inactive_time)

--- a/indra/newview/skins/default/xui/en/panel_preferences_graphics1.xml
+++ b/indra/newview/skins/default/xui/en/panel_preferences_graphics1.xml
@@ -1230,6 +1230,48 @@ If you do not understand the distinction then leave this control alone."
          width="100">
             Second(s)
         </text>
+        <!-- <FS:minerjr> [FIRE-35011] Weird patterned extreme CPU usage when using more than 6gb vram on 10g card -->
+        <!-- This is just here for testing purposes, will be removed later on -->
+        <combo_box
+         control_name="FSPerformanceAdditions"
+         follows="left|top"
+         layout="topleft"
+         top_delta="20"
+         left="10"
+         name="FSPerformanceAdditions"
+         tool_tip="Performance Features"
+         height="21"
+         width="300">
+            <combo_box.item
+             label="Use current methods"
+             name="0"
+             value="0" />
+            <combo_box.item
+             label="Use 1 spinlock instead of 2 to get worker texture object"
+             name="1"
+             value="1" />
+            <combo_box.item
+             label="Replace fetch with local Raw cache"
+             name="2"
+             value="2" />
+            <combo_box.item
+             label="Texture List Tracking of Bias Improvements"
+             name="3"
+             value="3" />            
+            <combo_box.item
+             label="Add max_time to imposter generation"
+             name="4"
+             value="4" />
+            <combo_box.item
+             label="Limit the amount of cube map regens to only visible ones"
+             name="5"
+             value="5" />
+            <combo_box.item
+             label="Limit the regen to cube maps to 1 time when become visible"
+             name="6"
+             value="6" />
+        </combo_box>
+        <!-- </FS:minerjr> [FIRE-35011] -->
     </panel>
 
 <!--Rendering-->


### PR DESCRIPTION
This is a test for people to try out for a possible partial fix for 35011 and other issues. There is many layers to the the performance issues with the viewer, it is a combination of larger amount of textures allowed to be loaded at any given time, larger cache sizes for files store on local storage and number of threads and locks being used throughout the code.

I have created a video to demo the change as well as talk about the overall issues.

[https://youtu.be/46nnABy5UTo](https://youtu.be/46nnABy5UTo)

This code contains a first couple of steps. There is an drop down combo box in the Preferences->Graphics->Hardware Settings which allow the user to pick form several options.

The first 3 are done currently. The first is normal behavior. The second is to use a different getFetchState method which does 2 task in one call, instead of in 2. The situation of rapid resize requests which would normally call out to the previous worker thread and get the old decoded texture. The problem is it did two sets of locks in a row on a worker which may be working on another texture and could be doing http requests. This would cause spin lock on the main thread and hitching.

The third option bypasses this request for the previous worker thread all together as it now stores a copy of the previous Raw and Aux Raw in an array on the texture itself. Allowing the texture to just re-use the previous data and to not have to go back for it again.

This is also done when a texture wants to resize before going through the process of creating a worker thread to pull the texture, it checks the array to see if a texture exists at the quality it wishes for and if so, just uses it.

There is a clean up function in with the other LLViewerTextureList update decode priority to delete all the raw textures on a given texture if they have not been updated or accessed after 30 seconds. This could be increased or added as user accessible value to give them room to increase the value if they are having yo-yo affects of texture and CPU usage.

It could be have more performance if we would bypass more of the texture system and directly create and load the texture with the commands and leave the loop that they have setup. Also, if we could use std::future as a way to kick off multiple tasks or even just to kick off and use the future<Texture>.Valid() to check if it is ready and if it isn't go and process the next texture and at the end, join the results... This could be the solution to use LLMutexTryLock instead of LLMutexLock's as it is there, but the system does not handle it well when a worker comes back as not done yet. I did a bit of a test and caused some rendering issues as well as textures getting stuck in teh queue. But I will take further look at that being a possible solution to the spinlocks we currently are suffering from.
