### PR TITLE
Add options in sounds explorer to block attached / rezzed sounds by avatar

### DIFF
--- a/indra/llcommon/llassettype.h
+++ b/indra/llcommon/llassettype.h
@@ -131,7 +131,10 @@ public:
         AT_GLTF = 58,   // gltf json document
         AT_GLTF_BIN = 59, // gltf binary data
 
-        AT_COUNT = 60,
+        AT_AVATAR_ATTACHED_SOUNDS = 60, // Black list avatar attached sounds
+        AT_AVATAR_REZZED_SOUNDS = 61, // Black list avatar rezzed sounds
+
+        AT_COUNT = 62,
 
             // +*********************************************************+
             // |  TO ADD AN ELEMENT TO THIS ENUM:                        |

--- a/indra/llinventory/llinventorytype.cpp
+++ b/indra/llinventory/llinventorytype.cpp
@@ -162,6 +162,9 @@ DEFAULT_ASSET_FOR_INV_TYPE[LLAssetType::AT_COUNT] =
     LLInventoryType::IT_MATERIAL,       // 57   AT_MATERIAL
     LLInventoryType::IT_GLTF,           // 58   AT_GLTF
     LLInventoryType::IT_GLTF_BIN,       // 59   AT_GLTF_BIN
+
+    LLInventoryType::IT_NONE,           // 60   AT_AVATAR_ATTACHED_SOUNDS
+    LLInventoryType::IT_NONE,           // 61   AT_AVATAR_REZZED_SOUNDS
 };
 
 // static

--- a/indra/newview/NACLfloaterexploresounds.h
+++ b/indra/newview/NACLfloaterexploresounds.h
@@ -32,6 +32,8 @@ private:
     void handleStopLocally();
     void handleSelection();
     void blacklistSound();
+    void blacklistAvatarAttachedSounds();
+    void blacklistAvatarRezzedSounds();
 
     LLScrollListCtrl*   mHistoryScroller;
     LLCheckBoxCtrl*     mCollisionSounds;
@@ -46,8 +48,10 @@ private:
 
     typedef std::map<LLUUID, boost::signals2::connection> blacklist_avatar_name_cache_connection_map_t;
     blacklist_avatar_name_cache_connection_map_t mBlacklistAvatarNameCacheConnections;
-
+    
     void onBlacklistAvatarNameCacheCallback(const LLUUID& av_id, const LLAvatarName& av_name, const LLUUID& asset_id, const std::string& region_name);
+    void onBlacklistAvatarAttachedSoundsNameCacheCallback(const LLUUID& av_id, const LLAvatarName& av_name, const LLUUID& asset_id, const std::string& region_name);
+    void onBlacklistAvatarRezzedSoundsNameCacheCallback(const LLUUID& av_id, const LLAvatarName& av_name, const LLUUID& asset_id, const std::string& region_name);
 };
 
 #endif

--- a/indra/newview/fsassetblacklist.cpp
+++ b/indra/newview/fsassetblacklist.cpp
@@ -60,6 +60,12 @@ LLAssetType::EType S32toAssetType(S32 assetindex)
         case 45:
             type = LLAssetType::AT_PERSON;
             break;
+        case 60:
+            type = LLAssetType::AT_AVATAR_ATTACHED_SOUNDS;
+            break;
+        case 61:
+            type = LLAssetType::AT_AVATAR_REZZED_SOUNDS;
+            break;
         default:
             type = LLAssetType::AT_NONE;
     }

--- a/indra/newview/fsfloaterassetblacklist.cpp
+++ b/indra/newview/fsfloaterassetblacklist.cpp
@@ -104,6 +104,10 @@ std::string FSFloaterAssetBlacklist::getTypeString(S32 type)
             return getString("asset_animation");
         case LLAssetType::AT_PERSON:
             return getString("asset_resident");
