### PR TITLE
[FIRE-35317] Restore AudioLevelWind as a debug setting

### DIFF
--- a/indra/newview/app_settings/settings.xml
+++ b/indra/newview/app_settings/settings.xml
@@ -1911,7 +1911,20 @@
       <key>Value</key>
       <real>0.7</real>
     </map>
-	<key>AudioStreamingMedia</key>
+    <!-- <FS> [FIRE-35317] Restore AudioLevelWind debug setting -->
+    <key>AudioLevelWind</key>
+    <map>
+      <key>Comment</key>
+      <string>Audio level of wind noise when standing still</string>
+      <key>Persist</key>
+      <integer>1</integer>
+      <key>Type</key>
+      <string>F32</string>
+      <key>Value</key>
+      <real>0.5</real>
+    </map>
+    <!-- </FS> -->
+    <key>AudioStreamingMedia</key>
     <map>
       <key>Comment</key>
       <string>Enable streaming</string>

--- a/indra/newview/llvieweraudio.cpp
+++ b/indra/newview/llvieweraudio.cpp
@@ -650,8 +650,11 @@ void audio_update_wind(bool force_update)
         // whereas steady-state avatar walk velocity is only 3.2 m/s.
         // Without this the world feels desolate on first login when you are
         // standing still.
-        const F32 WIND_LEVEL = 0.5f;
+        // <FS> [FIRE-35317] Restore AudioLevelWind debug setting
+        //const F32 WIND_LEVEL = 0.5f;
+        static LLUICachedControl<F32> WIND_LEVEL("AudioLevelWind", 0.5f);
         LLVector3 scaled_wind_vec = gWindVec * WIND_LEVEL;
+        // </FS>
 
         // Mix in the avatar's motion, subtract because when you walk north,
         // the apparent wind moves south.


### PR DESCRIPTION
[FIRE-35317](https://jira.firestormviewer.org/browse/FIRE-35317)

LindenLabs a while ago removed the AudioLevelWind debug setting since they considered it "unused". 
This PR simply reverts this change and brings it back, since there are some users who wish to disable to wind sound when hovering still.