### PR TITLE
[FIRE-34791] Fix FullScreen failing on Windows 11 24H2

### DIFF
--- a/indra/newview/llappviewerwin32.cpp
+++ b/indra/newview/llappviewerwin32.cpp
@@ -1034,6 +1034,29 @@ bool LLAppViewerWin32::reportCrashToBugsplat(void* pExcepInfo)
     return false;
 }
 
+bool LLAppViewerWin32::initWindow()
+{
+    // This is a workaround/hotfix for a change in Windows 11 24H2 (and possibly later)
+    // Where the window width and height need to correctly reflect an available FullScreen size
+    if (gSavedSettings.getBOOL("FullScreen"))
+    {
+        DEVMODE dev_mode;
+        ::ZeroMemory(&dev_mode, sizeof(DEVMODE));
+        dev_mode.dmSize = sizeof(DEVMODE);
+        if (EnumDisplaySettings(NULL, ENUM_CURRENT_SETTINGS, &dev_mode))
+        {
+            gSavedSettings.setU32("WindowWidth", dev_mode.dmPelsWidth);
+            gSavedSettings.setU32("WindowHeight", dev_mode.dmPelsHeight);
+        }
+        else
+        {
+            LL_WARNS("AppInit") << "Unable to set WindowWidth and WindowHeight for FullScreen mode" << LL_ENDL;
+        }
+    }
+
+    return LLAppViewer::initWindow();
+}
+
 void LLAppViewerWin32::initLoggingAndGetLastDuration()
 {
     LLAppViewer::initLoggingAndGetLastDuration();

--- a/indra/newview/llappviewerwin32.h
+++ b/indra/newview/llappviewerwin32.h
@@ -46,6 +46,7 @@ public:
     bool reportCrashToBugsplat(void* pExcepInfo) override;
 
 protected:
+    bool initWindow() override; // Override to initialize the viewer's window.
     void initLoggingAndGetLastDuration() override; // Override to clean stack_trace info.
     void initConsole() override; // Initialize OS level debugging console.
     bool initHardwareTest() override; // Win32 uses DX9 to test hardware.


### PR DESCRIPTION
[FIRE-34791](https://jira.firestormviewer.org/browse/FIRE-34791)

Possible fix for FullScreen not working on specific Windows setups based on Rilene Starlights information-
https://jira.firestormviewer.org/browse/FIRE-34791?focusedId=246285&#comment-246285
As well as additional information I discovered here-
https://jira.firestormviewer.org/browse/FIRE-34791?focusedId=246321&#comment-246321

This might not fix the issue as a whole, but it should fix the specific issue relating to what Rilene described which I do believe to be the same issue based on information I found.

Duplicate of my changes that got merged into SLV-
https://github.com/secondlife/viewer/pull/4023
