### PR TITLE
[FIRE-35276] Fix for client freeze in OpenSim getting picks limit

### DIFF
--- a/indra/newview/llagentbenefits.cpp
+++ b/indra/newview/llagentbenefits.cpp
@@ -37,6 +37,8 @@
 #include "llviewerregion.h"
 // </FS:Ansariel>
 
+constexpr S32 MAX_OPENSIM_PICKS = S32_MAX; // <FS/> [FIRE-35276] Fix for client freeze in OpenSim getting picks limit
+
 LLAgentBenefits::LLAgentBenefits():
     m_initalized(false),
     m_animated_object_limit(-1),
@@ -213,7 +215,7 @@ S32 LLAgentBenefits::getPicksLimit() const
 {
     // <FS:Ansariel> OpenSim legacy economy
     //return m_picks_limit;
-    return LLGridManager::instance().isInSecondLife() ? m_picks_limit : LLAgentPicksInfo::instance().getMaxNumberOfPicks();
+    return LLGridManager::instance().isInSecondLife() ? m_picks_limit : MAX_OPENSIM_PICKS;
     // </FS:Ansariel>
 }
 


### PR DESCRIPTION
[[FIRE-35276]](https://jira.firestormviewer.org/browse/FIRE-35276)

Fix for client freeze in OpenSim getting picks limit.

Setting the max picks limit to S32_MAX for OpenSim from my limited testing appears to have 0 downside and older viewers still handle this fine, they just don't allow additional picks to be created past 10.

If you believe using S32_MAX is excessive and it should be hard capped to a more reasonable number (such as 20 like on official secondlife which is set by their servers and told to the viewer), let me know and I'll update the PR accordingly.