### PR TITLE
minor: null pointer warnings

### DIFF
--- a/indra/llcommon/lltreeiterators.h
+++ b/indra/llcommon/lltreeiterators.h
@@ -372,8 +372,31 @@ private:
         // reset flag after each step
         mSkipChildren = false;
     }
+
     /// equality
-    bool equal(const self_type& that) const { return this->mPending == that.mPending; }
+    // <FS:Error-LP0> Possible null warning in mPending.
+    // bool equal(const self_type& that) const { return this->mPending == that.mPending; }
+    bool equal(const self_type& that) const
+    {
+       // Check if both mPending lists are of the same size
+       if (this->mPending.size() != that.mPending.size())
+       {
+           return false;
+       }
+   
+       // Compare each element in mPending safely
+       for (size_t i = 0; i < this->mPending.size(); ++i)
+       {
+           if (this->mPending[i] != that.mPending[i])
+           {
+               return false;
+           }
+       }
+   
+       return true;
+    }
+    // <FS:Error-LP0> [END] Possible null warning in mPending.
+
     /// implement dereference/indirection operators
     ptr_type& dereference() const { return const_cast<ptr_type&>(mPending.back()); }
 

--- a/indra/newview/llfloaterregioninfo.cpp
+++ b/indra/newview/llfloaterregioninfo.cpp
@@ -2184,29 +2184,38 @@ bool LLPanelRegionTerrainInfo::sendUpdate()
     return true;
 }
 
+// <FS:Error-LP0> Quieting lambda compiling warning: No-op function to consume cancel events
+static void onCancelCallback(LLUICtrl* /*ctrl*/, const LLSD& /*param*/)
+{
+    // Do nothing
+}
+
 void LLPanelRegionTerrainInfo::initMaterialCtrl(LLTextureCtrl*& ctrl, const std::string& name, S32 index)
 {
     ctrl = findChild<LLTextureCtrl>(name, true);
     if (!ctrl) return;
 
     // consume cancel events, otherwise they will trigger commit callbacks
-    ctrl->setOnCancelCallback([](LLUICtrl* ctrl, const LLSD& param) {});
+    // ctrl->setOnCancelCallback([](LLUICtrl* ctrl, const LLSD& param) {});  
+    ctrl->setOnCancelCallback(boost::bind(&onCancelCallback, _1, _2));
+// <FS:Error-LP0> [END] Quieting lambda compiling warning: No-op function to consume cancel events
+
     ctrl->setCommitCallback(
         [this, index](LLUICtrl* ctrl, const LLSD& param)
-    {
-        if (!mMaterialScaleUCtrl[index]
-            || !mMaterialScaleVCtrl[index]
-            || !mMaterialRotationCtrl[index]
-            || !mMaterialOffsetUCtrl[index]
-            || !mMaterialOffsetVCtrl[index]) return;
+        {
+            if (!mMaterialScaleUCtrl[index]
+                || !mMaterialScaleVCtrl[index]
+                || !mMaterialRotationCtrl[index]
+                || !mMaterialOffsetUCtrl[index]
+                || !mMaterialOffsetVCtrl[index]) return;
 
-        mMaterialScaleUCtrl[index]->setValue(1.f);
-        mMaterialScaleVCtrl[index]->setValue(1.f);
-        mMaterialRotationCtrl[index]->setValue(0.f);
-        mMaterialOffsetUCtrl[index]->setValue(0.f);
-        mMaterialOffsetVCtrl[index]->setValue(0.f);
-        onChangeAnything();
-    });
+            mMaterialScaleUCtrl[index]->setValue(1.f);
+            mMaterialScaleVCtrl[index]->setValue(1.f);
+            mMaterialRotationCtrl[index]->setValue(0.f);
+            mMaterialOffsetUCtrl[index]->setValue(0.f);
+            mMaterialOffsetVCtrl[index]->setValue(0.f);
+            onChangeAnything();
+        });
 }
 
 bool LLPanelRegionTerrainInfo::callbackTextureHeights(const LLSD& notification, const LLSD& response)


### PR DESCRIPTION
This update is not related to any known issues and is not intended to modify any current behavior other than to hush the compiler.
