### PR TITLE
Include PBR textures in Texture Refresh.

### DIFF
--- a/indra/newview/llviewermenu.cpp
+++ b/indra/newview/llviewermenu.cpp
@@ -3476,6 +3476,15 @@ void handle_object_tex_refresh(LLViewerObject* object, LLSelectNode* node)
             LLViewerTexture* spec_img = object->getTESpecularMap(i);
             faces_per_texture[spec_img->getID()].push_back(i);
         }
+
+        LLPointer<LLGLTFMaterial> mat = object->getTE(i)->getGLTFRenderMaterial();
+        if (mat.notNull())
+        {
+            for (U32 j = 0; j < LLGLTFMaterial::GLTF_TEXTURE_INFO_COUNT; ++j)
+            {
+                faces_per_texture[mat->mTextureId[j]].push_back(i);
+            }
+        }
     }
 
     map_t::iterator it;


### PR DESCRIPTION
This pull request simply adds the object's PBR textures to the `faces_per_texture` list that eventually gets discarded and redownloaded. Change is wholly contained within Zi's original 'FS' tags for the Texture Refresh feature, so I haven't added any more.