### PR TITLE
[FIRE-34494] fixes unable to open an IM with someone who started a group chat

### DIFF
--- a/indra/newview/fsfloaterim.cpp
+++ b/indra/newview/fsfloaterim.cpp
@@ -1253,6 +1253,22 @@ FSFloaterIM* FSFloaterIM::show(const LLUUID& session_id)
     if (!gIMMgr->hasSession(session_id))
         return nullptr;
 
+    // <AS:chanayane> [FIRE-34494] fixes unable to open an IM with someone who started a group chat
+    // Prevent showing non-IM sessions in FSFloaterIM::show()
+    LLIMModel::LLIMSession* session = LLIMModel::getInstance()->findIMSession(session_id);
+    if (!session || ( 
+           IM_NOTHING_SPECIAL          != session->mType
+        && IM_SESSION_P2P_INVITE       != session->mType
+        && IM_SESSION_INVITE           != session->mType
+        && IM_SESSION_CONFERENCE_START != session->mType
+        && IM_SESSION_GROUP_START      != session->mType))
+    {
+        LL_WARNS("IMVIEW") << "Attempted to show FSFloaterIM for non-IM session: "
+                        << (session ? std::to_string(session->mType) : "null") << LL_ENDL;
+        return nullptr;
+    }
+    // </AS:chanayane>
+
     if (!isChatMultiTab())
     {
         //hide all

--- a/indra/newview/llimview.cpp
+++ b/indra/newview/llimview.cpp
@@ -3905,14 +3905,53 @@ LLUUID LLIMMgr::addSession(
     //works only for outgoing ad-hoc sessions
     if (new_session &&
         ((IM_NOTHING_SPECIAL == dialog) || (IM_SESSION_P2P_INVITE == dialog) || (IM_SESSION_CONFERENCE_START == dialog)) &&
-        ids.size())
+        // <AS:chanayane> [FIRE-34494] fix unable to open an IM with someone who started a group chat
+        //ids.size())   
+        !ids.empty())
+        // </AS:chanayane>
     {
         session = LLIMModel::getInstance()->findAdHocIMSession(ids);
         if (session)
         {
-            new_session = false;
-            session_id = session->mSessionID;
+// <AS:chanayane> [FIRE-34494] fix unable to open an IM with someone who started a group chat
+            // new_session = false;
+            // session_id = session->mSessionID;
+
+            // Protect against wrong session type reuse (e.g., conference reused for IM)
+            if (session->mType != dialog)
+            {
+                LL_WARNS("IMVIEW") << "Discarding mismatched session type reuse: expected " 
+                   << dialog << " but found " << session->mType 
+                   << " for session " << session->mSessionID 
+                   << ". This may indicate improper reuse of a session object." << LL_ENDL;
+                session = nullptr;
+                new_session = true;
+                session_id = computeSessionID(dialog, other_participant_id);
+            }
+            else
+            {
+                new_session = false;
+                session_id = session->mSessionID;
+            }
         }
+    }
+
+    if (session && session->mType != dialog)
+    {
+        // Prevent reusing a session of the wrong type
+        session = nullptr;
+        new_session = true;
+
+        // Recompute session ID depending on dialog type
+        if (dialog == IM_SESSION_CONFERENCE_START)
+        {
+            session_id.generate();
+        }
+        else
+        {
+            session_id = computeSessionID(dialog, other_participant_id);
+        }
+// </AS:chanayane>
     }
 
     //Notify observers that a session was added


### PR DESCRIPTION
This was an annoying bug! It should be fixed with that PR.

**Summary**
This patch resolves an issue where the viewer incorrectly reused an existing session with the wrong dialog type (e.g., treating a group chat as a one-on-one IM). This led to confusing behavior when opening IMs with users who had previously initiated a group conversation.

**Changes**
_llimview.cpp:_

- Added type-checking logic to LLIMMgr::addSession() to ensure sessions are reused only if their mType matches the requested dialog.
- If a session exists but has a mismatched type, a new session is created instead.
- Used computeSessionID() for deterministic session creation where appropriate; generated a random UUID for conference sessions.
- Logged mismatches with LL_WARNS for debug visibility.

_fsfloaterim.cpp:_

- Patched FSFloaterIM::show() to check the underlying session's type before proceeding.
- Ensured the floater is only reused if the session type matches the intended dialog type.

**Impact**
- Prevents UI confusion caused by reusing session floaters with incorrect context.
- Fixes inability to open a new IM with someone who previously initiated a group chat.
- Improves internal consistency of session management logic.