### PR TITLE
[FIRE-35323] Fix poser values getting stuck after using visual manipulators

### DIFF
--- a/indra/newview/fsjointpose.cpp
+++ b/indra/newview/fsjointpose.cpp
@@ -150,15 +150,20 @@ void FSJointPose::recaptureJointAsDelta()
     {
         return;
     }
-    
+
     LLJoint* joint = mJointState->getJoint();
     if (!joint)
     {
         return;
     }
-    
+
     addStateToUndo(mCurrentState);
-    mCurrentState = FSJointState(joint);
+    FSJointState newState = FSJointState(joint);
+
+    // Fixes issue when using the visual manipulators after setting Move/Scale values
+    newState.restorePublicState(mCurrentState);
+
+    mCurrentState = newState;
 }
 
 void FSJointPose::swapRotationWith(FSJointPose* oppositeJoint)

--- a/indra/newview/fsjointpose.h
+++ b/indra/newview/fsjointpose.h
@@ -215,6 +215,21 @@ class FSJointPose
             joint->setScale(mBaseScale);
         }
 
+        void restorePublicState(FSJointState previousState)
+        {
+            const LLVector3& previousPosition = previousState.mPosition;
+            const LLVector3& previousScale = previousState.mScale;
+            const LLQuaternion& previousRotation = previousState.mRotation;
+
+            mBasePosition -= previousPosition;
+            mPosition = previousPosition;
+            mBaseScale -= previousScale;
+            mScale = previousScale;
+            mBaseRotation = ~previousRotation * mBaseRotation;
+            mBaseRotation.normalize();
+            mRotation = previousRotation;
+        }
+
       private:
         FSJointState(FSJointState* state)
         {


### PR DESCRIPTION
[FIRE-35323](https://jira.firestormviewer.org/browse/FIRE-35323)

If you had set public values (rotation, scale and position) in the Avatar and Animesh Poser, and then proceed to use the visual manipulators, it would result in the public values being set back to 0 and their results being written into the base values of the joints. This resulted in your avatar getting stuck with these changes after closing the poser.

This PR works around this by setting back the public values and correcting the base values to not have the public values written into them.
This may not be the "proper" solution, but it's a working workaround.


PS: I noticed the Poser Animator calls the same function I implemented the workaround in, so this PR needs to be properly tested to ensure there is no adverse side effects to the fix.