### PR TITLE
[FIRE-34257] Fix mousing over and clicking objects with FSSelectCopyableOnly or FSSelectLockedOnly enabled

### DIFF
--- a/indra/newview/llselectmgr.cpp
+++ b/indra/newview/llselectmgr.cpp
@@ -7969,19 +7969,20 @@ bool LLSelectMgr::canSelectObject(LLViewerObject* object, bool ignore_select_own
             // only select my own objects
             return false;
         }
+
+        // <FS:Ansariel> FIRE-14593: Option to select only copyable objects
+        if (!object->permCopy() && gSavedSettings.getBOOL("FSSelectCopyableOnly"))
+        {
+            return false;
+        }
+        // </FS:Ansariel>
+        // <FS:Ansariel> FIRE-17696: Option to select only locked objects
+        if (gSavedSettings.getBOOL("FSSelectLockedOnly") && object->permMove() && !object->isPermanentEnforced())
+        {
+            return false;
+        }
+        // </FS:Ansariel>// Can't select objects that are not owned by you or group
     }
-    // <FS:Ansariel> FIRE-14593: Option to select only copyable objects
-    if (!object->permCopy() && gSavedSettings.getBOOL("FSSelectCopyableOnly"))
-    {
-        return false;
-    }
-    // </FS:Ansariel>
-    // <FS:Ansariel> FIRE-17696: Option to select only locked objects
-    if (gSavedSettings.getBOOL("FSSelectLockedOnly") && object->permMove() && !object->isPermanentEnforced())
-    {
-        return false;
-    }
-    // </FS:Ansariel>
 
     // Can't select orphans
     if (object->isOrphaned()) return false;


### PR DESCRIPTION
[FIRE-34257](https://jira.firestormviewer.org/browse/FIRE-34257)

Fixes the above issue by moving the code dealing with Select only Copyable and Select only Locked objects inside the "!ignore_select_owned" block, which only fires when selecting an object in build/edit mode. When just mousing over and clicking on objects without build/edit mode up, ignore_select_owned is true and therefore is won't prevent the object from still being clicked with either of the 2 above settings enabled.

This behaviour makes those options behave like both SelectOwnedOnly and SelectMovableOnly already did.