### PR TITLE
Add support to area search for filtering reflection probes

### DIFF
--- a/indra/newview/fsareasearch.cpp
+++ b/indra/newview/fsareasearch.cpp
@@ -156,6 +156,7 @@ FSAreaSearch::FSAreaSearch(const LLSD& key) :
     mFilterPhantom(false),
     mFilterAttachment(false),
     mFilterMoaP(false),
+    mFilterReflectionProbe(false),
     mFilterDistance(false),
     mFilterDistanceMin(0),
     mFilterDistanceMax(999999),
@@ -904,6 +905,11 @@ void FSAreaSearch::matchObject(FSObjectProperties& details, LLViewerObject* obje
     }
 
     if (mFilterPermTransfer && !(details.owner_mask & PERM_TRANSFER))
+    {
+        return;
+    }
+
+    if (mFilterReflectionProbe && !objectp->mReflectionProbe.notNull())
     {
         return;
     }
@@ -2240,6 +2246,9 @@ bool FSPanelAreaSearchFilter::postBuild()
     mCheckboxMoaP = getChild<LLCheckBoxCtrl>("filter_moap");
     mCheckboxMoaP->setCommitCallback(boost::bind(&FSPanelAreaSearchFilter::onCommitCheckbox, this));
 
+    mCheckboxReflectionProbe = getChild<LLCheckBoxCtrl>("filter_reflection_probe");
+    mCheckboxReflectionProbe->setCommitCallback(boost::bind(&FSPanelAreaSearchFilter::onCommitCheckbox, this));
+
     mCheckboxPermCopy = getChild<LLCheckBoxCtrl>("filter_perm_copy");
     mCheckboxPermCopy->setCommitCallback(boost::bind(&FSPanelAreaSearchFilter::onCommitCheckbox, this));
 
@@ -2262,6 +2271,7 @@ void FSPanelAreaSearchFilter::onCommitCheckbox()
     mFSAreaSearch->setFilterForSale(mCheckboxForSale->get());
     mFSAreaSearch->setFilterDistance(mCheckboxDistance->get());
     mFSAreaSearch->setFilterMoaP(mCheckboxMoaP->get());
+    mFSAreaSearch->setFilterReflectionProbe(mCheckboxReflectionProbe->get());
 
     if (mCheckboxExcludePhysics->get())
     {

--- a/indra/newview/fsareasearch.cpp
+++ b/indra/newview/fsareasearch.cpp
@@ -167,6 +167,7 @@ FSAreaSearch::FSAreaSearch(const LLSD& key) :
     mBeacons(false),
     mExcludeAttachment(true),
     mExcludeTemporary(true),
+    mExcludeReflectionProbe(false),
     mExcludePhysics(true),
     mExcludeChildPrims(true),
     mExcludeNeighborRegions(true),
@@ -542,6 +543,11 @@ bool FSAreaSearch::isSearchableObject(LLViewerObject* objectp, LLViewerRegion* o
     }
 
     if (mExcludeTemporary && objectp->flagTemporaryOnRez())
+    {
+        return false;
+    }
+
+    if (mExcludeReflectionProbe && objectp->mReflectionProbe.notNull())
     {
         return false;
     }
@@ -2223,6 +2229,10 @@ bool FSPanelAreaSearchFilter::postBuild()
     mCheckboxExcludetemporary->set(true);
     mCheckboxExcludetemporary->setCommitCallback(boost::bind(&FSPanelAreaSearchFilter::onCommitCheckbox, this));
 
+    mCheckboxExcludeReflectionProbes = getChild<LLCheckBoxCtrl>("exclude_reflection_probes");
+    mCheckboxExcludeReflectionProbes->set(false);
+    mCheckboxExcludeReflectionProbes->setCommitCallback(boost::bind(&FSPanelAreaSearchFilter::onCommitCheckbox, this));
+
     mCheckboxExcludeChildPrim = getChild<LLCheckBoxCtrl>("exclude_childprim");
     mCheckboxExcludeChildPrim->set(true);
     mCheckboxExcludeChildPrim->setCommitCallback(boost::bind(&FSPanelAreaSearchFilter::onCommitCheckbox, this));
@@ -2300,6 +2310,19 @@ void FSPanelAreaSearchFilter::onCommitCheckbox()
         mFSAreaSearch->setExcludetemporary(false);
     }
     mFSAreaSearch->setFilterTemporary(mCheckboxTemporary->get());
