### PR TITLE
Texture Refactor: Smatter bias and texture scaling

### DIFF
--- a/indra/llmath/llcamera.cpp
+++ b/indra/llmath/llcamera.cpp
@@ -35,10 +35,6 @@ LLCamera::LLCamera() :
     LLCoordFrame(),
     mView(DEFAULT_FIELD_OF_VIEW),
     mAspect(DEFAULT_ASPECT_RATIO),
-    // <FS:minerjr> [FIRE-35081] Blurry prims not changing with graphics settings
-    //mInverseAspect(1.0f / DEFAULT_ASPECT_RATIO),
-    mDrawDistanceMultiplier(1.0f),
-    // </FS:minerjr> [FIRE-35081]
     mViewHeightInPixels( -1 ),          // invalid height
     mNearPlane(DEFAULT_NEAR_PLANE),
     mFarPlane(DEFAULT_FAR_PLANE),
@@ -74,11 +70,6 @@ LLCamera::LLCamera(F32 vertical_fov_rads, F32 aspect_ratio, S32 view_height_in_p
     mNearPlane = llclamp(near_plane, MIN_NEAR_PLANE, MAX_NEAR_PLANE);
     if(far_plane < 0) far_plane = DEFAULT_FAR_PLANE;
     mFarPlane = llclamp(far_plane, MIN_FAR_PLANE, MAX_FAR_PLANE);
-    // <FS:minerjr> [FIRE-35081] Blurry prims not changing with graphics settings 
-    // Store the draw distance multiplier based upon how much bigger/smaller the far plan is then the default (64.0f)
-    mDrawDistanceMultiplier = mFarPlane / DEFAULT_FAR_PLANE;
-    mDrawDistanceMultiplier = mDrawDistanceMultiplier < 1.0f ? 1.0f : mDrawDistanceMultiplier;
-    // </FS:minerjr> [FIRE-35081]
     setView(vertical_fov_rads);
 }
 
@@ -159,11 +150,6 @@ void LLCamera::setNear(F32 near_plane)
 void LLCamera::setFar(F32 far_plane)
 {
     mFarPlane = llclamp(far_plane, MIN_FAR_PLANE, MAX_FAR_PLANE);
-    // <FS:minerjr> [FIRE-35081] Blurry prims not changing with graphics settings 
-    // Store the draw distance multiplier based upon how much bigger/smaller the far plan is then the default (64.0f)
-    mDrawDistanceMultiplier = mFarPlane / DEFAULT_FAR_PLANE;
-    mDrawDistanceMultiplier = mDrawDistanceMultiplier < 1.0f ? 1.0f : mDrawDistanceMultiplier;
-    // </FS:minerjr> [FIRE-35081]
     calculateFrustumPlanes();
 }
 

--- a/indra/llmath/llcamera.h
+++ b/indra/llmath/llcamera.h
@@ -127,11 +127,6 @@ private:
 
     F32 mView;                  // angle between top and bottom frustum planes in radians.
     F32 mAspect;                // width/height
-    // <FS:minerjr> [FIRE-35081] Blurry prims not changing with graphics settings
-    // Store the inverse of the aspect ratio, for the texture's sizes
-    //F32 mInverseAspect;         // height/width
-    F32 mDrawDistanceMultiplier; // mFarPlane / DEFAULT_FAR_PLANE
-    // </FS:minerjr> [FIRE-35081]
     S32 mViewHeightInPixels;    // for ViewHeightInPixels() only
     F32 mNearPlane;
     F32 mFarPlane;
@@ -166,10 +161,6 @@ public:
     F32 getView() const                         { return mView; }               // vertical FOV in radians
     S32 getViewHeightInPixels() const           { return mViewHeightInPixels; }
     F32 getAspect() const                       { return mAspect; }             // width / height
-    // <FS:minerjr> [FIRE-35081] Blurry prims not changing with graphics settings
-    //F32 getInverseAspect() const                { return mInverseAspect; }      // width / height
-    F32 getDrawDistanceMultiplier() const       { return mDrawDistanceMultiplier; } // mFarPlane / DEFAULT_FAR_PLANE (could also include near plane as well)
-    // </FS:minerjr> [FIRE-35081]
     F32 getNear() const                         { return mNearPlane; }          // meters
     F32 getFar() const                          { return mFarPlane; }           // meters
 

--- a/indra/llrender/llimagegl.cpp
+++ b/indra/llrender/llimagegl.cpp
@@ -644,7 +644,7 @@ bool LLImageGL::setSize(S32 width, S32 height, S32 ncomponents, S32 discard_leve
                 // <FS:minerjr> [FIRE-35361] RenderMaxTextureResolution caps texture resolution lower than intended
                 // 2K textures could set the mMaxDiscardLevel above MAX_DISCARD_LEVEL, which would
                 // cause them to not be down-scaled so they would get stuck at 0 discard all the time.
-                mMaxDiscardLevel = llmax(mMaxDiscardLevel, (S8)MAX_DISCARD_LEVEL);
+                mMaxDiscardLevel = llmin(mMaxDiscardLevel, (S8)MAX_DISCARD_LEVEL);
                 // </FS:minerjr> [FIRE-35361]
             }
         }

