### PR TITLE
Fix GLTF texture panel bugs and inconsistencies compared to SLViewer

### DIFF
--- a/indra/newview/fspanelface.cpp
+++ b/indra/newview/fspanelface.cpp
@@ -220,10 +220,10 @@ void getSelectedGLTFMaterialMaxRepeats(LLGLTFMaterial::TextureInfo channel, F32&
 //
 
 // local preview of material changes
-class LLRenderMaterialFunctor : public LLSelectedTEFunctor
+class FSRenderMaterialFunctor : public LLSelectedTEFunctor
 {
 public:
-    LLRenderMaterialFunctor(const LLUUID &id)
+    FSRenderMaterialFunctor(const LLUUID &id)
         : mMatId(id)
     {
     }
@@ -249,10 +249,10 @@ private:
 // TODO: look at how to handle local textures, especially when saving materials
 // - Would be nice if we had this in its own file so we could include it from both sides ... -Zi
 //
-class LLRenderMaterialOverrideFunctor : public LLSelectedNodeFunctor
+class FSRenderMaterialOverrideFunctor : public LLSelectedNodeFunctor
 {
 public:
-    LLRenderMaterialOverrideFunctor(
+    FSRenderMaterialOverrideFunctor(
         LLGLTFMaterial* material_to_apply,
         U32 unsaved_changes
     )
@@ -1100,7 +1100,7 @@ void FSPanelFace::draw()
         getGLTFMaterial(mat);
 
         LLObjectSelectionHandle selected_objects = LLSelectMgr::getInstance()->getSelection();
-        LLRenderMaterialOverrideFunctor override_func(mat, mUnsavedChanges);
+        FSRenderMaterialOverrideFunctor override_func(mat, mUnsavedChanges);
         selected_objects->applyToNodes(&override_func);
 
         LLGLTFMaterialList::flushUpdates();

--- a/indra/newview/fspanelface.cpp
+++ b/indra/newview/fspanelface.cpp
@@ -732,9 +732,6 @@ void FSPanelFace::onMatTabChange()
     static S32 last_mat = -1;
     if( auto curr_mat = getCurrentMaterialType(); curr_mat != last_mat )
     {
-        // Fixes some UI desync
-        updateUI(true);
-
         LLSelectNode* node = LLSelectMgr::getInstance()->getSelection()->getFirstNode();
         LLViewerObject* objectp = node ? node->getObject() : NULL;
         if(objectp)
@@ -760,6 +757,16 @@ void FSPanelFace::onMatTabChange()
                 }
             }
         }
+
+        // Since we allow both PBR and BP textures to be applied at the same time,
+        // we need to hide or show the GLTF material only locally based on the current tab.
+        if (curr_mat != MATMEDIA_PBR)
+            LLSelectMgr::getInstance()->hideGLTFMaterial();
+        else
+            LLSelectMgr::getInstance()->showGLTFMaterial();
+
+        // Fixes some UI desync
+        updateUI(true);
     }
 }
 

--- a/indra/newview/fspanelface.h
+++ b/indra/newview/fspanelface.h
@@ -485,6 +485,7 @@ private:
 
     // Dirty flags - taken from llmaterialeditor.cpp ... LL please put this in a .h! -Zi
     U32 mUnsavedChanges; // flags to indicate individual changed parameters
+    U32 mRevertedChanges; // flags to indicate individual reverted parameters
 
     // Hey look everyone, a type-safe alternative to copy and paste! :)
     //