+        case LLAssetType::AT_AVATAR_ATTACHED_SOUNDS:
+            return getString("asset_avatar_attached_sounds");
+        case LLAssetType::AT_AVATAR_REZZED_SOUNDS:
+            return getString("asset_avatar_rezzed_sounds");
         default:
             return getString("asset_unknown");
     }

--- a/indra/newview/llviewermessage.cpp
+++ b/indra/newview/llviewermessage.cpp
@@ -4714,6 +4714,10 @@ void process_sound_trigger(LLMessageSystem *msg, void **)
     {
         return;
     }
+    if (FSAssetBlacklist::getInstance()->isBlacklisted(owner_id, LLAssetType::AT_AVATAR_REZZED_SOUNDS))
+    {
+        return;
+    }
     // </FS>
 
     // NaCl - Antispam Registry
@@ -4878,6 +4882,10 @@ void process_attached_sound(LLMessageSystem *msg, void **user_data)
 
     // <FS> Asset blacklist
     if (FSAssetBlacklist::getInstance()->isBlacklisted(sound_id, LLAssetType::AT_SOUND))
+    {
+        return;
+    }
+    if (FSAssetBlacklist::getInstance()->isBlacklisted(owner_id, LLAssetType::AT_AVATAR_ATTACHED_SOUNDS))
     {
         return;
     }

--- a/indra/newview/llviewerobject.cpp
+++ b/indra/newview/llviewerobject.cpp
@@ -6601,7 +6601,13 @@ void LLViewerObject::setAttachedSound(const LLUUID &audio_uuid, const LLUUID& ow
     {
         return;
     }
+    if (FSAssetBlacklist::getInstance()->isBlacklisted(owner_id, LLAssetType::AT_AVATAR_ATTACHED_SOUNDS))
+    {
+        return;
+    }
     // </FS:Ansariel>
+
+
 
     if (flags & LL_SOUND_FLAG_LOOP
         && mAudioSourcep && mAudioSourcep->isLoop() && mAudioSourcep->getCurrentData()

--- a/indra/newview/skins/default/xui/en/floater_NACL_explore_sounds.xml
+++ b/indra/newview/skins/default/xui/en/floater_NACL_explore_sounds.xml
@@ -52,4 +52,8 @@
 
 	<button bottom_delta="0" follows="left|bottom" height="20" label="Stop" name="stop_btn" right="-10" width="95" enabled="false"/>
 	<button bottom_delta="0" follows="left|bottom" height="20" label="Blacklist" name="bl_btn" right="-110" width="95" enabled="false"/>
+
+
+    <button bottom_delta="25" follows="left|bottom" height="20" label="Block attached sounds by avatar" name="block_avatar_attached_sounds_btn" left="10" width="195" enabled="true"/>
+    <button bottom_delta="0" follows="left|bottom" height="20" label="Block rezzed sounds by avatar" name="block_avatar_rezzed_sounds_btn" left_delta="200" width="195" enabled="true"/>
 </floater>

--- a/indra/newview/skins/default/xui/en/floater_fs_asset_blacklist.xml
+++ b/indra/newview/skins/default/xui/en/floater_fs_asset_blacklist.xml
@@ -27,6 +27,12 @@
 	<floater.string name="asset_resident">
 		Resident
 	</floater.string>
+    <floater.string name="asset_avatar_attached_sounds">
+        Avatar Attached Sounds
+    </floater.string>
+    <floater.string name="asset_avatar_rezzed_sounds">
+        Avatar Rezzed Sounds
+    </floater.string>
 	<floater.string name="asset_unknown">
 		Unknown
 	</floater.string>


### PR DESCRIPTION
Add options in sounds explorer to block attached / rezzed sounds by avatar

I did not update XML files for all langages, only EN
![Screen1](https://github.com/user-attachments/assets/c582741e-f5de-4948-b9eb-33972dce84fe)
![Screen2](https://github.com/user-attachments/assets/fee1eaaa-a7fc-415c-94a8-ebd49df05e06)