--- a/indra/newview/app_settings/settings.xml
+++ b/indra/newview/app_settings/settings.xml
@@ -2,6 +2,61 @@
 <llsd xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:noNamespaceSchemaLocation="llsd.xsd">
 <map>
+  <key>FSSlowTextFetchProtion</key>
+  <map>
+    <key>Comment</key>
+    <string>Slow texture fetch protection. Use check to skip over waiting for long texture fetch.</string>
+    <key>Persist</key>
+    <integer>1</integer>
+    <key>Type</key>
+    <string>Boolean</string>
+    <key>Value</key>
+    <integer>1</integer>
+  </map>
+  <key>FSAutoOnScrText</key>
+  <map>
+    <key>Comment</key>
+    <string>Auto scale on-screen LOD textures to fit on screen objects.</string>
+    <key>Persist</key>
+    <integer>1</integer>
+    <key>Type</key>
+    <string>Boolean</string>
+    <key>Value</key>
+    <integer>1</integer>
+  </map>
+  <key>FSAutoOfScrText</key>
+  <map>
+      <key>Comment</key>
+      <string>Auto scale off-screen LOD textures to save VRAM.</string>
+      <key>Persist</key>
+      <integer>1</integer>
+      <key>Type</key>
+      <string>Boolean</string>
+      <key>Value</key>
+      <integer>1</integer>
+  </map>    
+    <key>FSNearOfScrTextQuality</key>
+    <map>
+        <key>Comment</key>
+        <string>Near off-screen textures close to camera are treated as if they are on screen. Protects from bias and down scaling off-screen.</string>
+        <key>Persist</key>
+        <integer>2</integer>
+        <key>Type</key>
+        <string>Boolean</string>
+        <key>Value</key>
+        <integer>1</integer>
+    </map>
+    <key>FSFastMoveLowText</key>
+    <map>
+        <key>Comment</key>
+        <string>To save VRAM/Improve performance, while moving fast or turning, textures are down scaled.</string>
+        <key>Persist</key>
+        <integer>1</integer>
+        <key>Type</key>
+        <string>Boolean</string>
+        <key>Value</key>
+        <integer>0</integer>
+    </map>
   <key>FSLandmarkCreatedNotification</key>
   <map>
     <key>Comment</key>

--- a/indra/newview/llface.h
+++ b/indra/newview/llface.h
@@ -128,7 +128,7 @@ public:
     F32             getVirtualSize() const { return mVSize; }
     F32             getPixelArea() const { return mPixelArea; }
     F32             getImportanceToCamera() const { return mImportanceToCamera; }
-    F32             getCloseToCamera() const { return mCloseToCamera; }
+    bool            getCloseToCamera() const { return mCloseToCamera; } // <FS:minerjr> Change return from S32 to bool
 
     S32             getIndexInTex(U32 ch) const      { llassert(ch < LLRender::NUM_TEXTURE_CHANNELS); return mIndexInTex[ch]; }
     void            setIndexInTex(U32 ch, S32 index) { llassert(ch < LLRender::NUM_TEXTURE_CHANNELS); mIndexInTex[ch] = index; }
@@ -335,7 +335,7 @@ private:
     //1.0: the most important.
     //based on the distance from the face to the view point and the angle from the face center to the view direction.
     F32         mImportanceToCamera ;
-    F32         mCloseToCamera;
+    bool        mCloseToCamera; // <FS:minerjr> Change return from S32 to bool
     F32         mBoundingSphereRadius ;
     bool        mHasMedia ;
     bool        mIsMediaAllowed;

--- a/indra/newview/lltextureview.cpp
+++ b/indra/newview/lltextureview.cpp
@@ -550,9 +550,15 @@ void LLGLTexMemBar::draw()
    F64 raw_image_bytes_MB = raw_image_bytes / (1024.0 * 1024.0);
    F64 saved_raw_image_bytes_MB = saved_raw_image_bytes / (1024.0 * 1024.0);
    F64 aux_raw_image_bytes_MB = aux_raw_image_bytes / (1024.0 * 1024.0);
-   F64 texture_bytes_alloc = LLImageGL::getTextureBytesAllocated() / 1024.0 / 512.0;
-   F64 vertex_bytes_alloc = LLVertexBuffer::getBytesAllocated() / 1024.0 / 512.0;
-   F64 render_bytes_alloc = LLRenderTarget::sBytesAllocated / 1024.0 / 512.0;
+   // <FS:minerjr>
+   //F64 texture_bytes_alloc = LLImageGL::getTextureBytesAllocated() / 1024.0 / 512.0;
+   //F64 vertex_bytes_alloc = LLVertexBuffer::getBytesAllocated() / 1024.0 / 512.0;
+   //F64 render_bytes_alloc = LLRenderTarget::sBytesAllocated / 1024.0 / 512.0;
+   // Show true texture usage (don't divide by 1/2)
+   F64 texture_bytes_alloc = LLImageGL::getTextureBytesAllocated() / 1024.0 / 1024.0;
+   F64 vertex_bytes_alloc = LLVertexBuffer::getBytesAllocated() / 1024.0 / 1024.0;
+   F64 render_bytes_alloc = LLRenderTarget::sBytesAllocated / 1024.0 / 1024.0;
+   // </FS:minerjr>
 
     //----------------------------------------------------------------------------
     LLGLSUIDefault gls_ui;

