### PR TITLE
[FIRE-35185] Profile preview removing embedded URLs from 1st Life tab

### DIFF
--- a/indra/newview/llpanelprofile.cpp
+++ b/indra/newview/llpanelprofile.cpp
@@ -2770,6 +2770,7 @@ void LLPanelProfileFirstLife::onOpen(const LLSD& key)
         mDescriptionEdit->setTabStop(false);
     }
     mPreviewButton->setVisible(getSelfProfile()); // <AS:Chanayane> Preview button
+    mDescriptionEdit->setParseHTML(!getSelfProfile()); // <AS:Chanayane> Fix FIRE-35185 (disables link rendering while editing picks or 1st life)
 
     // <FS:Zi> Allow proper texture swatch handling
     mPicture->setEnabled(getSelfProfile());

--- a/indra/newview/llpanelprofilepicks.cpp
+++ b/indra/newview/llpanelprofilepicks.cpp
@@ -712,7 +712,10 @@ void LLPanelProfilePick::processProperties(void* data, EAvatarProcessorType type
 void LLPanelProfilePick::processProperties(const LLPickData* pick_info)
 {
     mIsEditing = false;
-    mPickDescription->setParseHTML(true);
+    // <AS:Chanayane> Fix FIRE-35185 (disables link rendering while editing picks or 1st life)
+    //mPickDescription->setParseHTML(true);
+    mPickDescription->setParseHTML(!getSelfProfile());
+    // </AS:Chanayane>
     mParcelId = pick_info->parcel_id;
     setSnapshotId(pick_info->snapshot_id);
     if (!getSelfProfile())


### PR DESCRIPTION
This disables rendering links when a pick or 1st life texts are in edit mode (white background, only for own profile).
It makes the preview feature work as intended.
This actually had nothing to do with the preview feature, but it allowed to notice that old bug more easily.