### PR TITLE
[FIRE-10419] Selectively process devices based on CLSID to prevent stuttering

### DIFF
--- a/indra/llwindow/llwindowcallbacks.cpp
+++ b/indra/llwindow/llwindowcallbacks.cpp
@@ -184,7 +184,7 @@ bool LLWindowCallbacks::handleTimerEvent(LLWindow *window)
     return false;
 }
 
-bool LLWindowCallbacks::handleDeviceChange(LLWindow *window, bool deviceRemoved)
+bool LLWindowCallbacks::handleDeviceChange(LLWindow *window, bool deviceRemoved) // <FS:Dax/> [FIRE-10419] Added deviceRemoved bool to prevent reinitialize on disconnect.
 {
     return false;
 }

--- a/indra/llwindow/llwindowcallbacks.cpp
+++ b/indra/llwindow/llwindowcallbacks.cpp
@@ -184,7 +184,7 @@ bool LLWindowCallbacks::handleTimerEvent(LLWindow *window)
     return false;
 }
 
-bool LLWindowCallbacks::handleDeviceChange(LLWindow *window)
+bool LLWindowCallbacks::handleDeviceChange(LLWindow *window, bool deviceRemoved)
 {
     return false;
 }

--- a/indra/llwindow/llwindowcallbacks.h
+++ b/indra/llwindow/llwindowcallbacks.h
@@ -67,7 +67,7 @@ public:
     virtual void handleWindowUnblock(LLWindow *window);                         // window coming back after taking over CPU for a while
     virtual void handleDataCopy(LLWindow *window, S32 data_type, void *data);
     virtual bool handleTimerEvent(LLWindow *window);
-    virtual bool handleDeviceChange(LLWindow *window, bool deviceRemoved);
+    virtual bool handleDeviceChange(LLWindow *window, bool deviceRemoved); // <FS:Dax/> [FIRE-10419] Added deviceRemoved bool to prevent reinitialize on disconnect.
     virtual bool handleDPIChanged(LLWindow *window, F32 ui_scale_factor, S32 window_width, S32 window_height);
     virtual bool handleWindowDidChangeScreen(LLWindow *window);
 

--- a/indra/llwindow/llwindowcallbacks.h
+++ b/indra/llwindow/llwindowcallbacks.h
@@ -67,7 +67,7 @@ public:
     virtual void handleWindowUnblock(LLWindow *window);                         // window coming back after taking over CPU for a while
     virtual void handleDataCopy(LLWindow *window, S32 data_type, void *data);
     virtual bool handleTimerEvent(LLWindow *window);
-    virtual bool handleDeviceChange(LLWindow *window);
+    virtual bool handleDeviceChange(LLWindow *window, bool deviceRemoved);
     virtual bool handleDPIChanged(LLWindow *window, F32 ui_scale_factor, S32 window_width, S32 window_height);
     virtual bool handleWindowDidChangeScreen(LLWindow *window);
 

