### PR TITLE
fix potential crash if item doesn't exist in inventory (potentially fixes FIRE-35293)

### DIFF
--- a/indra/newview/aoengine.cpp
+++ b/indra/newview/aoengine.cpp
@@ -999,6 +999,13 @@ void AOEngine::playAnimation(const LLUUID& animation)
     }
 
     LLViewerInventoryItem* item = gInventory.getItem(animation);
+
+    if (!item)
+    {
+        LL_WARNS("AOEngine") << "Inventory item for animation " << animation << " not found." << LL_ENDL;
+        return;
+    }
+
     AOSet::AOAnimation anim;
     anim.mName = item->LLInventoryItem::getName();
     anim.mInventoryUUID = item->getUUID();


### PR DESCRIPTION
This fixes a potential crash in the AO panel.
If an animation does not exist in inventory but exists in the AO panel, it would crash.
This is probably the cause of FIRE-35293
It will now silently exit from the AOEngine::playAnimation method if the animation does not exist in inventory.