### PR TITLE
Remove outdated kfmclient use

### DIFF
--- a/indra/newview/linux_tools/launch_url.sh
+++ b/indra/newview/linux_tools/launch_url.sh
@@ -51,12 +51,6 @@ if [ ! -z "$GNOME_DESKTOP_SESSION_ID" ] && which gnome-open >/dev/null; then
     exit
 fi
 
-# Launch the default KDE browser.
-if [ ! -z "$KDE_FULL_SESSION" ] && which kfmclient >/dev/null; then
-    kfmclient openURL "$URL" &
-    exit
-fi
-
 # List of browser commands that will be tried in the order listed. x-www-browser
 # will be tried first, which is a debian alternative.
 BROWSER_COMMANDS="      \


### PR DESCRIPTION
kfmclient will open all links in konquerer as the browser, ignoring any choices made in KDE settings' Default Application. This causes URL opening to not follow the expected behavior of respecting user set default application.

Searching for kfmclient leads me to believe this is no longer a used tool with KDE: https://techbase.kde.org/Development/Tools/Using_kfmclient If I understand this correctly, the replacement had been to use `kioclient exec` instead of `kfmclient openURL`. Trying this change the script works as intended in testing and opens the correct default browser atleast for me. But I believe that methods like xdg-open will cover more cases and is the more modern approach. So I would propose to skip the special check for KDE entirely.