--- a/indra/newview/llviewerobjectlist.cpp
+++ b/indra/newview/llviewerobjectlist.cpp
@@ -1673,7 +1673,7 @@ void LLViewerObjectList::cleanDeadObjects(bool use_timer)
     LLViewerObject *objectp;
 
     // <FS:Ansariel> Use timer for cleaning up dead objects
-    static const F64 max_time = 0.01; // Let's try 10ms per frame
+    static const F64 max_time = 0.001; // Let's try 1ms per frame (Was 10 ms, want to decrease to smooth fps)
     LLTimer timer;
     // </FS:Ansariel>
 

--- a/indra/newview/llviewertexture.h
+++ b/indra/newview/llviewertexture.h
@@ -225,6 +225,7 @@ public:
     static S32 sAuxCount;
     static LLFrameTimer sEvaluationTimer;
     static F32 sDesiredDiscardBias;
+    static F32 sPrevDesiredDiscardBias; // <FS:minerjr> Previous desired discard bias
     static U32 sBiasTexturesUpdated;
     static S32 sMaxSculptRez ;
     static U32 sMinLargeImageSize ;
@@ -438,8 +439,14 @@ public:
     bool        isInFastCacheList() { return mInFastCacheList; }
 
     // <FS:minerjr> [FIRE-35081] Blurry prims not changing with graphics settings
-    F32         getCloseToCamera() const {return mCloseToCamera ;} // Get close to camera value
-    void        setCloseToCamera(F32 value) {mCloseToCamera = value ;} // Set the close to camera value (0.0f or 1.0f)
+    bool        getCloseToCamera() const {return mCloseToCamera ;} // Get close to camera value
+    void        setCloseToCamera(bool value) {mCloseToCamera = value ;} // Set the close to camera value (true or false)
+    bool        getInFrustum() const {return mInFrustum ;} // Get in frustum value
+    void        setInFrustum(bool value) {mInFrustum = value ;} // Set the in frustum value (true or false)
+    F32         getBias() const { return mBias; } // Get the applied bias value to the texture
+    void        setBias(F32 value) { mBias = value; } // Set the applied bias value for the texture
+    F32         getImportanceToCamera() const { return mImportanceToCamera; }
+    void        setImportanceToCamera(F32 value) { mImportanceToCamera = value; }
     // </FS:minerjr> [FIRE-35081]
 
     /*virtual*/bool  isActiveFetching() override; //is actively in fetching by the fetching pipeline.
@@ -543,7 +550,10 @@ protected:
     bool   mForSculpt ; //a flag if the texture is used as sculpt data.
     bool   mIsFetched ; //is loaded from remote or from cache, not generated locally.
     // <FS:minerjr> [FIRE-35081] Blurry prims not changing with graphics settings
-    F32    mCloseToCamera; // Float (0.0f or 1.0f) to indicate if the texture is close to the camera
+    bool mCloseToCamera; // indicate if the texture is close to the camera
+    F32 mBias; // Textures now have an indivdual bias applied to them
+    F32 mImportanceToCamera; // Textures can now store the importance to camera
+    bool mInFrustum; // And store if the texture is in the frustum
     // </FS:minerjr> [FIRE-35081]
 
 public:
@@ -586,6 +596,7 @@ public:
 
 private:
     void init(bool firstinit) ;
+    S32 mScaleDownCount; // <FS:minerjr> scale down counter
 };
 
 //

--- a/indra/newview/llviewertexturelist.cpp
+++ b/indra/newview/llviewertexturelist.cpp
@@ -405,7 +405,10 @@ void LLViewerTextureList::dump()
         << " discard " << image->getDiscardLevel()
         << " desired " << image->getDesiredDiscardLevel()
         // <FS:minerjr> [FIRE-35081] Blurry prims not changing with graphics settings
-        << " close to camera " << (image->getCloseToCamera() > 0.0f ? "Y" : "N") // Display the close to camera flag
+        << " close to camera " << (image->getCloseToCamera() ? "Y" : "N") // Display the close to camera flag
+        << " importance to camera " << (image->getImportanceToCamera()) // Display the close to camera flag
+        << " in frustum " << (image->getInFrustum() ? "Y" : "N") // Display the in frustum flag
+        << " bias " << (image->getBias()) // Display the close to camera flag
         << " FFType " << fttype_to_string(image->getFTType()) // Display the FFType of the camera
         << " Type " << (S32)image->getType() // Display the type of the image (LOCAL_TEXTURE = 0, MEDIA_TEXTURE = 1, DYNAMIC_TEXTURE = 2, FETCHED_TEXTURE = 3,LOD_TEXTURE = 4)        
         << " Sculpted " << (image->forSculpt() ? "Y" : "N")
