### PR TITLE
Hop protocol fixes and negative Z coordinate OpenSim support

### DIFF
--- a/indra/llui/llurlentry.cpp
+++ b/indra/llui/llurlentry.cpp
@@ -1249,7 +1249,7 @@ void LLUrlEntryParcel::processParcelInfo(const LLParcelData& parcel_data)
 //
 LLUrlEntryPlace::LLUrlEntryPlace()
 {
-    mPattern = boost::regex("((hop://[-\\w\\.\\:\\@]+/)|((x-grid-location-info://[-\\w\\.]+/region/)|(secondlife://)))\\S+/?(\\d+/\\d+/\\d+|\\d+/\\d+)/?", // <AW: hop:// protocol>
+    mPattern = boost::regex("((hop://[-\\w\\.\\:\\@]+/)|((x-grid-location-info://[-\\w\\.]+/region/)|(secondlife://)))\\S+(?:/?(-?\\d+/-?\\d+/-?\\d+|-?\\d+/-?\\d+)/?)?", // <AW: hop:// protocol>
                             boost::regex::perl|boost::regex::icase);
     mMenuName = "menu_url_slurl.xml";
     mTooltip = LLTrans::getString("TooltipSLURL");

--- a/indra/newview/llfloaterworldmap.cpp
+++ b/indra/newview/llfloaterworldmap.cpp
@@ -57,6 +57,8 @@
 #include "llnotificationsutil.h"
 #include "llregionhandle.h"
 #include "llscrolllistctrl.h"
+#include "llviewernetwork.h" // <FS/> Access to GridManager
+#include "lfsimfeaturehandler.h" // <FS/> hyperGridURL()
 #include "llslurl.h"
 #include "lltextbox.h"
 #include "lltoolbarview.h"
@@ -77,6 +79,7 @@
 #include "llmapimagetype.h"
 #include "llweb.h"
 #include "llsliderctrl.h"
+#include "llspinctrl.h" // <FS/> setMinValue
 #include "message.h"
 #include "llwindow.h"           // copyTextToClipboard()
 #include <algorithm>
@@ -396,9 +399,16 @@ bool LLFloaterWorldMap::postBuild()
     mLandmarkIcon = getChild<LLUICtrl>("landmark_icon");
     mLocationIcon = getChild<LLUICtrl>("location_icon");
 
+    // <FS> [FIRE-35333] OpenSim needs to be able to adjust the minValue
+    /*
     mTeleportCoordSpinX = getChild<LLUICtrl>("teleport_coordinate_x");
     mTeleportCoordSpinY = getChild<LLUICtrl>("teleport_coordinate_y");
     mTeleportCoordSpinZ = getChild<LLUICtrl>("teleport_coordinate_z");
+    */
+    mTeleportCoordSpinX = getChild<LLSpinCtrl>("teleport_coordinate_x");
+    mTeleportCoordSpinY = getChild<LLSpinCtrl>("teleport_coordinate_y");
+    mTeleportCoordSpinZ = getChild<LLSpinCtrl>("teleport_coordinate_z");
+    // </FS>
 
     LLComboBox *avatar_combo = getChild<LLComboBox>("friend combo");
     avatar_combo->selectFirstItem();
@@ -518,6 +528,15 @@ void LLFloaterWorldMap::onOpen(const LLSD& key)
     {
         centerOnTarget(false);
     }
+
+    // <FS> [FIRE-35333] OpenSim allows Z coordinates to be negative based on MinSimHeight
+    if (!LLGridManager::getInstance()->isInSecondLife())
+    {
+        LLViewerRegion* regionp = gAgent.getRegion();
+        F32 min_sim_height = regionp ? regionp->getMinSimHeight() : 0.f;
+        mTeleportCoordSpinZ->setMinValue(min_sim_height);
+    }
+    // </FS>
 }
 
 // static
@@ -1003,7 +1022,12 @@ void LLFloaterWorldMap::updateLocation()
                 // Set the current SLURL
 // <FS:CR> Aurora-sim var region teleports
                 //mSLURL = LLSLURL(agent_sim_name, gAgent.getPositionGlobal());
-                mSLURL = LLSLURL(agent_sim_name, gAgent.getPositionAgent());
+                // <FS> [FIRE-35268] OpenSim support for when on other grids
+                if (LLGridManager::getInstance()->isInSecondLife())
+                    mSLURL = LLSLURL(agent_sim_name, gAgent.getPositionAgent());
+                else
+                    mSLURL = LLSLURL(LFSimFeatureHandler::instance().hyperGridURL(), agent_sim_name, gAgent.getPositionAgent());
+                // </FS>
 // </FS:CR>
             }
         }
