### PR TITLE
[FIRE-35304] Fix viewing and editing your own profile notes in OpenSim

### DIFF
--- a/indra/newview/llpanelprofile.cpp
+++ b/indra/newview/llpanelprofile.cpp
@@ -3147,10 +3147,10 @@ void LLPanelProfileNotes::updateData()
 #ifdef OPENSIM
     if (LLGridManager::instance().isInOpenSim() && gAgent.getRegionCapability(PROFILE_PROPERTIES_CAP).empty())
     {
-    LLUUID avatar_id = getAvatarId();
-        if (!getStarted() && avatar_id.notNull() && gAgent.getRegionCapability(PROFILE_PROPERTIES_CAP).empty() && !getSelfProfile())
-    {
-        setIsLoading();
+        LLUUID avatar_id = getAvatarId();
+        if (!getStarted() && avatar_id.notNull())
+        {
+            setIsLoading();
             LLAvatarPropertiesProcessor::getInstance()->sendAvatarNotesRequest(avatar_id);
         }
     }


### PR DESCRIPTION
[FIRE-35304](https://jira.firestormviewer.org/browse/FIRE-35304)

Fixes not being able to view and edit your own profiles notes while in OpenSim.

This is achieved by removing the incorrectly added !getSelfProfile() check. I also removed the redundant additional gAgent.getRegionCapability(PROFILE_PROPERTIES_CAP).empty() check since it already does it.