### PR TITLE
Fixes: Correctly update shadows on RenderShadowResolutionScale change

### DIFF
--- a/indra/newview/llviewercontrol.cpp
+++ b/indra/newview/llviewercontrol.cpp
@@ -1286,7 +1286,10 @@ void settings_setup_listeners()
     setting_setup_signal_listener(gSavedSettings, "RenderSpecularResY", handleLUTBufferChanged);
     setting_setup_signal_listener(gSavedSettings, "RenderSpecularExponent", handleLUTBufferChanged);
     setting_setup_signal_listener(gSavedSettings, "RenderAnisotropic", handleAnisotropicChanged);
-    setting_setup_signal_listener(gSavedSettings, "RenderShadowResolutionScale", handleShadowsResized);
+    // <FS:WW> Ensure shader update on shadow resolution scale change for correct shadow rendering.
+    // setting_setup_signal_listener(gSavedSettings, "RenderShadowResolutionScale", handleShadowsResized);
+    setting_setup_signal_listener(gSavedSettings, "RenderShadowResolutionScale", handleSetShaderChanged);
+    // </FS>
     setting_setup_signal_listener(gSavedSettings, "RenderGlow", handleReleaseGLBufferChanged);
     setting_setup_signal_listener(gSavedSettings, "RenderGlow", handleSetShaderChanged);
     setting_setup_signal_listener(gSavedSettings, "RenderGlowResolutionPow", handleReleaseGLBufferChanged);


### PR DESCRIPTION
Detailed description of the changes.

This Pull Request addresses an issue where shadows were not updating correctly when the `RenderShadowResolutionScale` setting was changed in-session. This resulted in broken or inconsistent shadows after adjusting the shadow resolution scale without restarting the viewer.

The root cause was that the signal listener for `RenderShadowResolutionScale` in `llviewercontrol.cpp` was incorrectly set to `handleShadowsResized`.  `handleShadowsResized` was not triggering a full shader update necessary for this particular setting to take effect dynamically.

This PR changes the signal listener to `handleSetShaderChanged`.  `handleSetShaderChanged` ensures a complete shader update is performed when `RenderShadowResolutionScale` is modified.  This approach aligns with how other dynamic render settings, such as `RenderDeferredSSAO`, are handled, ensuring that changes to `RenderShadowResolutionScale` are applied immediately and correctly in-session.

This fix resolves the shadow update issue and provides a more consistent and expected user experience when adjusting shadow resolution scaling. Users can now change `RenderShadowResolutionScale` and see the shadow quality update in real-time without requiring a viewer restart.

Testing:

- **Build:**  Rebuild the viewer with this change.
- **Run:** Launch the viewer and ensure shadows are enabled in your graphics settings.
- **In-world Testing:**
    1.  Go to an in-world location where shadows are visible (e.g., outdoors, or with objects casting shadows under a light source).
    2.  Open Graphics Preferences (Ctrl+Shift+G or Cmd+Shift+G).
    3.  Locate the "Shadows" tab.
    4.  Adjust the "Shadow Resolution Scale" slider (or directly modify the `RenderShadowResolutionScale` setting in the Debug Settings).
    5.  Observe the shadows in the scene as you change the `RenderShadowResolutionScale` setting.
    6.  **Verify:** The shadows should update dynamically and correctly in response to changes in `RenderShadowResolutionScale` *without* requiring a viewer restart.  Changing the slider should visibly alter the shadow resolution quality in real-time.

Documentation:

- No specific documentation updates are needed for the Wiki as this is a bug fix that improves the existing shadow rendering behavior.
- It is recommended to include a note about this fix in the Viewer release notes to inform users about the improved shadow updating behavior when changing the `RenderShadowResolutionScale` setting.
