### PR TITLE
[FIRE-35381] Fixes experience and item urls showing as raw urls

### DIFF
--- a/indra/llui/llurlentry.cpp
+++ b/indra/llui/llurlentry.cpp
@@ -1249,7 +1249,7 @@ void LLUrlEntryParcel::processParcelInfo(const LLParcelData& parcel_data)
 //
 LLUrlEntryPlace::LLUrlEntryPlace()
 {
-    mPattern = boost::regex("((hop://[-\\w\\.\\:\\@]+/)|((x-grid-location-info://[-\\w\\.]+/region/)|(secondlife://)))\\S+(?:/?(-?\\d+/-?\\d+/-?\\d+|-?\\d+/-?\\d+)/?)?", // <AW: hop:// protocol>
+    mPattern = boost::regex("((hop://[-\\w\\.\\:\\@]+/[^/]+/?)|((hop://[-\\w\\.\\:\\@]+/)|((x-grid-location-info://[-\\w\\.]+/region/)|(secondlife://)))\\S+/?(\\d+/\\d+/-?\\d+|\\d+/-?\\d+)/?)$", // <AW: hop:// protocol>
                             boost::regex::perl|boost::regex::icase);
     mMenuName = "menu_url_slurl.xml";
     mTooltip = LLTrans::getString("TooltipSLURL");


### PR DESCRIPTION
[FIRE-35381](https://jira.firestormviewer.org/browse/FIRE-35381)

Fixes the LLUrlEntryPlace regex pattern by and ensuring both hop:// and secondlife:// urls only apply to those which are meant for locations.