--- a/indra/newview/llface.cpp
+++ b/indra/newview/llface.cpp
@@ -1462,13 +1462,6 @@ bool LLFace::getGeometryVolume(const LLVolume& volume,
     // LLMaterial* mat = tep->getMaterialParams().get();
     LLMaterial* mat = tep ? tep->getMaterialParams().get() : 0;
     // </FS:ND>
-    // <FS:Beq> show legacy when editing the fallback materials.
-    static LLCachedControl<bool> showSelectedinBP(gSavedSettings, "FSShowSelectedInBlinnPhong");
-    if( gltf_mat && getViewerObject()->isSelected() && showSelectedinBP )
-    {
-        gltf_mat = nullptr;
-    }
-    // </FS:Beq>
 
     F32 r = 0, os = 0, ot = 0, ms = 0, mt = 0, cos_ang = 0, sin_ang = 0;
 

--- a/indra/newview/llselectmgr.h
+++ b/indra/newview/llselectmgr.h
@@ -1024,6 +1024,8 @@ public:
     // (edit linked parts, select face)
     bool selectGetNoIndividual();
 // </FS:Zi>
+    void showGLTFMaterial(); // <FS/> [FIRE-35138] Show the GLTF Material since we are no longer in BP
+    void hideGLTFMaterial(); // <FS/> [FIRE-35138] Hide the GLTF Material since we are currently in BP
 };
 
 // *DEPRECATED: For callbacks or observers, use

--- a/indra/newview/llviewerobject.cpp
+++ b/indra/newview/llviewerobject.cpp
@@ -7881,6 +7881,39 @@ void LLViewerObject::setRenderMaterialIDs(const LLUUID& id)
     setRenderMaterialID(-1, id);
 }
 