+
+    if (mCheckboxExcludeReflectionProbes->get())
+    {
+        mFSAreaSearch->setFilterReflectionProbe(false);
+        mCheckboxReflectionProbe->set(false);
+        mCheckboxReflectionProbe->setEnabled(false);
+        mFSAreaSearch->setExcludeReflectionProbe(true);
+    }
+    else
+    {
+        mCheckboxReflectionProbe->setEnabled(true);
+        mFSAreaSearch->setExcludeReflectionProbe(false);
+    }
 
     if (mCheckboxExcludeAttachment->get())
     {

--- a/indra/newview/fsareasearch.h
+++ b/indra/newview/fsareasearch.h
@@ -141,6 +141,7 @@ public:
     void setFilterPhantom(bool b) { mFilterPhantom = b; }
     void setFilterAttachment(bool b) { mFilterAttachment = b; }
     void setFilterMoaP(bool b) { mFilterMoaP = b; }
+    void setFilterReflectionProbe(bool b) { mFilterReflectionProbe = b; }
 
     void setRegexSearch(bool b) { mRegexSearch = b; }
     void setBeacons(bool b) { mBeacons = b; }
@@ -240,6 +241,7 @@ private:
     bool mFilterPhantom;
     bool mFilterAttachment;
     bool mFilterMoaP;
+    bool mFilterReflectionProbe;
 
     bool mFilterForSale;
     S32 mFilterForSaleMin;
@@ -382,6 +384,7 @@ private:
     LLCheckBoxCtrl* mCheckboxLocked;
     LLCheckBoxCtrl* mCheckboxPhantom;
     LLCheckBoxCtrl* mCheckboxMoaP;
+    LLCheckBoxCtrl* mCheckboxReflectionProbe;
     LLCheckBoxCtrl* mCheckboxDistance;
     LLSpinCtrl* mSpinDistanceMinValue;
     LLSpinCtrl* mSpinDistanceMaxValue;

--- a/indra/newview/fsareasearch.h
+++ b/indra/newview/fsareasearch.h
@@ -148,6 +148,7 @@ public:
 
     void setExcludeAttachment(bool b) { mExcludeAttachment = b; }
     void setExcludetemporary(bool b) { mExcludeTemporary = b; }
+    void setExcludeReflectionProbe(bool b) { mExcludeReflectionProbe = b; }
     void setExcludePhysics(bool b) { mExcludePhysics = b; }
     void setExcludeChildPrims(bool b) { mExcludeChildPrims = b; }
     void setExcludeNeighborRegions(bool b) { mExcludeNeighborRegions = b; }
@@ -231,6 +232,7 @@ private:
 
     bool mExcludeAttachment;
     bool mExcludeTemporary;
+    bool mExcludeReflectionProbe;
     bool mExcludePhysics;
     bool mExcludeChildPrims;
     bool mExcludeNeighborRegions;
@@ -396,6 +398,7 @@ private:
     LLCheckBoxCtrl* mCheckboxExcludeAttachment;
     LLCheckBoxCtrl* mCheckboxExcludePhysics;
     LLCheckBoxCtrl* mCheckboxExcludetemporary;
+    LLCheckBoxCtrl* mCheckboxExcludeReflectionProbes;
     LLCheckBoxCtrl* mCheckboxExcludeChildPrim;
     LLCheckBoxCtrl* mCheckboxExcludeNeighborRegions;
     LLCheckBoxCtrl* mCheckboxPermCopy;

--- a/indra/newview/skins/default/xui/en/floater_fs_area_search.xml
+++ b/indra/newview/skins/default/xui/en/floater_fs_area_search.xml
@@ -579,6 +579,14 @@
 			 name="exclude_temporary"
 			 label="Temporary"
 			 width="80"/>
+            <check_box
+			 follows="top|left"
+			 top_pad="10"
+			 layout="topleft"
+			 left="10"
+			 name="exclude_reflection_probes"
+			 label="Reflection Probes"
+			 width="80"/>
 			<check_box
 			 follows="top|left"
 			 top_pad="10"

--- a/indra/newview/skins/default/xui/en/floater_fs_area_search.xml
+++ b/indra/newview/skins/default/xui/en/floater_fs_area_search.xml
@@ -378,6 +378,15 @@
 			 name="filter_perm_transfer"
 			 label="Transfer"
 			 width="100"/>
+            <check_box
+			 follows="top|left"
+             top_pad="10"
+			 layout="topleft"
+			 left="10"
+			 name="filter_reflection_probe"
+			 label="Reflection Probes"
+             tool_tip="Includes manual probes only, not auto-probes. Only includes mirror probes if mirrors are enabled in graphics preferences. If reflection coverage is set to none, or the probe is not baked, objects may not be identified."
+			 width="100"/>
 			<check_box
 			 follows="top|left"
 			 height="20"
@@ -416,7 +425,7 @@
 			 layout="topleft"
 			 left_pad="5"
 			 max_val="999999999"
-			 min_val="0"  
+			 min_val="0"
 			 name="max_price"
 			 top_delta="-4"
 			 width="80"/>
@@ -525,7 +534,7 @@
 			 layout="topleft"
 			 left_pad="5"
 			 max_val="999999999"
-			 min_val="0"  
+			 min_val="0"
 			 name="max_distance"
 			 top_delta="-4"
 			 width="80"/>


### PR DESCRIPTION
This PR adds support to area search for filtering reflection probe objects. The most reliable way I was able to get objects to show be detected was checking for a object coupled to the object, but am open to suggestions for a method that may work better across all circumstances.

![Screenshot From 2025-05-02 19-01-25](https://github.com/user-attachments/assets/cfb5cf59-9fc5-46d1-b3f6-12b54976f4e1)
![Screenshot From 2025-05-02 19-01-52](https://github.com/user-attachments/assets/5e0a016b-afc0-4f1d-8a36-1d605b5d7243)
