### PR TITLE
Improves GLTF hiding while object is displaying Blinn-Phong

### DIFF
--- a/indra/newview/fspanelface.cpp
+++ b/indra/newview/fspanelface.cpp
@@ -737,7 +737,6 @@ void FSPanelFace::onMatTabChange()
         if(objectp)
         {
             last_mat = curr_mat;
-            gSavedSettings.setBOOL("FSShowSelectedInBlinnPhong", (curr_mat == MATMEDIA_MATERIAL));
             // Iterate through the linkset and mark each object for update
             for (LLObjectSelection::iterator iter = LLSelectMgr::getInstance()->getSelection()->begin();
                  iter != LLSelectMgr::getInstance()->getSelection()->end(); ++iter)
@@ -760,6 +759,7 @@ void FSPanelFace::onMatTabChange()
 
         // Since we allow both PBR and BP textures to be applied at the same time,
         // we need to hide or show the GLTF material only locally based on the current tab.
+        gSavedSettings.setBOOL("FSShowSelectedInBlinnPhong", (curr_mat == MATMEDIA_MATERIAL));
         if (curr_mat != MATMEDIA_PBR)
             LLSelectMgr::getInstance()->hideGLTFMaterial();
         else

--- a/indra/newview/llviewerobject.h
+++ b/indra/newview/llviewerobject.h
@@ -214,6 +214,7 @@ public:
     const uuid_vec_t& getSavedGLTFMaterialIds() const { return mSavedGLTFMaterialIds; };
     const gltf_materials_vec_t& getSavedGLTFOverrideMaterials() const { return mSavedGLTFOverrideMaterials; };
     void saveGLTFMaterials();
+    void updateSavedGLTFMaterial(S32 te);
     void clearSavedGLTFMaterials();
     // </FS>
 


### PR DESCRIPTION
Follow up to this PR-
https://github.com/FirestormViewer/phoenix-firestorm/pull/106

This PR further improves the functionality of hiding and reverting the GLTF material while in BP mode by ensuring updates from the server (such as changes made by other users) correctly update the locally saved GLTF materials so they can be reverted properly. Also fixes a bug while making texture changes in BP mode was reapplying the GLTF materials since the message from the server didn't match the locally null'd GLTF materials.

This should be much more consistent than it was before and desync less if other people have made changes to the same objects you have been previously editing in BP mode. 
There is still 1 minor issue, where if two people are editing the same object at the same time, one person changing PBR the other BP, it will cause a desync for the person editing BP, and to fix it you can do either: 1. Change to the PBR tab, unselecting and reselecting the object will resync it. Or 2. Relog.