### PR TITLE
Small Improvement to Performance Auto Tune feature

### DIFF
--- a/indra/newview/app_settings/settings_firestorm.xml
+++ b/indra/newview/app_settings/settings_firestorm.xml
@@ -230,6 +230,42 @@
     <key>Value</key>
     <integer>0</integer>
   </map>
+  
+  <key>AutoTuneRenderFarClipMin</key>
+  <map>
+    <key>Comment</key>
+    <string>The lowest draw distance that auto tune is allowed to use</string>
+    <key>Persist</key>
+    <integer>1</integer>
+    <key>Type</key>
+    <string>F32</string>
+    <key>Value</key>
+    <real>32.0</real>
+  </map>
+  
+  <key>AutoTuneRenderFarClipTarget</key>
+  <map>
+    <key>Comment</key>
+    <string>The draw distance that auto tune will try to achieve</string>
+    <key>Persist</key>
+    <integer>1</integer>
+    <key>Type</key>
+    <string>F32</string>
+    <key>Value</key>
+    <real>256.0</real>
+  </map>
+  
+  <key>AutoTuneImpostorFarAwayDistance</key>
+  <map>
+    <key>Comment</key>
+    <string>Avatars beyond this range will automatically be optimized</string>
+    <key>Persist</key>
+    <integer>1</integer>
+    <key>Type</key>
+    <string>F32</string>
+    <key>Value</key>
+    <real>64.0</real>
+  </map>
 
   <key>FSChatWindow</key>
   <map>

--- a/indra/newview/fsfloaterperformance.cpp
+++ b/indra/newview/fsfloaterperformance.cpp
@@ -162,8 +162,11 @@ bool FSFloaterPerformance::postBuild()
     mNearbyPanel->getChild<LLSliderCtrl>("RenderAvatarMaxART")->setCommitCallback(boost::bind(&FSFloaterPerformance::updateMaxRenderTime, this));
 
     LLAvatarComplexityControls::setIndirectMaxArc();
+
+    // This seems counter intuitive, since what if a user wants to set this lower or higher than their currently set view distance,
+    // and also have it persist upon viewer startup? Commenting this out for now, so if it is desired it can be easily brought back.
     // store the current setting as the users desired reflection detail and DD
-    if(!LLPerfStats::tunables.userAutoTuneEnabled)
+    /*if(!LLPerfStats::tunables.userAutoTuneEnabled)
     {
         if (gSavedDrawDistance)
         {
@@ -173,7 +176,7 @@ bool FSFloaterPerformance::postBuild()
         {
             gSavedSettings.setF32("AutoTuneRenderFarClipTarget", LLPipeline::RenderFarClip);
         }
-    }
+    }*/
 
     return true;
 }

--- a/indra/newview/skins/default/xui/en/floater_fs_performance.xml
+++ b/indra/newview/skins/default/xui/en/floater_fs_performance.xml
@@ -297,6 +297,10 @@
             label="Avatars and Scene"
             name="av_and_scene"
             value="1" />
+        <combo_box.item
+            label="Scene Only"
+            name="scene_only"
+            value="2" />
       </combo_box>
       <button
           height="16"

--- a/indra/newview/skins/default/xui/en/panel_fs_performance_autotune.xml
+++ b/indra/newview/skins/default/xui/en/panel_fs_performance_autotune.xml
@@ -154,7 +154,7 @@ follows="top|left"
 name="pref_dd_autotune"
 left_pad="20"
 min_val="32"
-max_val="256"
+max_val="1024"
 width="140">
 </spinner>
 <text


### PR DESCRIPTION
Currently the Performance Auto Tune feature (located under World->Improve Graphics Speed... or Advanced->Performance Tools->Improve Graphics Speed...) only has the options for Avatar only, or Avatar and Scene, there is no Scene only option. In the SLViewer, there is a Scene only option and the LLPerfStats implementation that Firestorm uses for the feature is already setup to work with Scene only.

This PR simply adds the dropdown option for Scene Only to be in-line with SLViewer and also for those who don't want the feature impacting Avatar Complexity. Another small change the PR makes, is increasing the preferred render distance maximum from 256 all the way up to 1024. Since I see no reason it should be limited to 256 if you are around regions that are easy to render and you could easily render over 256m at a target framerate, and then once you go to a more demanding region, it will dynamically drop it back under anyway.

I also changed a few of the auto tune settings that didn't persist to now persist, to save people the trouble of having to change them every single time you use the feature, which some people may want on all the time and kept it on across logging out and back in.


TODO: Translation request to add this additional combo box value (scene_only) for "FSTuningFPSStrategy" in all the floater_fs_performance.xml translations.