### PR TITLE
Fix preference highlighted text font being applied to chat input field

### DIFF
--- a/indra/llui/lltextbase.cpp
+++ b/indra/llui/lltextbase.cpp
@@ -1530,19 +1530,7 @@ void LLTextBase::draw()
             bg_rect.intersectWith( text_rect );
 
         gl_rect_2d( text_rect, bg_color, true );
-
-        // <FS> Additionally set the font color of highlighted text instead of using LabelTextColor
-        const LLColor4& font_color = ll::ui::SearchableControl::getHighlightFontColor();
-        setColor(font_color);
-        // </FS>
     }
-    // <FS> Set the font color back to LabelTextColor if not highlighted
-    else
-    {
-        const LLColor4& font_color = LLUIColorTable::instance().getColor("LabelTextColor");
-        setColor(font_color);
-    }
-    // </FS>
 
     bool should_clip = mClip || mScroller != NULL;
     // <FS:Zi> Fix text bleeding at top edge of scrolling text editors

--- a/indra/newview/llsearchableui.cpp
+++ b/indra/newview/llsearchableui.cpp
@@ -36,6 +36,16 @@ ll::prefs::SearchableItem::~SearchableItem()
 void ll::prefs::SearchableItem::setNotHighlighted()
 {
     mCtrl->setHighlighted( false );
+
+    // <FS> Set the font color back to LabelTextColor if not highlighted
+    // This is really ugly but I don't know how it can be done better
+    LLTextBase* mCtrlTextBase = (LLTextBase*)dynamic_cast<const LLTextBase*>(mCtrl);
+    if (mCtrlTextBase)
+    {
+        const LLColor4& font_color = LLUIColorTable::instance().getColor("LabelTextColor");
+        mCtrlTextBase->setColor(font_color);
+    }
+    // </FS>
 }
 
 bool ll::prefs::SearchableItem::hightlightAndHide( LLWString const &aFilter )
@@ -49,13 +59,27 @@ bool ll::prefs::SearchableItem::hightlightAndHide( LLWString const &aFilter )
 
     if( aFilter.empty() )
     {
-        mCtrl->setHighlighted( false );
+        // <FS> Call the setNotHighlighted() method instead to set font color too
+        //mCtrl->setHighlighted( false );
+        setNotHighlighted();
+        // </FS>
         return true;
     }
 
     if( mLabel.find( aFilter ) != LLWString::npos )
     {
         mCtrl->setHighlighted( true );
+
+        // <FS> Set the font color of highlighted text instead of using LabelTextColor
+        // This is really ugly but I don't know how it can be done better
+        LLTextBase* mCtrlTextBase = (LLTextBase*)dynamic_cast<const LLTextBase*>(mCtrl);
+        if (mCtrlTextBase)
+        {
+            const LLColor4& font_color = mCtrl->getHighlightFontColor();
+            mCtrlTextBase->setColor(font_color);
+        }
+        // </FS>
+
         return true;
     }
 


### PR DESCRIPTION
Fixes the issue picked up by Beq where it was changing the text colour of the chat windows input field.

Because of the way LL has the control setup, I needed to break some C++ core guidelines and cast away const to make this work 😅