### PR TITLE
Fix mouselook leftclick disabled by passon from `llTakeControl`

### DIFF
--- a/indra/newview/llagent.cpp
+++ b/indra/newview/llagent.cpp
@@ -4140,15 +4140,14 @@ void LLAgent::initOriginGlobal(const LLVector3d &origin_global)
 
 bool LLAgent::leftButtonGrabbed() const
 {
-    const bool camera_mouse_look = gAgentCamera.cameraMouselook();
-    // <FS:Sek> Fix mouse look click when only passed on controls are used
-    return (!camera_mouse_look && mControlsTakenCount[CONTROL_LBUTTON_DOWN_INDEX] > 0)
-        || (camera_mouse_look && mControlsTakenCount[CONTROL_ML_LBUTTON_DOWN_INDEX] > 0);
-    //return (!camera_mouse_look && mControlsTakenCount[CONTROL_LBUTTON_DOWN_INDEX] > 0)
-    //    || (camera_mouse_look && mControlsTakenCount[CONTROL_ML_LBUTTON_DOWN_INDEX] > 0)
-    //    || (!camera_mouse_look && mControlsTakenPassedOnCount[CONTROL_LBUTTON_DOWN_INDEX] > 0)
-    //    || (camera_mouse_look && mControlsTakenPassedOnCount[CONTROL_ML_LBUTTON_DOWN_INDEX] > 0);
-    // </FS:Sek>
+    if (gAgentCamera.cameraMouselook())
+    {
+        return mControlsTakenCount[CONTROL_ML_LBUTTON_DOWN_INDEX] > 0;
+    }
+    else
+    {
+        return mControlsTakenCount[CONTROL_LBUTTON_DOWN_INDEX] > 0;
+    }
 }
 
 bool LLAgent::rotateGrabbed() const

--- a/indra/newview/llagent.cpp
+++ b/indra/newview/llagent.cpp
@@ -4141,10 +4141,14 @@ void LLAgent::initOriginGlobal(const LLVector3d &origin_global)
 bool LLAgent::leftButtonGrabbed() const
 {
     const bool camera_mouse_look = gAgentCamera.cameraMouselook();
+    // <FS:Sek> Fix mouse look click when only passed on controls are used
     return (!camera_mouse_look && mControlsTakenCount[CONTROL_LBUTTON_DOWN_INDEX] > 0)
-        || (camera_mouse_look && mControlsTakenCount[CONTROL_ML_LBUTTON_DOWN_INDEX] > 0)
-        || (!camera_mouse_look && mControlsTakenPassedOnCount[CONTROL_LBUTTON_DOWN_INDEX] > 0)
-        || (camera_mouse_look && mControlsTakenPassedOnCount[CONTROL_ML_LBUTTON_DOWN_INDEX] > 0);
+        || (camera_mouse_look && mControlsTakenCount[CONTROL_ML_LBUTTON_DOWN_INDEX] > 0);
+    //return (!camera_mouse_look && mControlsTakenCount[CONTROL_LBUTTON_DOWN_INDEX] > 0)
+    //    || (camera_mouse_look && mControlsTakenCount[CONTROL_ML_LBUTTON_DOWN_INDEX] > 0)
+    //    || (!camera_mouse_look && mControlsTakenPassedOnCount[CONTROL_LBUTTON_DOWN_INDEX] > 0)
+    //    || (camera_mouse_look && mControlsTakenPassedOnCount[CONTROL_ML_LBUTTON_DOWN_INDEX] > 0);
+    // </FS:Sek>
 }
 
 bool LLAgent::rotateGrabbed() const

--- a/indra/newview/llviewerwindow.cpp
+++ b/indra/newview/llviewerwindow.cpp
@@ -5430,14 +5430,6 @@ LLPickInfo LLViewerWindow::pickImmediate(S32 x, S32 y_from_bot, bool pick_transp
         pick_transparent = true;
     }
 
-    // <FS:Sek> Pick from center of screen in mouselook
-    if (gAgentCamera.getCameraMode() == CAMERA_MODE_MOUSELOOK)
-    {
-        x = gViewerWindow->getWorldViewRectScaled().getWidth() / 2;
-        y_from_bot = gViewerWindow->getWorldViewRectScaled().getHeight() / 2;
-    }
-    // </FS:Sek>
-
     // shortcut queueing in mPicks and just update mLastPick in place
     MASK key_mask = gKeyboard->currentMask(true);
     mLastPick = LLPickInfo(LLCoordGL(x, y_from_bot), key_mask, pick_transparent, pick_rigged, pick_particle, pick_reflection_probe, true, false, NULL);


### PR DESCRIPTION
### Fix mouselook leftclick disabled by passon from `llTakeControl`

### Description
This PR reverts #107 and removes `pass_on` checking from `LLAgent::leftButtonGrabbed()` 

The old PR did not address the actual issue, and the `if` condition was always false, so it did nothing and should be removed.

The actual issue is caused by `LLAgent::leftButtonGrabbed()` checks the `TakenPassedOnCount` on top of the `TakenCount` unlike every other `...Grabbed()` function below it

This causes `llTakeControls(CONTROL_ML_LBUTTON, TRUE, TRUE)` to work incorrectly and prevent mouse look click even though it should not do that

### Testing

Here is a minimal LSL script to reproduce and test the issue
Simply placing this into an object and accepting the permission will prevent clicking in mouse look if this fix is not present
(changing the script and removing the `llTakeControl` or adjusting its values will re-enable clicking)

```lsl
default {
    state_entry() {
        llRequestPermissions(llGetOwner(), PERMISSION_TAKE_CONTROLS);
    }
    run_time_permissions(integer perm) {
        if(PERMISSION_TAKE_CONTROLS & perm) {
            llTakeControls(CONTROL_ML_LBUTTON, TRUE, TRUE);              
        }
    }
    control(key id, integer level, integer edge)
    {}
}
```

### Documentation

ref: [Wiki: llTakeControls](https://wiki.secondlife.com/wiki/LlTakeControls)
According to the wiki this restores an intended behavior 