### PR TITLE
Revert on removing RenderSkyAmbientScale and RenderSkyAutoAdjustLegacy from graphic_preset_controls.xml

### DIFF
--- a/indra/newview/app_settings/graphic_preset_controls.xml
+++ b/indra/newview/app_settings/graphic_preset_controls.xml
@@ -74,11 +74,13 @@
 		<string>RenderShaderLightingMaxLevel</string>
 		<string>RenderShadowDetail</string>
 		<string>RenderShadowResolutionScale</string>
+		<string>RenderSkyAmbientScale</string>
 		<string>RenderSkyAutoAdjustAmbientScale</string>
 		<string>RenderSkyAutoAdjustBlueDensityScale</string>
 		<string>RenderSkyAutoAdjustBlueHorizonScale</string>
 		<string>RenderSkyAutoAdjustSunColorScale</string>
 		<string>RenderSkyAutoAdjustHDRScale</string>
+		<string>RenderSkyAutoAdjustLegacy</string>
 		<string>RenderSkyAutoAdjustProbeAmbiance</string>
 		<string>RenderSkySunlightScale</string>
 		<string>RenderSSAOIrradianceScale</string>


### PR DESCRIPTION
Follow up to this-
https://github.com/FirestormViewer/phoenix-firestorm/pull/114

Reverting the changes of removing RenderSkyAmbientScale and RenderSkyAutoAdjustLegacy from the graphic_preset_controls.xml, but still leaving them being defaulted for now.
The reason being is, when LL eventually bump their featuretable version number, we want these settings to be defaulted by that forced reset (due to the problem discussed in the above PR and the issue it links).
Also, after the bump to the version, we can then remove the need for defaulting the value on preset load and instead change it to just not load the setting from presets, even though it is still being saved and resettable.

This way we solve- 1. The bump fixes incorrect settings being kept after a preset load of an old preset without the need to load a preset. 2. After the bump, no longer requiring to default on a preset load for those who want to change the values themselves and persist across preset loads


A much further explanation of the problem is explained here-
https://jira.firestormviewer.org/browse/FIRE-35532?focusedId=246718&#comment-246718