### PR TITLE
Improve Shadow Resolution Update by Guarding Against Invalid mRT Dimensions

### DIFF
--- a/indra/newview/llviewercontrol.cpp
+++ b/indra/newview/llviewercontrol.cpp
@@ -1286,10 +1286,11 @@ void settings_setup_listeners()
     setting_setup_signal_listener(gSavedSettings, "RenderSpecularResY", handleLUTBufferChanged);
     setting_setup_signal_listener(gSavedSettings, "RenderSpecularExponent", handleLUTBufferChanged);
     setting_setup_signal_listener(gSavedSettings, "RenderAnisotropic", handleAnisotropicChanged);
-    // <FS:WW> Ensure shader update on shadow resolution scale change for correct shadow rendering.
-    // setting_setup_signal_listener(gSavedSettings, "RenderShadowResolutionScale", handleShadowsResized);
-    setting_setup_signal_listener(gSavedSettings, "RenderShadowResolutionScale", handleSetShaderChanged);
-    // </FS>
+    // <FS:WW> Revert RenderShadowResolutionScale listener to handleShadowsResized (Firestorm default)
+    // Reverting back to the original Firestorm behavior of using `handleShadowsResized` for the RenderShadowResolutionScale setting.
+    // This undoes a previous Aperture-specific change that used `handleSetShaderChanged`.
+    setting_setup_signal_listener(gSavedSettings, "RenderShadowResolutionScale", handleShadowsResized);
+    // </FS:WW>
     setting_setup_signal_listener(gSavedSettings, "RenderGlow", handleReleaseGLBufferChanged);
     setting_setup_signal_listener(gSavedSettings, "RenderGlow", handleSetShaderChanged);
     setting_setup_signal_listener(gSavedSettings, "RenderGlowResolutionPow", handleReleaseGLBufferChanged);

--- a/indra/newview/pipeline.cpp
+++ b/indra/newview/pipeline.cpp
@@ -131,6 +131,10 @@
 
 #include "SMAAAreaTex.h"
 #include "SMAASearchTex.h"
+    
+// <FS:WW>
+#include "llerror.h"
+// </FS:WW>
 
 #ifndef LL_WINDOWS
 #define A_GCC 1