+// <FS> [FIRE-35138] Helpers for GLTF Materials since we support PBR and BP at same time
+void LLViewerObject::saveGLTFMaterials()
+{
+    if (!mSavedGLTFMaterialIds.empty())
+    {
+        // Already saved, no need to do it again
+        return;
+    }
+
+    for (S32 te = 0; te < getNumTEs(); ++te)
+    {
+        mSavedGLTFMaterialIds.emplace_back(getRenderMaterialID(te));
+
+        LLPointer<LLGLTFMaterial> old_override = getTE(te)->getGLTFMaterialOverride();
+        if (old_override.notNull())
+        {
+            LLGLTFMaterial* copy = new LLGLTFMaterial(*old_override);
+            mSavedGLTFOverrideMaterials.emplace_back(copy);
+        }
+        else
+        {
+            mSavedGLTFOverrideMaterials.emplace_back(nullptr);
+        }
+    }
+}
+
+void LLViewerObject::clearSavedGLTFMaterials()
+{
+    mSavedGLTFMaterialIds.clear();
+    mSavedGLTFOverrideMaterials.clear();
+}
+// </FS>
+
 void LLViewerObject::setRenderMaterialIDs(const LLRenderMaterialParams* material_params, bool local_origin)
 {
     if (!local_origin)

--- a/indra/newview/llviewerobject.h
+++ b/indra/newview/llviewerobject.h
@@ -100,6 +100,9 @@ typedef void (*inventory_callback)(LLViewerObject*,
                                    S32 serial_num,
                                    void*);
 
+// <FS> [FIRE-35138] typedef for saved GLTF override materials
+typedef std::vector<LLPointer<LLGLTFMaterial> > gltf_materials_vec_t;
+
 // for exporting textured materials from SL
 struct LLMaterialExportInfo
 {
@@ -135,6 +138,10 @@ protected:
         LLNetworkData *data;
     };
     std::unordered_map<U16, ExtraParameter*> mExtraParameterList;
+    // <FS> [FIRE-35138] Saved GLTF materials to be restored when needed
+    uuid_vec_t mSavedGLTFMaterialIds;
+    gltf_materials_vec_t mSavedGLTFOverrideMaterials;
+    // </FS>
 
 public:
     typedef std::list<LLPointer<LLViewerObject> > child_list_t;
@@ -203,6 +210,13 @@ public:
     // update_server - if true, will send updates to server and clear most overrides
     void setRenderMaterialID(S32 te, const LLUUID& id, bool update_server = true, bool local_origin = true);
     void setRenderMaterialIDs(const LLUUID& id);
+
+    // <FS> [FIRE-35138] Helpers for GLTF Materials since we support PBR and BP at same time
+    const uuid_vec_t& getSavedGLTFMaterialIds() const { return mSavedGLTFMaterialIds; };
+    const gltf_materials_vec_t& getSavedGLTFOverrideMaterials() const { return mSavedGLTFOverrideMaterials; };
+    void saveGLTFMaterials();
+    void clearSavedGLTFMaterials();
+    // </FS>
 
     virtual bool    isHUDAttachment() const { return false; }
     virtual bool    isTempAttachment() const;

--- a/indra/newview/llvovolume.cpp
+++ b/indra/newview/llvovolume.cpp
@@ -5663,14 +5663,6 @@ void LLVolumeGeometryManager::registerFace(LLSpatialGroup* group, LLFace* facep,
     auto* gltf_mat = (LLFetchedGLTFMaterial*)te->getGLTFRenderMaterial();
     llassert(gltf_mat == nullptr || dynamic_cast<LLFetchedGLTFMaterial*>(te->getGLTFRenderMaterial()) != nullptr);
 
-    // <FS:Beq> show legacy when editing the fallback materials.
-    static LLCachedControl<bool> showSelectedinBP(gSavedSettings, "FSShowSelectedInBlinnPhong");
-    if( gltf_mat && facep->getViewerObject()->isSelected() && showSelectedinBP )
-    {
-        gltf_mat = nullptr;
-    }
-    // </FS:Beq>
-
     if (gltf_mat != nullptr)
     {
         mat_id = gltf_mat->getHash(); // TODO: cache this hash
@@ -6880,14 +6872,6 @@ U32 LLVolumeGeometryManager::genDrawInfo(LLSpatialGroup* group, U32 mask, LLFace
 
             const LLTextureEntry* te = facep->getTextureEntry();
             LLGLTFMaterial* gltf_mat = te->getGLTFRenderMaterial();
-
-            // <FS:Beq> show legacy when editing the fallback materials.
-            static LLCachedControl<bool> showSelectedinBP(gSavedSettings, "FSShowSelectedInBlinnPhong");
-            if( gltf_mat && facep->getViewerObject()->isSelected() && showSelectedinBP )
-            {
-                gltf_mat = nullptr;
-            }
-            // </FS:Beq>
 
             if (hud_group && gltf_mat == nullptr)
             { //all hud attachments are fullbright


### PR DESCRIPTION
[FIRE-32413](https://jira.firestormviewer.org/browse/FIRE-32413)
[FIRE-34261](https://jira.firestormviewer.org/browse/FIRE-34261)
[FIRE-34350](https://jira.firestormviewer.org/browse/FIRE-34350)
[FIRE-35138](https://jira.firestormviewer.org/browse/FIRE-35138)
[FIRE-35173](https://jira.firestormviewer.org/browse/FIRE-35173)

While using the legacy LL texture panel instead of the FS alternative one, attempting to edit GLTF settings will cause textures on the material to be reverted/removed.
This was caused by the LLRenderMaterialOverrideFunctor intended for the FS texture panel to be used for the regular one, which resulted in it not applying settings properly. This PR simply renames the functor so it is only used for the FS texture panel and not the LL texture panel.
Additionally, when selecting a texture and clicking the cancel button using the FS texture panel, the chosen texture does not get reverted. This was caused by the FS texture panels LLRenderMaterialOverrideFunctor not implementing reverting changes if a texture selection had been cancelled. This PR reimplements reverting the texture if the selection has been cancelled.
Lastly, when both a PBR material and BP is applied at the same time, viewing the model with the BP tab selected caused the object to display completely incorrectly and parts of the PBR material were applying ontop of BP.
This was caused by the GLTF overrides not being correctly removed when on the BP tab. This PR correctly hides and restores the GLTF material on selected objects when changing between PBR and BP.