### PR TITLE
[FIRE-35288] Obtain MaxProfilePicks from simulator features

### DIFF
--- a/indra/newview/llagentbenefits.cpp
+++ b/indra/newview/llagentbenefits.cpp
@@ -37,8 +37,6 @@
 #include "llviewerregion.h"
 // </FS:Ansariel>
 
-constexpr S32 MAX_OPENSIM_PICKS = S32_MAX; // <FS/> [FIRE-35276] Fix for client freeze in OpenSim getting picks limit
-
 LLAgentBenefits::LLAgentBenefits():
     m_initalized(false),
     m_animated_object_limit(-1),
@@ -215,7 +213,23 @@ S32 LLAgentBenefits::getPicksLimit() const
 {
     // <FS:Ansariel> OpenSim legacy economy
     //return m_picks_limit;
-    return LLGridManager::instance().isInSecondLife() ? m_picks_limit : MAX_OPENSIM_PICKS;
+    if (LLGridManager::instance().isInSecondLife())
+        return m_picks_limit;
+
+    constexpr S32 MAX_PROFILE_PICKS = 20;
+
+    S32 max_picks = MAX_PROFILE_PICKS;
+
+    if (gAgent.getRegion())
+    {
+        LLSD features;
+        gAgent.getRegion()->getSimulatorFeatures(features);
+        if (features.has("MaxProfilePicks"))
+        {
+            max_picks = features["MaxProfilePicks"].asInteger();
+        }
+    }
+    return max_picks;
     // </FS:Ansariel>
 }
 


### PR DESCRIPTION
[[FIRE-35288]](https://jira.firestormviewer.org/browse/FIRE-35288)

OpenSimulator very recently implemented the Simulator Feature "MaxProfilePicks", in order to determine the maximum profile picks a person can have.

The above PR implements this, and if the feature is not provided (the server is on an older version), it falls back to the new default value of 20 (previously S32_MAX but as explained by Ubit, this is not ideal for a number of reasons).

I didn't add a comment for this specific Jira issue, since it is already inside the // <FS:Ansariel> OpenSim legacy economy block, and also other Simulator Features that have been added in the past such as MaxAgentAttachments, is inside this same block.
If you want me to tag it anyway, please let me know and I can do it anyway. (Please tell me how you would want it though, because doubling up on the FS comment tag seems a bit redundant.