@@ -789,6 +793,43 @@ void LLPipeline::requestResizeShadowTexture()
 
 void LLPipeline::resizeShadowTexture()
 {
+
+    // <FS:WW> Add frame skip counter and logging for shadow texture resizing.
+    // A static counter to keep track of skipped frames
+    static int sSkippedFrameCount = 0;
+
+    if (!mRT || mRT->width == 0 || mRT->height == 0)
+    {
+        // Log warning about invalid render target dimensions.
+        sSkippedFrameCount++;
+        // Include skipped frame count in the log message.
+        // Indicate the number of frames skipped so far.
+        // Use LL_WARNS for warning log level.
+        // Add "Render" category to the log message.
+        LL_WARNS("Render") << "Shadow texture resizing aborted: render target dimensions invalid. Skipped "
+                           << sSkippedFrameCount << " frame(s) so far." << LL_ENDL;
+        return;
+    }
+
+    // If there were skipped frames before mRT became valid, log that information.
+    if (sSkippedFrameCount > 0)
+    {
+        // Log info message when render target becomes valid after skips.
+        // Indicate the number of frames skipped previously.
+        // Use LL_INFOS for info log level.
+        // Add "Render" category to the log message.
+        LL_INFOS("Render") << "Render target now valid after "
+                           << sSkippedFrameCount << " skipped frame(s)." << LL_ENDL;
+        sSkippedFrameCount = 0;
+    }
+
+    // Add verbose logging for shadow texture resizing.
+    LL_WARNS() << "LLPipeline::resizeShadowTexture() called." << LL_ENDL;
+    LL_INFOS() << "Resizing shadow texture. mRT->width = "
+               << mRT->width << " mRT->height = " << mRT->height << LL_ENDL;
+
+    // </FS:WW>
+
     releaseSunShadowTargets();
     releaseSpotShadowTargets();
     allocateShadowBuffer(mRT->width, mRT->height);


### PR DESCRIPTION
This is a follow-up fix to my merged PR (Fixes: Correctly update shadows on RenderShadowResolutionScale changes) which addressed broken shadow rendering after in‑session shader changes. While the previous “sledgehammer” solution—forcing a full shader recompile—resolved the issue, it introduced significant overhead by thrashing the shader cache and resetting various pipeline states.

## Background

In Firestorm, we have observed that immediately upon startup the underlying shadow render target (mRT) may report zero dimensions—even before any shader toggling occurs. This condition leads to incorrect updates of shadow textures when the RenderShadowResolutionScale setting is modified. In contrast, the official Linden Lab viewer typically exhibits this behavior only after an in‑session shader change. In Firestorm, however, the issue appears to be more consistent.

## The Fix

To prevent the shadow texture from being resized with invalid dimensions, this fix adds a guard in `LLPipeline::resizeShadowTexture()` that checks whether `mRT` has valid (nonzero) dimensions. If the dimensions are invalid, the function logs a warning and aborts the resize for that frame. This effectively acts as a lightweight timing buffer, ensuring that as soon as `mRT` becomes valid (usually within one frame), the shadows update correctly without forcing a full shader recompile.

## Updated Code

```cpp
void LLPipeline::resizeShadowTexture()
{

    // <FS:WW> Add frame skip counter and logging for shadow texture resizing.
    // A static counter to keep track of skipped frames
    static int sSkippedFrameCount = 0;

    if (!mRT || mRT->width == 0 || mRT->height == 0)
    {
        // Log warning about invalid render target dimensions.
        sSkippedFrameCount++;
        // Include skipped frame count in the log message.
        // Indicate the number of frames skipped so far.
        // Use LL_WARNS for warning log level.
        // Add "Render" category to the log message.
        LL_WARNS("Render") << "Shadow texture resizing aborted: render target dimensions invalid. Skipped "
                           << sSkippedFrameCount << " frame(s) so far." << LL_ENDL;
        return;
    }

    // If there were skipped frames before mRT became valid, log that information.
    if (sSkippedFrameCount > 0)
    {
        // Log info message when render target becomes valid after skips.
        // Indicate the number of frames skipped previously.
        // Use LL_INFOS for info log level.
        // Add "Render" category to the log message.
        LL_INFOS("Render") << "Render target now valid after "
                           << sSkippedFrameCount << " skipped frame(s)." << LL_ENDL;
        sSkippedFrameCount = 0;
    }

    // Add verbose logging for shadow texture resizing.
    LL_WARNS() << "LLPipeline::resizeShadowTexture() called." << LL_ENDL;
    LL_INFOS() << "Resizing shadow texture. mRT->width = "
               << mRT->width << " mRT->height = " << mRT->height << LL_ENDL;

    // </FS:WW>

    releaseSunShadowTargets();
    releaseSpotShadowTargets();
    allocateShadowBuffer(mRT->width, mRT->height);
    gResizeShadowTexture = false;
}
```
    

## Logging Evidence

For additional transparency during testing and review, I have intentionally left debug logging in the code to report how many frames are skipped before mRT becomes valid. Below are some sample log entries:

 ```     
Line 1456: 2025-03-12T10:42:18Z WARNING #Render# newview/pipeline.cpp(799) LLPipeline::resizeShadowTexture : Shadow texture resizing aborted: render target dimensions invalid. Skipped 1 frame(s) so far.
Line 1519: 2025-03-12T10:42:31Z WARNING #Render# newview/pipeline.cpp(799) LLPipeline::resizeShadowTexture : Shadow texture resizing aborted: render target dimensions invalid. Skipped 2 frame(s) so far.
Line 1544: 2025-03-12T10:42:45Z WARNING #Render# newview/pipeline.cpp(799) LLPipeline::resizeShadowTexture : Shadow texture resizing aborted: render target dimensions invalid. Skipped 3 frame(s) so far.
```
    
These logs confirm that the guard causes a one-frame (or so) delay per adjustment of RenderShadowResolutionScale when mRT is initially zero. In practice, this delay is minimal and imperceptible to users, yet it prevents broken shadows without the heavy-handed approach of forcing a full shader recompile.

## Path Forward

Short-Term Improvement: This fix ensures that when RenderShadowResolutionScale is adjusted via Debug Settings, shadow rendering updates correctly in real time, without requiring an extra shader toggle or viewer restart.

Long-Term Solution: While this guard provides an immediate and effective workaround, it remains a temporary solution. The root cause that causes mRT to be zero appears to be shared between Firestorm and the official viewer, though Firestorm demonstrates it more consistently from startup and without requiring and previous shader changes. Further investigation is needed to pinpoint the precise cause of the mRT issue so that a more permanent and elegant solution can be devised in the future.

> [!NOTE]  
> I’ve intentionally left the detailed debug logging (the LL_WARNS and LL_INFOS messages with the frame counter) in the code for now. This logging provides explicit confirmation of when and how many frames are skipped, and should be useful during review and for anyone reproducing or further testing the fix. Please let me know if you’d prefer that this debug logging be removed before merging.