--- a/indra/llwindow/llwindowwin32.cpp
+++ b/indra/llwindow/llwindowwin32.cpp
@@ -579,8 +579,7 @@ LLWindowWin32::LLWindowWin32(LLWindowCallbacks* callbacks,
 
     // Make an instance of our window then define the window class
     mhInstance = GetModuleHandle(NULL);
-
-    // Get a notification filter setup for HID devices
+    // <FS:Dax> [FIRE-10419] Add notification filters for device notifcations for HID device handling
     DEV_BROADCAST_DEVICEINTERFACE notificationFilter;
 
     ZeroMemory(&notificationFilter, sizeof(notificationFilter));
@@ -588,7 +587,7 @@ LLWindowWin32::LLWindowWin32(LLWindowCallbacks* callbacks,
     notificationFilter.dbcc_devicetype = DBT_DEVTYP_DEVICEINTERFACE;
 
     HDEVNOTIFY deviceNotification = RegisterDeviceNotification(mWindowHandle, &notificationFilter, DEVICE_NOTIFY_WINDOW_HANDLE | DEVICE_NOTIFY_ALL_INTERFACE_CLASSES);
-
+    // </FS>
     // Init Direct Input - needed for joystick / Spacemouse
 
     LPDIRECTINPUT8 di8_interface;
@@ -2384,6 +2383,7 @@ LRESULT CALLBACK LLWindowWin32::mainWindowProc(HWND h_wnd, UINT u_msg, WPARAM w_
             //    return 1;
             // }
 
+
             // Only bother initalizing when needed.
             if (deviceCLSIDWhitelist.empty())
             {
@@ -2410,6 +2410,7 @@ LRESULT CALLBACK LLWindowWin32::mainWindowProc(HWND h_wnd, UINT u_msg, WPARAM w_
                 }
             }
             break;
+            // </FS>
         }
 
         case WM_PAINT:

--- a/indra/llwindow/llwindowwin32.cpp
+++ b/indra/llwindow/llwindowwin32.cpp
@@ -580,6 +580,15 @@ LLWindowWin32::LLWindowWin32(LLWindowCallbacks* callbacks,
     // Make an instance of our window then define the window class
     mhInstance = GetModuleHandle(NULL);
 
+    // Get a notification filter setup for HID devices
+    DEV_BROADCAST_DEVICEINTERFACE notificationFilter;
+
+    ZeroMemory(&notificationFilter, sizeof(notificationFilter));
+    notificationFilter.dbcc_size       = sizeof(DEV_BROADCAST_DEVICEINTERFACE);
+    notificationFilter.dbcc_devicetype = DBT_DEVTYP_DEVICEINTERFACE;
+
+    HDEVNOTIFY deviceNotification = RegisterDeviceNotification(mWindowHandle, &notificationFilter, DEVICE_NOTIFY_WINDOW_HANDLE | DEVICE_NOTIFY_ALL_INTERFACE_CLASSES);
+
     // Init Direct Input - needed for joystick / Spacemouse
 
     LPDIRECTINPUT8 di8_interface;
@@ -2291,6 +2300,24 @@ void LLWindowWin32::gatherInput()
     updateCursor();
 }
 
+// Define device classID for filtering
+constexpr std::array<const wchar_t*, 3> classIDStrings = {
+    L"{745a17a0-74d3-11d0-b6fe-00a0c90f57da}", // Modern HID
+    L"{4d36e96c-e325-11ce-bfc1-08002be10318}", // Legacy/Serial
+    L"{a5dcbf10-6530-11d2-901f-00c04fb951ed}"  // SpaceNavigator/Xbox
+};
+
+std::array<GUID, classIDStrings.size()> deviceCLSIDWhitelist;
+
+// Convert to CLSID to make it easier
+void initializeDeviceCLSIDArray()
+{
+    for (size_t i = 0; i < classIDStrings.size(); ++i)
+    {
+        CLSIDFromString(classIDStrings[i], &deviceCLSIDWhitelist[i]);
+    }
+}
+
 static LLTrace::BlockTimerStatHandle FTM_KEYHANDLER("Handle Keyboard");
 static LLTrace::BlockTimerStatHandle FTM_MOUSEHANDLER("Handle Mouse");
 
@@ -2349,11 +2376,38 @@ LRESULT CALLBACK LLWindowWin32::mainWindowProc(HWND h_wnd, UINT u_msg, WPARAM w_
         case WM_DEVICECHANGE:
         {
             LL_PROFILE_ZONE_NAMED_CATEGORY_WIN32("mwp - WM_DEVICECHANGE");
-            if (w_param == DBT_DEVNODES_CHANGED || w_param == DBT_DEVICEARRIVAL)
-            {
-                WINDOW_IMP_POST(window_imp->mCallbacks->handleDeviceChange(window_imp));
 
-                return 1;
+            // <FS> [FIRE-10419] Prevent all devices from being scanned on each change
+            // if (w_param == DBT_DEVNODES_CHANGED || w_param == DBT_DEVICEARRIVAL)
+            // {
+            //    WINDOW_IMP_POST(window_imp->mCallbacks->handleDeviceChange(window_imp));
+            //    return 1;
+            // }
+
+            // Only bother initalizing when needed.
+            if (deviceCLSIDWhitelist.empty())
+            {
+                initializeDeviceCLSIDArray();
+            }
+            
+            if (w_param == DBT_DEVICEARRIVAL || w_param == DBT_DEVICEREMOVECOMPLETE)
+            {
+                DEV_BROADCAST_HDR* dtype = (DEV_BROADCAST_HDR*)l_param;
+                if (dtype->dbch_devicetype == DBT_DEVTYP_DEVICEINTERFACE)
+                {
+                    DEV_BROADCAST_DEVICEINTERFACE* iface = (DEV_BROADCAST_DEVICEINTERFACE*)l_param;
+
+                    // Iterate through the CLSID whitelist for comparison and only fire if it's a useful device
+                    for (const auto& guid : deviceCLSIDWhitelist)
+                    {
+                        if (memcmp(&iface->dbcc_classguid, &guid, sizeof(GUID)) == 0)
+                        {
+                            bool deviceRemoved = (w_param == DBT_DEVICEREMOVECOMPLETE);
+                            WINDOW_IMP_POST(window_imp->mCallbacks->handleDeviceChange(window_imp, deviceRemoved));
+                            break; 
+                        }
+                    }
+                }
             }
             break;
         }

--- a/indra/newview/llviewerwindow.cpp
+++ b/indra/newview/llviewerwindow.cpp
@@ -1839,10 +1839,10 @@ bool LLViewerWindow::handleTimerEvent(LLWindow *window)
     return false;
 }
 
-bool LLViewerWindow::handleDeviceChange(LLWindow *window)
+bool LLViewerWindow::handleDeviceChange(LLWindow *window, bool deviceRemoved)
 {
     // give a chance to use a joystick after startup (hot-plugging)
-    if (!LLViewerJoystick::getInstance()->isJoystickInitialized() )
+    if (!deviceRemoved && !LLViewerJoystick::getInstance()->isJoystickInitialized())
     {
         LLViewerJoystick::getInstance()->init(true);
         return true;

--- a/indra/newview/llviewerwindow.cpp
+++ b/indra/newview/llviewerwindow.cpp
@@ -1839,7 +1839,19 @@ bool LLViewerWindow::handleTimerEvent(LLWindow *window)
     return false;
 }
 
-bool LLViewerWindow::handleDeviceChange(LLWindow *window, bool deviceRemoved)
+// <FS:Dax> [FIRE-10419] Added deviceRemoved bool to prevent reinitialize on disconnect.
+// bool LLViewerWindow::handleDeviceChange(LLWindow* window)
+// {
+//     if (!LLViewerJoystick::getInstance()->isJoystickInitialized())
+//     {
+//         LLViewerJoystick::getInstance()->init(true);
+//         return true;
+//     }
+//     return false;
+// }
+// </FS>
+
+bool LLViewerWindow::handleDeviceChange(LLWindow *window, bool deviceRemoved) 
 {
     // give a chance to use a joystick after startup (hot-plugging)
     if (!deviceRemoved && !LLViewerJoystick::getInstance()->isJoystickInitialized())

--- a/indra/newview/llviewerwindow.h
+++ b/indra/newview/llviewerwindow.h
@@ -225,7 +225,7 @@ public:
     /*virtual*/ void handleWindowUnblock(LLWindow *window);
     /*virtual*/ void handleDataCopy(LLWindow *window, S32 data_type, void *data);
     /*virtual*/ bool handleTimerEvent(LLWindow *window);
-    /*virtual*/ bool handleDeviceChange(LLWindow *window);
+    /*virtual*/ bool handleDeviceChange(LLWindow *window, bool deviceRemoved);
     /*virtual*/ bool handleDPIChanged(LLWindow *window, F32 ui_scale_factor, S32 window_width, S32 window_height);
     /*virtual*/ bool handleWindowDidChangeScreen(LLWindow *window);
 

--- a/indra/newview/llviewerwindow.h
+++ b/indra/newview/llviewerwindow.h
@@ -225,7 +225,7 @@ public:
     /*virtual*/ void handleWindowUnblock(LLWindow *window);
     /*virtual*/ void handleDataCopy(LLWindow *window, S32 data_type, void *data);
     /*virtual*/ bool handleTimerEvent(LLWindow *window);
-    /*virtual*/ bool handleDeviceChange(LLWindow *window, bool deviceRemoved);
+    /*virtual*/ bool handleDeviceChange(LLWindow *window, bool deviceRemoved); // <FS:Dax/> [FIRE-10419] Added deviceRemoved bool to prevent reinitialize on disconnect.
     /*virtual*/ bool handleDPIChanged(LLWindow *window, F32 ui_scale_factor, S32 window_width, S32 window_height);
     /*virtual*/ bool handleWindowDidChangeScreen(LLWindow *window);
 


### PR DESCRIPTION
Hey people,

First contrib so please be patient! 
I have fixed:
[FIRE-10419] (Reported in 2013)
https://jira.firestormviewer.org/browse/FIRE-10419
and
[FIRE-32546]
https://jira.firestormviewer.org/browse/FIRE-32546 which is a dupe.

So the problem is that some devices and applications will cause windows to send out device notifications frequently, this causes a 10-15 second stutter whenever this happens, this can be every few minutes. 

So what i've done is basically register for device notifications, then filter out what we need based on CLSIDs to only init those, 
This based on https://jira.firestormviewer.org/secure/attachment/22091/joystick2.patch by Casper Warden but with a bunch of changes. For one I dropped the sensors for now as we don't need them, cleaned up the code a little and made some changes for better performances I think, but performance lottery. 

Test case for existing functionality still working:
1. Attach controller/joystick
2. Move around, if its works its detected

Test case for testing if lag is fixed requires a PC with a device that will be very 'chatty' like a Valve Index in my case, basically just idle.

I've tested both the fix for the stutter and with a controller, all works.
Not sure if we're expecting any other CLSIDs or if my optimization is overkill and we should keep everything within the main loop. 