### PR TITLE
Set the font color of search highlighted text

### DIFF
--- a/indra/llui/lltextbase.cpp
+++ b/indra/llui/lltextbase.cpp
@@ -1530,7 +1530,19 @@ void LLTextBase::draw()
             bg_rect.intersectWith( text_rect );
 
         gl_rect_2d( text_rect, bg_color, true );
+
+        // <FS> Additionally set the font color of highlighted text instead of using LabelTextColor
+        const LLColor4& font_color = ll::ui::SearchableControl::getHighlightFontColor();
+        setColor(font_color);
+        // </FS>
     }
+    // <FS> Set the font color back to LabelTextColor if not highlighted
+    else
+    {
+        const LLColor4& font_color = LLUIColorTable::instance().getColor("LabelTextColor");
+        setColor(font_color);
+    }
+    // </FS>
 
     bool should_clip = mClip || mScroller != NULL;
     // <FS:Zi> Fix text bleeding at top edge of scrolling text editors

--- a/indra/newview/skins/default/xui/en/panel_preferences_colors.xml
+++ b/indra/newview/skins/default/xui/en/panel_preferences_colors.xml
@@ -1902,7 +1902,7 @@
      label_height="0"
      layout="topleft"
      left="350"
-     top_pad="5"
+     top_pad="9"
      name="area_search_beacon_color"
      tool_tip="Choose area search beacon color"
      width="44">


### PR DESCRIPTION
As requested by Anastasia and Beq, this change makes it so when searching for something in preferences, it sets the font colour of items found in the actual pages, and not just the tab and menu buttons.
Note: This is different from LL's behaviour, they always just use "LabelTextColor" even when things are highlighted.

Also fixes a slight misalignment of the area search beacon colour picker.