@@ -1056,7 +1080,12 @@ void LLFloaterWorldMap::updateLocation()
 //      if ( gotSimName )
         {
             // mSLURL = LLSLURL(sim_name, pos_global);
-            mSLURL = LLSLURL(sim_info->getName(), sim_info->getGlobalOrigin(), pos_global);
+            // <FS> [FIRE-35268] OpenSim support for when on other grids
+            if (LLGridManager::getInstance()->isInSecondLife())
+                mSLURL = LLSLURL(sim_info->getName(), gAgent.getPositionAgent());
+            else
+                mSLURL = LLSLURL(LFSimFeatureHandler::instance().hyperGridURL(), sim_info->getName(), gAgent.getPositionAgent());
+            // </FS>
         }
 // </FS:Beq pp Oren>
         else
@@ -1079,7 +1108,18 @@ void LLFloaterWorldMap::updateLocation()
 void LLFloaterWorldMap::trackURL(const std::string& region_name, S32 x_coord, S32 y_coord, S32 z_coord)
 {
     LLSimInfo* sim_info = LLWorldMap::getInstance()->simInfoFromName(region_name);
-    z_coord = llclamp(z_coord, 0, 4096);
+    // <FS> [FIRE-35333] OpenSim allows Z coordinates to be negative based on MinSimHeight
+    if (!LLGridManager::getInstance()->isInSecondLife())
+    {
+        LLViewerRegion* regionp = gAgent.getRegion();
+        F32 min_sim_height = regionp ? regionp->getMinSimHeight() : 0.f;
+        z_coord = llclamp(z_coord, min_sim_height, 4096);
+    }
+    else
+    {
+        z_coord = llclamp(z_coord, 0, 4096);
+    }
+    // </FS>
     if (sim_info)
     {
         LLVector3 local_pos;

--- a/indra/newview/llfloaterworldmap.h
+++ b/indra/newview/llfloaterworldmap.h
@@ -245,9 +245,16 @@ private:
     LLUICtrl*               mLocationIcon = nullptr;
 
     LLSearchEditor*         mLocationEditor = nullptr;
+    // <FS> [FIRE-35333] OpenSim needs to be able to adjust the minValue
+    /*
     LLUICtrl*               mTeleportCoordSpinX = nullptr;
     LLUICtrl*               mTeleportCoordSpinY = nullptr;
     LLUICtrl*               mTeleportCoordSpinZ = nullptr;
+    */
+    LLSpinCtrl*             mTeleportCoordSpinX = nullptr;
+    LLSpinCtrl*             mTeleportCoordSpinY = nullptr;
+    LLSpinCtrl*             mTeleportCoordSpinZ = nullptr;
+    // </FS>
 
     LLSliderCtrl*           mZoomSlider = nullptr;
 

--- a/indra/newview/lltracker.cpp
+++ b/indra/newview/lltracker.cpp
@@ -546,7 +546,12 @@ void LLTracker::drawBeacon(LLVector3 pos_agent, std::string direction, LLColor4 
         height = pos_agent.mV[2];
     }
 
-    nRows = (U32)ceil((BEACON_ROWS * height) / MAX_HEIGHT);
+    // <FS> [FIRE-35333] OpenSim allows Z coordinates to be negative based on MinSimHeight
+    if (height < 0.f)
+        nRows = 0;
+    else
+        nRows = (U32)ceil((BEACON_ROWS * height) / MAX_HEIGHT);
+    // </FS>
     if(nRows<2) nRows=2;
     rowHeight = height / nRows;
 
@@ -557,7 +562,10 @@ void LLTracker::drawBeacon(LLVector3 pos_agent, std::string direction, LLColor4 
 
     F32 x = x_axis.mV[0];
     F32 y = x_axis.mV[1];
-    F32 z = 0.f;
+    // <FS> [FIRE-35333] OpenSim allows Z coordinates to be negative based on MinSimHeight
+    //F32 z = 0.f;
+    F32 z = llmin(height, 0.f);
+    // </FS>
     F32 z_next;
 
     F32 a,an;


### PR DESCRIPTION
Fixes all problems in the two following Jira issues-
https://jira.firestormviewer.org/browse/FIRE-35268
https://jira.firestormviewer.org/browse/FIRE-35333

1. Copying the SLurl on the world map in OpenSim, now correctly creates the SLurl of the grid you are on (you will need to wait a few seconds on a new grid, since the viewer doesn't receive the latest grids simulation features and grid info until a few seconds after arriving. Attempting to immediately copy the SLurl on a new grid will still have the old grid url. There is no  easy way around this without fixing the overarching race condition issue on grid swapping)
2. Hop protocol urls in nearby chat and IM's now get correctly hyperlinked if the coordinates are missing, or if the Z value in the coordinate is negative (supported by OpenSim)
3. The world map now allows you to enter a Z value less than 0 depending on the regions MinSimHeight (This requires an OpenSim server update to fully support, since currently even though building and being at negative Z values are supported, attempting to teleport to one sends you to 128,128,128 until it gets fixed in the near future).

Side fixes related to above changes:
1. Fixed the tracker beacon when it was tracking a coordinate with a negative Z value to no longer underflow due to using U32 and causing a viewer freeze.