### PR TITLE
Option to short-circuit repeated environment keybinds to shared environment

### DIFF
--- a/indra/newview/app_settings/settings.xml
+++ b/indra/newview/app_settings/settings.xml
@@ -26299,5 +26299,16 @@ Change of this parameter will affect the layout of buttons in notification toast
       <key>Value</key>
       <integer>1</integer>
     </map>
+    <key>FSRepeatedEnvTogglesShared</key>
+    <map>
+      <key>Comment</key>
+      <string>Whether repeated presses of sky preset shortcuts should revert to shared environment</string>
+      <key>Persist</key>
+      <integer>1</integer>
+      <key>Type</key>
+      <string>Boolean</string>
+      <key>Value</key>
+      <integer>0</integer>
+    </map>
   </map>
 </llsd>

--- a/indra/newview/llviewermenu.cpp
+++ b/indra/newview/llviewermenu.cpp
@@ -11787,6 +11787,19 @@ class LLWorldEnvSettings : public view_listener_t
 #endif
 // </FS:Beq>
 
+        // <FS:Darl> Redundant environment toggles revert to shared environment
+        LLSettingsSky::ptr_t sky = LLEnvironment::instance().getEnvironmentFixedSky(LLEnvironment::ENV_LOCAL);
+        LLUUID skyid = (sky) ? sky->getAssetId() : LLUUID::null;
+        bool repeatedEnvTogglesShared = gSavedSettings.getBOOL("FSRepeatedEnvTogglesShared");
+
+        if(repeatedEnvTogglesShared && ((skyid == LLEnvironment::KNOWN_SKY_SUNRISE       && event_name == "sunrise") ||
+                                        (skyid == LLEnvironment::KNOWN_SKY_MIDDAY        && event_name == "noon") ||
+                                        (skyid == LLEnvironment::KNOWN_SKY_LEGACY_MIDDAY && event_name == "legacy noon") ||
+                                        (skyid == LLEnvironment::KNOWN_SKY_SUNSET        && event_name == "sunset") ||
+                                        (skyid == LLEnvironment::KNOWN_SKY_MIDNIGHT      && event_name == "midnight")))
+            event_name = "region";
+        // </FS:Darl>
+
         if (event_name == "sunrise")
         {
             // <FS:Beq> FIRE-29926 - allow manually selected environments to have a user defined transition time.

--- a/indra/newview/skins/default/xui/en/panel_preferences_firestorm.xml
+++ b/indra/newview/skins/default/xui/en/panel_preferences_firestorm.xml
@@ -218,6 +218,17 @@
          left="10"
          width="500"
          tool_tip="Restores the current environment settings after next login."/>
+        <check_box
+         top_pad="5"
+         control_name="FSRepeatedEnvTogglesShared"
+         follows="left|top"
+         height="16"
+         initial_value="true"
+         name="FSRepeatedEnvTogglesShared"
+         label="Repeated environment keybinds revert to shared environment"
+         left="10"
+         width="500"
+         tool_tip="Causes repeated keybinds (e.g. ctrl+shift+y) to alternate between the requested preset &amp; shared environment"/>
     </panel>
 
 


### PR DESCRIPTION
This PR adds a setting to simplify toggling between menu presets (e.g. ctrl+shift+Y for midday) and shared environment. When the setting is true and the requested preset is already active, it overrides the request to shared settings.

Setting is disabled by default.

https://github.com/user-attachments/assets/6184bddf-e4d3-4197-9156-3b2cfc06d3ad

