### PR TITLE
[FIRE-35331] Fix Region/Estate panel sizes

### DIFF
--- a/indra/newview/skins/default/xui/en/floater_region_info.xml
+++ b/indra/newview/skins/default/xui/en/floater_region_info.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <floater
  legacy_header_height="18"
- height="535"
+ height="575"
  help_topic="regioninfo"
  layout="topleft"
  name="regioninfo"
@@ -9,7 +9,7 @@
  title="Region / Estate"
  width="485">
     <tab_container
-     bottom="535"
+     bottom="575"
      follows="left|right|top|bottom"
      layout="topleft"
      left="1"

--- a/indra/newview/skins/default/xui/en/panel_region_access.xml
+++ b/indra/newview/skins/default/xui/en/panel_region_access.xml
@@ -56,14 +56,14 @@
     <view_border
      bevel_style="none"
      follows="top|left"
-     height="400"
+     height="437"
      layout="topleft"
      left="10"
      top_pad="-5"
      width="453" />
     <name_list
      follows="left|top"
-     height="400"
+     height="437"
      layout="topleft"
      left_delta="0"
      multi_select="true"
@@ -157,14 +157,14 @@
     <view_border
      bevel_style="none"
      follows="top|left"
-     height="370"
+     height="410"
      layout="topleft"
      left="10"
      top_pad="-5"
      width="453" />
     <name_list
      follows="left|top"
-     height="370"
+     height="410"
      layout="topleft"
      left_delta="0"
      multi_select="true"
@@ -256,14 +256,14 @@
     <view_border
      bevel_style="none"
      follows="top|left"
-     height="370"
+     height="410"
      layout="topleft"
      left="10"
      top_pad="-5"
      width="453" />
     <name_list
      follows="left|top"
-     height="370"
+     height="410"
      layout="topleft"
      left_delta="0"
      multi_select="true"
@@ -356,14 +356,14 @@
     <view_border
      bevel_style="none"
      follows="top|left"
-     height="370"
+     height="410"
      layout="topleft"
      left="10"
      top_pad="-5"
      width="453" />
       <name_list
        follows="left|top"
-       height="370"
+       height="410"
        layout="topleft"
        left_delta="0"
        multi_select="true"

--- a/indra/newview/skins/default/xui/en/panel_region_terrain.xml
+++ b/indra/newview/skins/default/xui/en/panel_region_terrain.xml
@@ -2,7 +2,7 @@
 <panel
  border="true"
  follows="top|left"
- height="460"
+ height="500"
  help_topic="panel_region_terrain_tab"
  label="Terrain"
  layout="topleft"


### PR DESCRIPTION
[FIRE-35331](https://jira.firestormviewer.org/browse/FIRE-35331)

Currently, the Region/Estate floater is sized too small so that the terrain tab is missing the Apply button. It is also missing some of the PBR Transforms settings due to getting cut off.

This PR resizes the the float and individual panels so everything is accessible again, and it also readjusts the Access panel so there isn't unused space.