### PR TITLE
[FIRE-34020] [OPENSIM] Copy of address bar contents does not URL encode space in region name for OpenSim only

### DIFF
--- a/indra/newview/llurllineeditorctrl.cpp
+++ b/indra/newview/llurllineeditorctrl.cpp
@@ -86,6 +86,10 @@ void LLURLLineEditor::copyEscapedURLToClipboard()
     // *HACK: Because LLSLURL is currently broken we cannot use it to check if unescaped_text is a valid SLURL (see EXT-8335).
     if (LLStringUtil::startsWith(unescaped_text, "http://") || LLStringUtil::startsWith(unescaped_text, "secondlife://")) // SLURL
         text_to_copy = utf8str_to_wstring(LLWeb::escapeURL(unescaped_text));
+    // <FS:HT> [FIRE-34020] Copy of address bar contents does not URL encode space in region name for OpenSim only
+    else if (LLStringUtil::startsWith(unescaped_text, "hop://")) 
+        text_to_copy = utf8str_to_wstring(LLWeb::escapeURL(unescaped_text));
+    // </FS:HT>
     else // human-readable location
         text_to_copy = utf8str_to_wstring(unescaped_text);
 


### PR DESCRIPTION
This fixes [FIRE-34020](https://jira.firestormviewer.org/browse/FIRE-34020) by ensuring that `hop://` addresses are correctly URL-encoded when copied to the clipboard from the address bar, similar to `secondlife://` addresses.

The problem was that `LLURLLineEditor::copyEscapedURLToClipboard` only knew about `http://` and `secondlife://` schemes. With this change it now handles `hop://` as well.

Testing:
1. Visit any OpenSim region containing spaces (for example) in the Region Name.
2. Copy the address bar to the clipboard (using <kbd>ctrl-c</kbd> or context menu).
3. Paste the clipboard contents somewhere and should see `%20`'s have been applied.

Thanks!

cc: @aiaustin