### PR TITLE
[FIRE-35294] Make minerjr's chat console hiding work with toast chat too

### DIFF
--- a/indra/newview/llfloaterimnearbychathandler.cpp
+++ b/indra/newview/llfloaterimnearbychathandler.cpp
@@ -96,6 +96,13 @@ public:
         {
             ctrl->getSignal()->connect(boost::bind(&LLFloaterIMNearbyChatScreenChannel::updateToastFadingTime, this));
         }
+        // <FS:darl> [FIRE-35039 > FIRE-35294] Add flag to show/hide the on-screen console
+        ctrl = gSavedSettings.getControl("FSShowOnscreenConsole").get();
+        if (ctrl)
+        {
+            ctrl->getSignal()->connect(boost::bind(&LLFloaterIMNearbyChatScreenChannel::removeToastsFromChannel, this));
+        }
+        // </FS:darl> [FIRE-35039 > FIRE-35294] Add flag to show/hide the on-screen console
     }
 
     void addChat    (LLSD& chat);
@@ -693,6 +700,14 @@ void LLFloaterIMNearbyChatHandler::processChat(const LLChat& chat_msg,
         return;
     }
     // </FS:Ansariel>
+
+    // <FS:darl> [FIRE-35039 > FIRE-35294] Add flag to show/hide the on-screen console
+    static LLUICachedControl<bool> showOnscreenConsole("FSShowOnscreenConsole");
+    if (!showOnscreenConsole)
+    {
+        return;
+    }
+    // </FS:darl> [FIRE-35039 > FIRE-35294]
 
     static LLCachedControl<bool> useChatBubbles(gSavedSettings, "UseChatBubbles");
     static LLCachedControl<bool> fsBubblesHideConsoleAndToasts(gSavedSettings, "FSBubblesHideConsoleAndToasts");


### PR DESCRIPTION
The feature that minerjr added with FIRE-35039 covered the vintage style console chat, and added the checkbox corner on the chat toolbar icon. It bothered me that this feature didn't work for toast chat since that's my preferred method, so I am providing my implementation that covers this case.