### PR TITLE
[FIRE-35390] Fix loading old presets with RenderSkyAutoAdjustLegacy and RenderSkyAmbientScale causing graphical inconsistency

### DIFF
--- a/indra/newview/app_settings/graphic_preset_controls.xml
+++ b/indra/newview/app_settings/graphic_preset_controls.xml
@@ -74,13 +74,11 @@
 		<string>RenderShaderLightingMaxLevel</string>
 		<string>RenderShadowDetail</string>
 		<string>RenderShadowResolutionScale</string>
-		<string>RenderSkyAmbientScale</string>
 		<string>RenderSkyAutoAdjustAmbientScale</string>
 		<string>RenderSkyAutoAdjustBlueDensityScale</string>
 		<string>RenderSkyAutoAdjustBlueHorizonScale</string>
 		<string>RenderSkyAutoAdjustSunColorScale</string>
 		<string>RenderSkyAutoAdjustHDRScale</string>
-		<string>RenderSkyAutoAdjustLegacy</string>
 		<string>RenderSkyAutoAdjustProbeAmbiance</string>
 		<string>RenderSkySunlightScale</string>
 		<string>RenderSSAOIrradianceScale</string>

--- a/indra/newview/llpresetsmanager.cpp
+++ b/indra/newview/llpresetsmanager.cpp
@@ -538,6 +538,11 @@ void LLPresetsManager::loadPreset(const std::string& subdirectory, std::string n
         {
             gSavedSettings.setString("PresetGraphicActive", name);
 
+            // <FS> [FIRE-35390] Old viewer presets have these as true and 0.7, whereas the equivalent on modern viewers is false and 1.0
+            gSavedSettings.setBOOL("RenderSkyAutoAdjustLegacy", false);
+            gSavedSettings.setF32("RenderSkyAmbientScale", 1.0);
+            // </FS>
+
             // <FS:Ansariel> Update indirect controls
             LLAvatarComplexityControls::setIndirectControls();
 


### PR DESCRIPTION
[FIRE-35390](https://jira.firestormviewer.org/browse/FIRE-35390)

When loading a graphical preset from 7.1.11 or earlier, unless the user had explicitly set RenderSkyAutoAdjustLegacy to false and RenderSkyAmbientScale to 1.0 in debug settings before creating the preset, these debug settings are set as true and 0.7 respectively and get loaded into newer viewers and remains true and 0.7 unless a user manually turns them back to their default values in debug settings.

Setting graphical settings to default does not set this value back to false either (which I believe is intentional so I didn't change this). However, if the users "Default.xml" preset was automatically created on 7.1.11 or earlier, loading that to try and default your settings also sets RenderSkyAutoAdjustLegacy to true and RenderSkyAmbientScale to 0.7 instead of the correct false and 1.0, since the Default.xml is never updated to the newer viewers defaults unless it gets manually deleted from your presets folder.

This debug settings being set to true and 0.7 respectively in recent versions of the viewer causes a major graphical difference depending on the EEP colouring of a region or parcel. This difference can be observed in the linked issue above.

SecondLife Viewer does NOT exhibit this issue since they never save and load both RenderSkyAutoAdjustLegacy and RenderSkyAmbientScale with graphical presets, so as long as someone doesn't manually set it to true in the official viewer, it remains false even loading an old preset.

I could not think of a better solution at this time for this problem. I thought about storing what the values were before loading the preset and then restoring the stored values. But this doesn't help those that have already loaded an old preset or an old default preset before this point on a newer viewer, and loading a newly created one would still have kept the values of the old viewer defaults.

This change will now prevent those setting from being saved in presets in the future, and having RenderSkyAutoAdjustLegacy purposefully set to true and RenderSkyAmbientScale set to anything other than 1.0, and then loading any preset will now set them back to false and 1.0 respectively. 
I believe this is the better trade off than people potentially forever having both of them incorrectly set to old default values, and have no idea about the debug settings to turn set them to the new default values. Since many people will likely load an old preset from 7.1.11 release, or even load the "Default" preset at some point in the future, both of which will force the debug settings to true and 0.7 respectively, with no way to set them to the new default values without knowing about it in debug settings.