### PR TITLE
FIRE-34775: For OpenSim switch back to PST/PDT

### DIFF
--- a/indra/llcommon/llstring.cpp
+++ b/indra/llcommon/llstring.cpp
@@ -31,6 +31,7 @@
 #include "llfasttimer.h"
 #include "llsd.h"
 #include <vector>
+#include "llviewernetwork.h" // <FS/> Access to GridManager
 
 #if LL_WINDOWS
 #include "llwin32headers.h"
@@ -1628,12 +1629,17 @@ bool LLStringUtil::formatDatetime(std::string& replacement, std::string token,
         }
         else
         {
-#if 0
+// FIRE-34775 : Switch back to PST/PDT
+#ifdef OPENSIM
             // EXT-1565 : Zai Lynch, James Linden : 15/Oct/09
             // [BSI] Feedback: Viewer clock mentions SLT, but would prefer it to show PST/PDT
             // "slt" = Second Life Time, which is deprecated.
             // If not utc or user local time, fallback to Pacific time
-            replacement = LLStringOps::getPacificDaylightTime() ? "PDT" : "PST";
+            if (LLGridManager::getInstance()->isInSecondLife()) {
+               replacement = "SLT";
+            } else {
+               replacement = LLStringOps::getPacificDaylightTime() ? "PDT" : "PST";
+            }
 #else
             // SL-20370 : Steeltoe Linden : 29/Sep/23
             // Change "PDT" to "SLT" on menu bar


### PR DESCRIPTION
Based on FIRE-34775, switching back to PST/PDT for the OpenSim version, retaining SLT at SL. I don't have a test environment, but this probably works.