### PR TITLE
primfeed: cannot use string with constexpr; revert to static const

### DIFF
--- a/indra/newview/fsfloaterprimfeed.cpp
+++ b/indra/newview/fsfloaterprimfeed.cpp
@@ -337,7 +337,7 @@ void FSPrimfeedPhotoPanel::sendPhoto()
 {
     auto ratingToString = [&](int rating)
     {
-        constexpr std::array<std::string, 4> RATING_NAMES = {
+        static const std::array<std::string, 4> RATING_NAMES = {
             "general",   // 1
             "moderate",  // 2
             "adult",     // 3


### PR DESCRIPTION
(I'm an idiot and closed the previous PR by mistake while updating my fork. I'm re-opening it using a feature branch to avoid doing that again.)

Original PR: https://github.com/FirestormViewer/phoenix-firestorm/pull/133

# Problem

https://github.com/FirestormViewer/phoenix-firestorm/commit/51c461500dabd9014786b695e9f29f7ed96edab7 introduced the use of `constexpr` with a `std::string`. This is C++20 compliant but not supported by gcc-11, which is our target compiler for Linux.

As a result, Linux users are currently unable to build Firestorm without a patch.

# Solutions

While we could replace the string with a stringview, LLSD params (just a few lines down) will complain because it expects a string, so more refactoring would be required.

Reverting from `constexpr` back to `static const` is the simplest and least impactful solution, and is what this PR does.

A third option would be to target a newer compiler version, but that would be a pretty significant effort. Still, this is the second or third time I've had to ask someone to change something which was technically C++20 but not supported by gcc-11. (See compatibility here: https://gcc.gnu.org/projects/cxx-status.html) I assume it will continue to happen, so maybe that's worth considering.


Anyway, sorry for the mess.