### PR TITLE
Add support for canceled restarts to region restart channel reporting

### DIFF
--- a/indra/newview/llviewermessage.cpp
+++ b/indra/newview/llviewermessage.cpp
@@ -6671,6 +6671,7 @@ void process_alert_core(const std::string& message, bool modal)
         if (text.substr(0, restart_cancelled.length()) == restart_cancelled)
         {
             LLFloaterRegionRestarting::close();
+            fs_report_region_restart_to_channel(-1); // <FS:Darl> Announce region restart to a defined chat channel
         }
 
             std::string new_msg =LLNotifications::instance().getGlobalString(text);
@@ -8729,7 +8730,14 @@ void fs_report_region_restart_to_channel(S32 seconds)
         msg->addUUIDFast(_PREHASH_AgentID, gAgent.getID());
         msg->addUUIDFast(_PREHASH_SessionID, gAgent.getSessionID());
         msg->nextBlockFast(_PREHASH_ChatData);
-        msg->addStringFast(_PREHASH_Message, "region_restart_in:" + llformat("%d", seconds));
+        if(seconds >= 0)
+        {
+            msg->addStringFast(_PREHASH_Message, "region_restart_in:" + llformat("%d", seconds));
+        }
+        else // Input is a negative number
+        {
+            msg->addStringFast(_PREHASH_Message, "region_restart_cancelled");
+        }
         msg->addU8Fast(_PREHASH_Type, CHAT_TYPE_WHISPER);
         msg->addS32("Channel", channel);
         gAgent.sendReliableMessage();


### PR DESCRIPTION
This PR adds support for reporting canceled restarts so that scripts users write to avoid them by way of scripted teleports won't be teleported away thinking the restart is still on track.

I spoke with Pantera about the best way to implement this, and exchanged thoughts with Lucia Nightfire who holds the only known public implementation of this feature that Pantera or I are aware of. My original intention was to send a -1 value to the chat message however it was understood that this would break Lucia's existing scripted item on the marketplace.
- Link to the product: https://marketplace.secondlife.com/p/Box-Region-Restart-Evader-HUD-Updated-April-8-2022/23463179

The settled-upon best course forward after speaking with both parties was for a different message entirely to be sent, which this PR implements as `region_restart_cancelled`.