### PR TITLE
[FIRE-35292] Fix Exporting Texture getting downscaled and compression

### DIFF
--- a/indra/newview/daeexport.cpp
+++ b/indra/newview/daeexport.cpp
@@ -505,7 +505,15 @@ void ColladaExportFloater::CacheReadResponder::saveTexturesWorker(void* data)
             std::string name = gDirUtilp->getDirName(me->mFilename);
             name += gDirUtilp->getDirDelimiter() + me->mTexturesToSave[id];
             CacheReadResponder* responder = new CacheReadResponder(id, img, name, img_type);
-            LLAppViewer::getTextureCache()->readFromCache(id, 0, 999999, responder);
+            // <FS:minerjr> [FIRE-35292] Fix for textures getting downscaled and compressed           
+            //LLAppViewer::getTextureCache()->readFromCache(id, 0, 999999, responder);
+            // The above line hard coded the size of data to read from the cached version of the texture as 999999,
+            // where now we will calcuate the correct value based upon the texture's full width, height and # of components (3=RGB, 4=RGBA) and
+            // the discard level (0)). There is a choice to change the rate, but we seem to use the value of 1/8 compression level
+            S32 texture_size = LLImageJ2C::calcDataSizeJ2C(imagep->getFullWidth(), imagep->getFullHeight(), imagep->getComponents(), 0);// , F32 rate) rate = const F32 DEFAULT_COMPRESSION_RATE = 1.f/8.f;
+            // Use calculated texture_size (from LLTextureFetch::createRequest see "else if (w*h*c > 0)" statement for more info)
+            LLAppViewer::getTextureCache()->readFromCache(id, 0, texture_size, responder); 
+            // </FS:minerjr> [FIRE-35292]
             me->mTexturesToSave.erase(id);
             me->updateTitleProgress();
             me->mTimer.reset();

--- a/indra/newview/daeexport.cpp
+++ b/indra/newview/daeexport.cpp
@@ -505,14 +505,14 @@ void ColladaExportFloater::CacheReadResponder::saveTexturesWorker(void* data)
             std::string name = gDirUtilp->getDirName(me->mFilename);
             name += gDirUtilp->getDirDelimiter() + me->mTexturesToSave[id];
             CacheReadResponder* responder = new CacheReadResponder(id, img, name, img_type);
-            // <FS:minerjr> [FIRE-35292] Fix for textures getting downscaled and compressed           
+            // <FS:minerjr> [FIRE-35292] Fix for textures getting downscaled and compressed
             //LLAppViewer::getTextureCache()->readFromCache(id, 0, 999999, responder);
             // The above line hard coded the size of data to read from the cached version of the texture as 999999,
             // where now we will calcuate the correct value based upon the texture's full width, height and # of components (3=RGB, 4=RGBA) and
             // the discard level (0)). There is a choice to change the rate, but we seem to use the value of 1/8 compression level
             S32 texture_size = LLImageJ2C::calcDataSizeJ2C(imagep->getFullWidth(), imagep->getFullHeight(), imagep->getComponents(), 0);// , F32 rate) rate = const F32 DEFAULT_COMPRESSION_RATE = 1.f/8.f;
             // Use calculated texture_size (from LLTextureFetch::createRequest see "else if (w*h*c > 0)" statement for more info)
-            LLAppViewer::getTextureCache()->readFromCache(id, 0, texture_size, responder); 
+            LLAppViewer::getTextureCache()->readFromCache(id, 0, texture_size, responder);
             // </FS:minerjr> [FIRE-35292]
             me->mTexturesToSave.erase(id);
             me->updateTitleProgress();

--- a/indra/newview/daeexport.cpp
+++ b/indra/newview/daeexport.cpp
@@ -428,6 +428,8 @@ void ColladaExportFloater::CacheReadResponder::completed(bool success)
             // For other formats we need to decode first
             if (mFormattedImage->updateData() && ( (mFormattedImage->getWidth() * mFormattedImage->getHeight() * mFormattedImage->getComponents()) != 0 ) )
             {
+                mFormattedImage->setDiscardLevel(0); // <FS/> [FIRE-35292] Fix for textures getting downscaled and compressed
+
                 LLPointer<LLImageRaw> raw = new LLImageRaw;
                 raw->resize(mFormattedImage->getWidth(), mFormattedImage->getHeight(),  mFormattedImage->getComponents());
 

--- a/indra/newview/llagentbenefits.cpp
+++ b/indra/newview/llagentbenefits.cpp
@@ -220,7 +220,7 @@ S32 LLAgentBenefits::getPicksLimit() const
     }
     else
     {
-        constexpr S32 MAX_OPENSIM_PICKS_FALLBACK = 20; // [FIRE-35276] Freeze on OpenSim (default agreed with Ubit Umarov) (originally by Haklezz)
+        constexpr S32 MAX_OPENSIM_PICKS_FALLBACK = 20; // [FIRE-35276] Freeze on OpenSim (default agreed with Ubit Umarov) (originally by Hecklezz)
 
         S32 max_profile_picks = MAX_OPENSIM_PICKS_FALLBACK;
 
@@ -234,7 +234,7 @@ S32 LLAgentBenefits::getPicksLimit() const
             }
         }
         return max_profile_picks;
-    }    
+    }
     // </FS:Ansariel>
 }
 


### PR DESCRIPTION
[FIRE-35292](https://jira.firestormviewer.org/browse/FIRE-35292)
Fixes the issue described in the Jira ticket where exporting textures as PNG or TGA were getting downscaled and compressed when they weren't supposed to be. This is achieved by simply setting the discard level back to 0 before it decodes the image and saves it to disk.


_Fixing the Uploading of J2C textures is not implemented yet. This is an issue that impacts secondlife's viewer too, and as such, I have opened an issue with their version and they have already taken it on as a bug and slated for milestone 2025.04. If LL chooses not to fix it themselves, or their fix needs changes for OpenSim, I will open another PR when necessary_


(Also corrects a minor error in a comment from a previous commit)