### PR TITLE
Bugfix: Correct floater XUI title overrun on Starlight CUI object profile view

### DIFF
--- a/indra/newview/skins/starlightcui/xui/en/sidepanel_task_info.xml
+++ b/indra/newview/skins/starlightcui/xui/en/sidepanel_task_info.xml
@@ -67,7 +67,7 @@
      font="SansSerifHuge"
      height="26"
      layout="topleft"
-     left_pad="10"
+     left="48"
      name="title"
      text_color="LtGray"
      top="0"


### PR DESCRIPTION
This PR adjusts the title over the object profile popup on the Starlight CUI skin. This was reported in the Firestorm Support English chat by Vulcan Viper.

## Fixed (PR)
![Screenshot From 2025-05-14 16-26-43](https://github.com/user-attachments/assets/b89d983f-5daa-4413-8348-7a6c37e3287a)

## Broken (Current)
![Screenshot From 2025-05-14 16-27-29](https://github.com/user-attachments/assets/ba1bfdd2-e9e5-4181-a407-d461d001710c)
