### PR TITLE
Fixes: Improve SSAO Appearance Consistency for High-Resolution Snapshots

### DIFF
--- a/indra/newview/pipeline.cpp
+++ b/indra/newview/pipeline.cpp
@@ -8796,14 +8796,20 @@ void LLPipeline::bindDeferredShader(LLGLSLShader& shader, LLRenderTarget* light_
     shader.uniform1f(LLShaderMgr::DEFERRED_SHADOW_NOISE, RenderShadowNoise);
     shader.uniform1f(LLShaderMgr::DEFERRED_BLUR_SIZE, RenderShadowBlurSize);
 
-    shader.uniform1f(LLShaderMgr::DEFERRED_SSAO_RADIUS, RenderSSAOScale);
-    shader.uniform1f(LLShaderMgr::DEFERRED_SSAO_MAX_RADIUS, (GLfloat)RenderSSAOMaxScale);
+// <FS:WW> Compute scale factor to match AO appearance between view and snapshot.
+	F32 screen_to_target_scale_factor = (F32)gViewerWindow->getWindowHeightRaw() / deferred_target->getHeight();
+	//shader.uniform1f(LLShaderMgr::DEFERRED_SSAO_RADIUS, RenderSSAOScale);
+	shader.uniform1f(LLShaderMgr::DEFERRED_SSAO_RADIUS, RenderSSAOScale / screen_to_target_scale_factor);
+	//shader.uniform1f(LLShaderMgr::DEFERRED_SSAO_MAX_RADIUS, (GLfloat)RenderSSAOMaxScale);
+	shader.uniform1f(LLShaderMgr::DEFERRED_SSAO_MAX_RADIUS, RenderSSAOMaxScale / screen_to_target_scale_factor);
+	// </FS:WW>
 
     F32 ssao_factor = RenderSSAOFactor;
     shader.uniform1f(LLShaderMgr::DEFERRED_SSAO_FACTOR, ssao_factor);
     shader.uniform1f(LLShaderMgr::DEFERRED_SSAO_FACTOR_INV, 1.0f/ssao_factor);
 
     LLVector3 ssao_effect = RenderSSAOEffect;
+
     F32 matrix_diag = (ssao_effect[0] + 2.0f*ssao_effect[1])/3.0f;
     F32 matrix_nondiag = (ssao_effect[0] - ssao_effect[1])/3.0f;
     // This matrix scales (proj of color onto <1/rt(3),1/rt(3),1/rt(3)>) by


### PR DESCRIPTION
Detailed description of the changes.

This Pull Request addresses an issue where Screen Space Ambient Occlusion (SSAO) appearance was inconsistent, particularly in high-resolution snapshots compared to the main viewer window.

**This fix is based on a similar method previously implemented by BeqJanus to address the same type of resolution inconsistency issue with Depth of Field effects in snapshots.**

Previously, the SSAO radii parameters (RenderSSAOScale and RenderSSAOMaxScale) were directly applied to the shader without considering the resolution difference between the viewer window and the render target (snapshot).  This resulted in SSAO appearing too small and under-sampled in high-resolution snapshots, as the sampling radius was not scaled up to match the larger snapshot resolution.

To resolve this, a scaling factor is now calculated based on the ratio of the viewer window's height to the snapshot's height:

    scale_factor = viewer_window_height / snapshot_height

This scale factor is then used to divide the user-defined SSAO radius values before they are passed to the shader.  When the snapshot resolution is higher than the viewer resolution, the `scale_factor` becomes less than 1. Dividing by this factor effectively increases the SSAO radii, ensuring the ambient occlusion effect scales proportionally to the higher resolution.

For example, if the viewer is running at 1080p height and a snapshot is taken at 4096p height, the scale factor would be approximately 1080 / 4096 ≈ 0.2637. Dividing the SSAO radii by 0.2637 results in multiplying them by approximately 3.79, thus scaling up the SSAO effect to maintain visual consistency in the high-resolution snapshot.

**Visual Evidence:**

This Pull Request includes 5 attached images to visually demonstrate the SSAO consistency improvement:

*   **`1024_baseline.png`:** This image shows a snapshot taken at a typical near 1080p resolution. It serves as the baseline for SSAO appearance against which higher resolution snapshots should be compared.
*   **`4096_before.png` and `8192_before.png`:** These images show snapshots taken at 4096p and 8192p resolutions *before* this fix was applied. In these images, it is evident that the SSAO effect appears diminished and does not match the baseline appearance from `1024_baseline.png`.
*   **`4096_after.png` and `8192_after.png`:** These images show snapshots taken at 4096p and 8192p resolutions *after* this fix was applied.  In these images, the SSAO effect in the high-resolution snapshots now closely matches the SSAO appearance in the `1024_baseline.png` image, demonstrating the improved consistency.


Intended Impact & Benefits:

- **Visual Consistency:** Ensures that the SSAO effect maintains a consistent visual scale and intensity between the interactive viewer display and high-resolution snapshots, providing a more predictable and professional output.
- **Improved User Experience:** Users capturing high-resolution snapshots will now experience a more accurate and visually pleasing SSAO effect, preventing the unintended diminishment of ambient occlusion and preserving the intended scene aesthetics.
- **Balanced Quality Across Resolutions:**  The fix dynamically adjusts the SSAO radii based on resolution, maintaining a balanced and consistent level of detail and intensity across varying output resolutions without requiring manual user adjustments.

Testing:

- **Build:** Rebuild the Viewer after applying this commit.
- **Run:** Launch the viewer and ensure that Screen Space Ambient Occlusion (SSAO) is enabled in the graphics settings.
- **Visual Comparison (Viewer vs. High-Resolution Snapshot):**
    1.  In the viewer, observe the appearance of SSAO in a scene with noticeable ambient occlusion effects.
    2.  Take a high-resolution snapshot to disk (e.g., 4096p or higher).
    3.  Compare the SSAO effect in the saved snapshot image to the SSAO in the live viewer window. The SSAO in the snapshot should now appear visually consistent in scale and intensity with the viewer, and not diminished or under-sampled.
- **Resolution Variation (Recommended):** Test with different viewer window sizes (e.g., 720p, 1080p) and snapshot resolutions (including resolutions higher than the viewer) to verify that the SSAO consistency is maintained across a range of rendering targets.

Documentation:

- No specific updates to the Wiki are required as this commit is a bug fix that improves the existing SSAO feature's consistency.
- It is recommended to include a note about this fix in the Viewer release notes to inform users about the improved SSAO behavior in high-resolution snapshots.
![1024_baseline](https://github.com/user-attachments/assets/a37ae577-8538-4f1b-a703-538623719df5)
![4096_after_small](https://github.com/user-attachments/assets/a4f426ec-30b8-48f9-8141-d2062d49226b)
![4096_before_small](https://github.com/user-attachments/assets/a87a41bb-381f-41ad-bdb4-a879eca514dd)
![8196_before_small](https://github.com/user-attachments/assets/56361e1c-f8de-4af5-9d1e-95c59c5509bd)
![8196_after_small](https://github.com/user-attachments/assets/07fb4058-6268-4148-a6ce-a2f2295630cd)
