### PR TITLE
[FIRE-35529] Add missing filters on object inventories for Starlight and Vintage skins

### DIFF
--- a/indra/newview/skins/starlight/xui/en/floater_tools.xml
+++ b/indra/newview/skins/starlight/xui/en/floater_tools.xml
@@ -3333,16 +3333,27 @@ Low ↔ Lwst
              top_pad="1"
              name="btn_reset_scripts"
              width="90" />
+            <filter_editor
+             follows="left|top|right"
+             label="Enter filter text"
+             layout="topleft"
+             top="45"
+             left="10"
+             max_length_chars="300"
+             highlight_text_field="true"
+             name="contents_filter"
+             height="23"
+             width="275" />
             <panel_inventory_object
              border="true"
              border_visible="true"
              bevel_style="in"
              follows="left|top|right"
-             height="345"
+             height="325"
              layout="topleft"
              left="10"
              name="contents_inventory"
-             top="50"
+             top="70"
              width="275" />
 		</panel>
         </tab_container>

--- a/indra/newview/skins/starlightcui/xui/en/floater_tools.xml
+++ b/indra/newview/skins/starlightcui/xui/en/floater_tools.xml
@@ -3334,16 +3334,27 @@ Low ↔ Lwst
              top_pad="1"
              name="btn_reset_scripts"
              width="90" />
+            <filter_editor
+             follows="left|top|right"
+             label="Enter filter text"
+             layout="topleft"
+             top="45"
+             left="10"
+             max_length_chars="300"
+             highlight_text_field="true"
+             name="contents_filter"
+             height="23"
+             width="275" />
             <panel_inventory_object
              border="true"
              border_visible="true"
              bevel_style="in"
              follows="left|top|right"
-             height="345"
+             height="325"
              layout="topleft"
              left="10"
              name="contents_inventory"
-             top="50"
+             top="70"
              width="275" />
 		</panel>
         </tab_container>

--- a/indra/newview/skins/vintage/xui/en/floater_tools.xml
+++ b/indra/newview/skins/vintage/xui/en/floater_tools.xml
@@ -3335,16 +3335,27 @@ Low ↔ Lwst
              top_pad="1"
              name="btn_reset_scripts"
              width="90" />
+            <filter_editor
+             follows="left|top|right"
+             label="Enter filter text"
+             layout="topleft"
+             top="45"
+             left="10"
+             max_length_chars="300"
+             highlight_text_field="true"
+             name="contents_filter"
+             height="23"
+             width="275" />
             <panel_inventory_object
              border="true"
              border_visible="true"
              bevel_style="in"
              follows="left|top|right"
-             height="345"
+             height="325"
              layout="topleft"
              left="10"
              name="contents_inventory"
-             top="50"
+             top="70"
              width="275" />
 		</panel>
         </tab_container>


### PR DESCRIPTION
[FIRE-35529](https://jira.firestormviewer.org/browse/FIRE-35529)

Fixes the above issue