@@ -1095,16 +1098,25 @@ void LLViewerTextureList::updateImageDecodePriority(LLViewerFetchedTexture* imag
     {
         static LLCachedControl<F32> texture_scale_min(gSavedSettings, "TextureScaleMinAreaFactor", 0.0095f);
         static LLCachedControl<F32> texture_scale_max(gSavedSettings, "TextureScaleMaxAreaFactor", 25.f);
+        // <FS:minerjr> New flags for users to change settings for save vram
+        static LLCachedControl<bool> auto_scale_on_screen_textures(gSavedSettings, "FSAutoOnScrText", true);
+        static LLCachedControl<bool> auto_scale_off_screen_textures(gSavedSettings, "FSAutoOfScrText", true);
+        static LLCachedControl<bool> exclude_off_screen_close_to_camera(gSavedSettings, "FSExcludeOffScreenCtoC", true);        
+        // </FS:minerjr>
 
         F32 max_vsize = 0.f;
         bool on_screen = false;
 
         U32 face_count = 0;
+        U32 max_faces_to_check = 1024;
 
         // get adjusted bias based on image resolution
         LLImageGL* img = imagep->getGLTexture();
         F32 max_discard = F32(img ? img->getMaxDiscardLevel() : MAX_DISCARD_LEVEL);
-        F32 bias = llclamp(max_discard - 2.f, 1.f, LLViewerTexture::sDesiredDiscardBias);
+        // <FS:minerjr>
+        // Use a fixed bias level instead of scaling back and forther. Help prevent as much fetching
+        //F32 bias = llclamp(max_discard - 2.f, 1.f, LLViewerTexture::sDesiredDiscardBias);
+        F32 bias = llclamp(max_discard - 2.f, 1.f, 4.0f);
 
         // convert bias into a vsize scaler
         // <FS:minerjr> [FIRE-35081] Blurry prims not changing with graphics settings
@@ -1112,28 +1124,11 @@ void LLViewerTextureList::updateImageDecodePriority(LLViewerFetchedTexture* imag
         // Pre-divide the bias so you can just use multiply in the loop
         bias = (F32) 1.0f / llroundf(powf(4, bias - 1.f));
 
-        // Apply new rules to bias discard, there are now 2 bias, off-screen and on-screen.
-        // On-screen Bias
-        // Only applied to LOD Textures and one that have Discard > 1 (0, 1 protected)
-        // 
-        // Off-screen Bias
-        // Will be using the old method of applying the mMaxVirtualSize, however
-        // only on LOD textures and fetched textures get bias applied.
-        // 
-        // Local (UI & Icons), Media and Dynamic textures should not have any discard applied to them.
-        // 
-        // Without this, textures will become blurry that are on screen, which is one of the #1
-        // user complaints.
-
-        // Store a seperate max on screen vsize without bias applied.
-        F32 max_on_screen_vsize = 0.0f;
-        S32 on_screen_count = 0;
         // Moved all the variables outside of the loop
-        bool current_on_screen = false;
         F32 vsize = 0.0f; // Moved outside the loop to save reallocation every loop
         F32 important_to_camera = 0.0f;
-        F32 close_to_camera = 0.0f; // Track if the texture is close to the cameras
-        F64 animated = 0; // U64 used to track if a pointer is set for the animations. (The texture matrix of the face is null if no animation assigned to the texture)
+        bool close_to_camera = false;// 0.0f; // Track if the texture is close to the cameras
+        bool animated = false; // U64 used to track if a pointer is set for the animations. (The texture matrix of the face is null if no animation assigned to the texture)
                            // So if you keep adding and the final result is 0, there is no animation
         // </FS:minerjr> [FIRE-35081]
         // boost resolution of textures that are important to the camera
@@ -1170,20 +1165,16 @@ void LLViewerTextureList::updateImageDecodePriority(LLViewerFetchedTexture* imag
                     // Also moved allocation outside the loop
                     // <FS:minerjr> [FIRE-35081] Blurry prims not changing with graphics settings
                     //F32 vsize = face->getPixelArea();
-
-                    //on_screen |= face->mInFrustum;
                     // Get the already calculated face's virtual size, instead of re-calculating it
                     vsize = face->getVirtualSize();
-                    
-                    current_on_screen = face->mInFrustum; // Create a new var to store the current on screen status                    
-                    on_screen_count += current_on_screen; // Count the number of on sceen faces instead of using brach
-                    important_to_camera = face->mImportanceToCamera; // Store so we don't have to do 2 indirects later on
-                    // If the face/texture is animated, then set the boost level to high, so that it will ways be the best quality
-                    animated += S64(face->mTextureMatrix);
-                    animated += S64(face->hasMedia()); // Add has media for both local and parcel media
-                    animated += S64(imagep->hasParcelMedia());
 
-                    // <FS:minerjr> [FIRE-35081] Blurry prims not changing with graphics settings (It is)
+                    on_screen |= face->mInFrustum;
+                    
+                    important_to_camera = llmax(important_to_camera, face->mImportanceToCamera); // Store so we don't have to do 2 indirects later on
+
+                    //Close to camera now flags that the texture should not have bias applied.
+                    close_to_camera |= face->mCloseToCamera;
+                    
                     /*
                     // Scale desired texture resolution higher or lower depending on texture scale
                     //
@@ -1193,7 +1184,6 @@ void LLViewerTextureList::updateImageDecodePriority(LLViewerFetchedTexture* imag
                     //
                     // Maximum usage examples: huge chunk of terrain repeats texture
                     // TODO: make this work with the GLTF texture transforms
-
                     S32 te_offset = face->getTEOffset();  // offset is -1 if not inited
                     LLViewerObject* objp = face->getViewerObject();
                     const LLTextureEntry* te = (te_offset < 0 || te_offset >= objp->getNumTEs()) ? nullptr : objp->getTE(te_offset);
@@ -1205,68 +1195,39 @@ void LLViewerTextureList::updateImageDecodePriority(LLViewerFetchedTexture* imag
                     // use mImportanceToCamera to make bias switch a bit more gradual
                     if (!face->mInFrustum || LLViewerTexture::sDesiredDiscardBias > 1.9f + face->mImportanceToCamera / 2.f)
                     {
-                        vsize /= bias;
+                    vsize /= bias;
                     }
 
                     // boost resolution of textures that are important to the camera
                     if (face->mInFrustum)
                     {
-                        static LLCachedControl<F32> texture_camera_boost(gSavedSettings, "TextureCameraBoost", 8.f);
-                        vsize *= llmax(face->mImportanceToCamera*texture_camera_boost, 1.f);
+                    static LLCachedControl<F32> texture_camera_boost(gSavedSettings, "TextureCameraBoost", 8.f);
+                    vsize *= llmax(face->mImportanceToCamera*texture_camera_boost, 1.f);
                     }
-
+                    */
+                    
                     max_vsize = llmax(max_vsize, vsize);
 
                     // addTextureStats limits size to sMaxVirtualSize
-                    if (max_vsize >= LLViewerFetchedTexture::sMaxVirtualSize
+                    if (max_vsize >= LLViewerFetchedTexture::sMaxVirtualSize * 0.25f // <FS:minerjr> scale is different
                         && (on_screen || LLViewerTexture::sDesiredDiscardBias <= BIAS_TRS_ON_SCREEN))
                     {
                         break;
                     }
-                    */
-
-                    // Use math to skip having to use a conditaional check
-                    // Bools are stored as 0 false, 1 true, use to cheat
-                    // Lerp instead of doing conditional input
-                    // If the image is import to the camera, even a little then make the on screen true                    
-                    on_screen_count += S32(important_to_camera * 1000.0f);
-                    //vsize = vsize + (vsize * (1.0f + important_to_camera * texture_camera_boost) - vsize) * F32(current_on_screen);
-                    // Apply boost of size based upon importance to camera
-                    vsize = vsize + (vsize * important_to_camera * texture_camera_boost);
-                    // Apply second boost based upon if the texture is close to the camera (< 16.1 meters * draw distance multiplier)
-                    vsize = vsize + (vsize * face->mCloseToCamera * texture_camera_boost);
-                    // Update the max on screen vsize based upon the on screen vsize
-                    close_to_camera += face->mCloseToCamera;
-                    // LL_DEBUGS() << face->getViewerObject()->getID() << " TID " << imagep->getID() << " #F " << imagep->getNumFaces(i) << " OS Vsize: " << vsize << " Vsize: " << (vsize * bias) << " CTC: " << face->mCloseToCamera << " Channel " << i << " Face Index " << fi << LL_ENDL;
-                    max_on_screen_vsize = llmax(max_on_screen_vsize, vsize);
-                    max_vsize = llmax(max_vsize, vsize * bias);
-                    // </FS:minerjr> [FIRE-35081]
                 }
             }
 
-            // <FS> [FIRE-35081] Blurry prims not changing with graphics settings
-            //if (max_vsize >= LLViewerFetchedTexture::sMaxVirtualSize
-            //    && (on_screen || LLViewerTexture::sDesiredDiscardBias <= BIAS_TRS_ON_SCREEN))
-            //{
-            //    break;
-            //}
-            // </FS>
+            if (max_vsize >= LLViewerFetchedTexture::sMaxVirtualSize * 0.25f // <FS:minerjr> scale is different
+                && (on_screen || LLViewerTexture::sDesiredDiscardBias <= BIAS_TRS_ON_SCREEN))
+            {
+                break;
+            }
         }
 
-        // <FS:minerjr> [FIRE-35081] Blurry prims not changing with graphics settings
-        // Replaced all the checks for this bool to be only in this 1 place instead of in the loop.
-        // If the on screen counter is greater then 0, then there was at least 1 on screen texture
-        on_screen = bool(on_screen_count);
-        imagep->setCloseToCamera(close_to_camera > 0.0f ? 1.0f : 0.0f);
-
-        //if (face_count > 1024)
-        // Add check for if the image is animated to boost to high as well
-        if (face_count > 1024 || animated != 0)
-        // </FS:minerjr> [FIRE-35081]
+        if (face_count > max_faces_to_check)
         { // this texture is used in so many places we should just boost it and not bother checking its vsize
-            // this is especially important because the above is not time sliced and can hit multiple ms for a single texture
-            imagep->setBoostLevel(LLViewerFetchedTexture::BOOST_HIGH);
-            // Do we ever remove it? This also sets texture nodelete!
+          // this is especially important because the above is not time sliced and can hit multiple ms for a single texture
+            max_vsize = MAX_IMAGE_AREA;
         }
 
         if (imagep->getType() == LLViewerTexture::LOD_TEXTURE && imagep->getBoostLevel() == LLViewerTexture::BOOST_NONE)
@@ -1274,41 +1235,82 @@ void LLViewerTextureList::updateImageDecodePriority(LLViewerFetchedTexture* imag
           // this is an alternative to decaying mMaxVirtualSize over time
           // that keeps textures from continously downrezzing and uprezzing in the background
 
-            if (LLViewerTexture::sDesiredDiscardBias > BIAS_TRS_OUT_OF_SCREEN ||
-                (!on_screen && LLViewerTexture::sDesiredDiscardBias > BIAS_TRS_ON_SCREEN))
+            // <FS:minerjr>
+            //if (LLViewerTexture::sDesiredDiscardBias > BIAS_TRS_OUT_OF_SCREEN ||
+            //    (!on_screen && LLViewerTexture::sDesiredDiscardBias > BIAS_TRS_ON_SCREEN))
+            //{
+            //    imagep->mMaxVirtualSize = 0.f;
+            //}
+            // Added flag that can allow on screen LOD textures to always downscale to match size object size on screen.
+            if (auto_scale_on_screen_textures)
             {
                 imagep->mMaxVirtualSize = 0.f;
             }
+            else if (!close_to_camera && (LLViewerTexture::sDesiredDiscardBias > BIAS_TRS_OUT_OF_SCREEN ||
+                (!on_screen && LLViewerTexture::sDesiredDiscardBias > BIAS_TRS_ON_SCREEN)))
+            {
+                imagep->mMaxVirtualSize = 0.f;
+            }
+
+
         }
 
         // <FS:minerjr> [FIRE-35081] Blurry prims not changing with graphics settings
-        //imagep->addTextureStats(max_vsize);
-        // New logic block for the bias system        
-        // Then depending on the type of texture, the higher resolution on_screen_max_vsize is applied.
-        // On Screen (Without Bias applied:
-        //      LOD/Fetch Texture: Discard Levels 0, 1
-        //      Fetch Texture 2, 3, 5 with bias < 2.0
-        //      BoostLevel = Boost_High
-        //      Local, Media, Dynamic Texture        
-        // If the textures are on screen and either 1 are the first 2 levels of discard and are either fetched or LOD textures
-        if (on_screen && ((imagep->getDiscardLevel() < 2 && imagep->getType() >= LLViewerTexture::FETCHED_TEXTURE) || (imagep->getType() == LLViewerTexture::FETCHED_TEXTURE && LLViewerTexture::sDesiredDiscardBias < 2.0f)))
+        // New logic block for the bias system
+        // Settings from the LLFace.cpp now have features such as close to camera (within 16 meters) and updated importance to camera and mInFrustum
+        // If the texture is a fetched texture and on screen, as long as the designed bias is less then 1.9 + how important is to screen
+        if (on_screen && ((imagep->getType() == LLViewerTexture::FETCHED_TEXTURE && LLViewerTexture::sDesiredDiscardBias < 1.9f + important_to_camera * 0.5f)))
         {
-            // Always use the best quality of the texture
-            imagep->addTextureStats(max_on_screen_vsize);
+            // Don't apply bias to this texture.
+            imagep->setBias(1.0f);
         }
-        // If the boost level just became high, or the texture is (Local, Media Dynamic)
-        else if (imagep->getBoostLevel() >= LLViewerTexture::BOOST_HIGH || imagep->getType() < LLViewerTexture::FETCHED_TEXTURE || close_to_camera)
+        // If close to the camera (LLFace.cpp sets this flag), the texture is (Local, Media Dynamic), the boost level just became high, or 
+        else if (close_to_camera || imagep->getType() < LLViewerTexture::FETCHED_TEXTURE || imagep->getBoostLevel() >= LLViewerTexture::BOOST_HIGH)
         {
-            // Always use the best quality of the texture
-            imagep->addTextureStats(max_on_screen_vsize);
+            // Don't apply bias to this texture.
+            imagep->setBias(1.0f);
         }
-        // All other texture cases will use max_vsize with bias applied.
+        // Handle bias or other situtations for other types of textures
         else
         {
-            imagep->addTextureStats(max_vsize);
+            // If the texture is on screen and the importance to the camera is decreasing and is a low importance to the camera as well as the bias is increasing over the
+            // previous frame, then set the image to have a fixed bias
+            if (on_screen && important_to_camera < imagep->getImportanceToCamera() && important_to_camera < (0.33f * (LLViewerTexture::sDesiredDiscardBias - 1.0f)) &&
+                LLViewerTexture::sDesiredDiscardBias > BIAS_TRS_OUT_OF_SCREEN && LLViewerTexture::sPrevDesiredDiscardBias <= LLViewerTexture::sDesiredDiscardBias)
+            {
+                // Apply the fixed bias to this texture
+                imagep->setBias(bias);
+            }
+            // If this texture is not on screen and bias is incrasing, then set the image to have bias
+            else if (!on_screen && LLViewerTexture::sDesiredDiscardBias > BIAS_TRS_ON_SCREEN && LLViewerTexture::sDesiredDiscardBias >= LLViewerTexture::sPrevDesiredDiscardBias)
+            {
+                // Apply the fixed bias to this texture
+                imagep->setBias(bias);
+            }
+            // Once the desired discard bias is back to 1.00, then if the texture is important to the camera, then 
+            else if (on_screen && LLViewerTexture::sDesiredDiscardBias == 1.0f && important_to_camera > 0.0f)
+            {
+                // Reset this textures bias back to 1.0
+                imagep->setBias(1.0f);
+            }
         }
+        // Store the current importance to camera flag, on screen and close to camera flags for this image. Each texture has thier own tracked values
+        // Can be stored internally as bitfield as we use accessor methods to change values
+        imagep->setImportanceToCamera(important_to_camera);
+        imagep->setInFrustum(on_screen);
+        imagep->setCloseToCamera(close_to_camera);  
         // </FS:minerjr> [FIRE-35081]
+
+        imagep->addTextureStats(max_vsize);
     }
+    // <FS:minerjr>
+    // If the texture is not suppose to have bias, turn if off.
+    // Map/Mini-Map will change object's boost level to NONE and MAP back and forth so the bias may accidenly get applied to a texture
+    else
+    {
+        imagep->setBias(1.0f);
+    }
+    // </FS:minerjr>
 
 #if 0
     imagep->setDebugText(llformat("%d/%d - %d/%d -- %d/%d",
@@ -1407,6 +1409,8 @@ F32 LLViewerTextureList::updateImagesCreateTextures(F32 max_time)
         imagep->mCreatePending = false;
         mCreateTextureList.pop();
 
+        // <FS:minerjr> Disable the downscaling just after loading the texture. We now have a 3 update wait before downscaling to make sure we really want to.
+        /*
         if (imagep->hasGLTexture() && imagep->getDiscardLevel() < imagep->getDesiredDiscardLevel() &&
            // <FS:minerjr> [FIRE-35081] Blurry prims not changing with graphics settings
            //(imagep->getDesiredDiscardLevel() <= MAX_DISCARD_LEVEL))
@@ -1420,7 +1424,8 @@ F32 LLViewerTextureList::updateImagesCreateTextures(F32 max_time)
             LL_WARNS_ONCE("Texture") << "Texture will be downscaled immediately after loading." << LL_ENDL;
             imagep->scaleDown();
         }
-
+        */
+        // </FS:minerjr>
         if (create_timer.getElapsedTimeF32() > max_time * 0.5f)
         {
             break;

--- a/indra/newview/llvlcomposition.cpp
+++ b/indra/newview/llvlcomposition.cpp
@@ -89,7 +89,7 @@ namespace
     {
         if (!tex) { return; }
         tex->setBoostLevel(LLGLTexture::BOOST_NONE);
-        tex->setMinDiscardLevel(MAX_DISCARD_LEVEL + 1);
+        tex->setMinDiscardLevel(MAX_DISCARD_LEVEL); // <FS:minerjr> needs to be in range
     }
 
     void unboost_minimap_material(LLFetchedGLTFMaterial* mat)

--- a/indra/newview/llvovolume.cpp
+++ b/indra/newview/llvovolume.cpp
@@ -980,7 +980,9 @@ void LLVOVolume::updateTextureVirtualSize(bool forced)
 
         // <FS:minerjr> [FIRE-35081] Blurry prims not changing with graphics settings
         // If the new area is changed from the old area, then accept it.
-        if (mPixelArea != old_area)
+        //if (mPixelArea != old_area)
+        // Added a check based on checking if the pixel area are not NAN or Infinity
+        if (std::isnormal(mPixelArea) && std::isnormal(old_area) && mPixelArea != old_area)
         {
             changed = true;
         }

--- a/indra/newview/skins/default/xui/en/panel_preferences_graphics1.xml
+++ b/indra/newview/skins/default/xui/en/panel_preferences_graphics1.xml
@@ -1230,6 +1230,53 @@ If you do not understand the distinction then leave this control alone."
          width="100">
             Second(s)
         </text>
+
+        <check_box
+          control_name="FSAutoOnScrText"
+          height="16"
+          label="Auto Scale: On-Screen Textures"
+          layout="topleft"
+          left="10"
+          top_pad="10"
+          name="FSAutoOnScrText"
+          tool_tip="Saves VRAM by auto-scale on-screen LOD textures to perfectly fit size of objects."
+          width="475"
+        />
+        <check_box
+          control_name="FSAutoOfScrText"
+          height="16"
+          label="Auto Scale: Off-Screen Textures"
+          follows="left|top"
+          layout="topleft"
+          left="10"
+          top_pad="10"
+          name="FSAutoOfScrText"
+          tool_tip="Saves VRAM by auto-scale off-screen LOD textures."
+          width="475"
+        />
+        <check_box
+          control_name="FSNearOfScrTextQuality"
+          height="16"
+          label="Near Off-screen Textures: Keep Texture Quality"
+          layout="topleft"
+          left="10"
+          top_pad="10"
+          name="FSNearOfScrTextQuality"
+          tool_tip="Excludes off-screen textures close to camera from being scaled down or from having bias applied."
+          width="475"
+        />
+        <check_box
+          control_name="FSFastMoveLowText"
+          height="16"
+          label="Moving Fast/Turning: Lower Texture Quality for Faster Speed"
+          layout="topleft"
+          left="10"
+          top_pad="10"
+          name="FSFastMoveLowText"
+          tool_tip="While moving or turning fast, new textures are loaded at a capped quality level to speed up loading assets. On is the previous existing behavior."
+          width="475"
+        />
+
     </panel>
 
 <!--Rendering-->


### PR DESCRIPTION
This PR is designed to address issues around the scaling of textures and VRAM usage due to recent changes over the past while to texture system.

Added individual per texture bias. When applying bias to on screen textures, Importance to screen can shield textures from having bias applied. Scales based on the bias level. Also modified close to camera calculation to start at 32 meters. As the bias increases, the area around the camera that is protected from the bias will decrease down to 16 meters. Any texture close to camera does not have bias applied. 

Improved how textures are calculated in size so they match the actual size on screen an object is. This fixes large objects far away and small objects up close having different quality of textures applied to them.

Added some new controls for textures in the Preferences->Graphics->Hardware Settings Tab.

![image](https://github.com/user-attachments/assets/2b1daee1-405a-4e95-85d1-aa1e55c26169)

Auto Scale: On-Screen Textures:
On screen LOD textures will  automatically up/down scale to match the physical size of the object and no longer stick at the highest discard level. Can turn off for the previous method.

Auto-Scale: Off-Screen Textures
This allows the user to force off screen textures to have automatically scale down once off screen.

Near Off-screen Textures: Keep Texture Quality
Off-screen textures that are close to the camera will be treated as if they are on screen and close to the camera. This protects them also from bias being applied to them.

Moving Fast/Turning: Lower Texture Quality for Faster Speed 
While moving forward fast, or doing fast turns, all textures will have a reduction in quality to try to make loading them faster. This is the existing behaviour, now exposed to allow the user to turn on/off.

Removed artificial limit on VRAM calculations. VRAM that appeared in the viewer and calculations was actually 1/2 the calculated amount, due to wanting to give more wiggle room . The latest version from LL introduced a new divider to further slash the size of the VRAM, so there is no need to double dip on reducing the amount of VRAM the viewer can use. Just have the 1 new control select the divider for the VRAM...

Added new checks to only downscale a texture after 3 consecutive requests for lower quality. Any check that goes back up in quality will reset the counter.

Added option to skip waiting for fetches to finish before going on the next texture. This is more helpful for fetches that take a long time due to slow internet download speed or issues with slow writes to disk or slow read times. It returns and will get the fetch on the next update cycle. There is a debug flag to turn this off called "FSFastMoveLowText". Didn't expose it for now.

Removed forcing all textures to be updated when ever the Bias first goes over 1.00. Depending on the # of textures loaded would cause large lag spike on the users as they were all updated in a single frame.

Reduced amount of time deleting objects per frame from 10 ms to 1 ms. Takes 10x longer, but smooths out the frames more.

Fixed scale down edge case which would try to downscale textures beyond mMaxDiscardLevel of an texture.

Added updated decode priority value for fetched textures so that the higher the boost level, the higher on the priority fetch queue.

Fixes some issues with incorrect checks being done. As well as refactored to code to remove unneeded changes and revert code back closer to original LL code to make adding changes easier. Will eventually push a PR to LL with changes.

Added additional Importance to Camera and In Frustum to textures allow for debug output in the Developer Menu Dump.

Cleaned up and updated logic for the LLViewerTextureList::updateImageDecodePriority to be up to date with latest LL version with changes reapplied.

Removed changes to llcamera as they were no longer needed.

