### PR TITLE
Fix object and HUD clicking in mouselook mode

### DIFF
--- a/indra/newview/llviewerwindow.cpp
+++ b/indra/newview/llviewerwindow.cpp
@@ -5426,6 +5426,14 @@ LLPickInfo LLViewerWindow::pickImmediate(S32 x, S32 y_from_bot, bool pick_transp
         pick_transparent = true;
     }
 
+    // <FS:Sek> Pick from center of screen in mouselook
+    if (gAgentCamera.getCameraMode() == CAMERA_MODE_MOUSELOOK)
+    {
+        x = gViewerWindow->getWorldViewRectScaled().getWidth() / 2;
+        y_from_bot = gViewerWindow->getWorldViewRectScaled().getHeight() / 2;
+    }
+    // </FS:Sek>
+
     // shortcut queueing in mPicks and just update mLastPick in place
     MASK key_mask = gKeyboard->currentMask(true);
     mLastPick = LLPickInfo(LLCoordGL(x, y_from_bot), key_mask, pick_transparent, pick_rigged, pick_particle, pick_reflection_probe, true, false, NULL);


### PR DESCRIPTION
### Fix object and HUD clicking in mouselook mode

### Description
In the current implementation, clicking objects in mouselook (first-person) mode does not function correctly because the viewer attempts to pick using the hidden mouse cursor location instead of the center of the screen where the crosshair is located. This leads to objects being unclickable, significantly impairing the usability of mouselook mode.

This pull request fixes the issue by adjusting the picking logic within `LLViewerWindow::pickImmediate()` to always use the center coordinates of the viewport when in mouselook mode.

### Implementation Details
Modified `indra/newview/llviewerwindow.cpp`:

```cpp
// <FS:Sek> Pick from center of screen in mouselook
if (gAgentCamera.getCameraMode() == CAMERA_MODE_MOUSELOOK)
{
    x = gViewerWindow->getWorldViewRectScaled().getWidth() / 2;
    y_from_bot = gViewerWindow->getWorldViewRectScaled().getHeight() / 2;
}
// </FS:Sek>
```

### Testing
1. Enter mouselook mode.
2. Attempt to click interactive objects (doors, buttons, scripted objects).
3. Verify clicks now accurately register at the screen's center (crosshair), and object interactions function as expected.
4. Also verify that HUDs can be clicked correctly in mouselook mode (hold Alt).

### Documentation
No additional documentation changes are necessary, as this restores intended functionality.

### Related Issues
This fix addresses a known upstream issue: [[Second Life Viewer Issue #1519](https://github.com/secondlife/viewer/issues/1519)]

### Additional Notes
This fix was tested on Linux. I'm submitting this fix directly to Firestorm because building and testing Firestorm on Linux is significantly easier than the official LL viewer.