### PR TITLE
[FIRE-35327] Fixes Antialising type setting under preferences

### DIFF
--- a/indra/newview/llfloaterpreference.cpp
+++ b/indra/newview/llfloaterpreference.cpp
@@ -2339,7 +2339,7 @@ void LLFloaterPreference::refresh()
     LLPanel::refresh();
 
     // <FS:Ansariel> Improved graphics preferences
-    getChild<LLUICtrl>("fsaa")->setValue((LLSD::Integer)  gSavedSettings.getU32("RenderFSAASamples"));
+    getChild<LLUICtrl>("fsaa")->setValue((LLSD::Integer)  gSavedSettings.getU32("RenderFSAAType"));
     updateSliderText(getChild<LLSliderCtrl>("RenderPostProcess",    true), getChild<LLTextBox>("PostProcessText",           true));
     LLAvatarComplexityControls::setIndirectControls();
     setMaxNonImpostorsText(gSavedSettings.getU32("RenderAvatarMaxNonImpostors"),getChild<LLTextBox>("IndirectMaxNonImpostorsText", true));


### PR DESCRIPTION
[FIRE-35327](https://jira.firestormviewer.org/browse/FIRE-35327)

Fixes the Antialiasing type under preferences from being set to the wrong value and not saving correctly.
(It was incorrectly tied to the Antialiasing sampling setting)