### PR TITLE
[FIRE-35656] Add privacy option to block payment notification from mu…

### DIFF
--- a/indra/newview/app_settings/settings.xml
+++ b/indra/newview/app_settings/settings.xml
@@ -21130,6 +21130,17 @@ Change of this parameter will affect the layout of buttons in notification toast
     <key>Value</key>
     <integer>1</integer>
   </map>
+  <key>FSBlockPaymentNotificationFromMutedAvatars</key>
+  <map>
+    <key>Comment</key>
+    <string>If enabled, the viewer not show incoming payment dialogs if the payment was sent by a blocked / muted avatar.</string>
+    <key>Persist</key>
+    <integer>1</integer>
+    <key>Type</key>
+    <string>Boolean</string>
+    <key>Value</key>
+    <integer>0</integer>
+  </map>
   <key>FSShowGroupTitleInTooltip</key>
   <map>
     <key>Comment</key>

--- a/indra/newview/llviewermessage.cpp
+++ b/indra/newview/llviewermessage.cpp
@@ -5826,6 +5826,7 @@ static void process_money_balance_reply_extended(LLMessageSystem* msg)
 
     bool you_paid_someone = (source_id == gAgentID);
     std::string gift_suffix = (transaction_type == TRANS_GIFT ? "_gift" : "");
+    bool is_muted = false;
     if (you_paid_someone)
     {
         if(!gSavedSettings.getBOOL("NotifyMoneySpend"))
@@ -5947,7 +5948,7 @@ static void process_money_balance_reply_extended(LLMessageSystem* msg)
 
         // <FS:Ansariel> FIRE-21803: Prevent cheating IM restriction via pay message
         //if (!reason.empty() && !LLMuteList::getInstance()->isMuted(source_id))
-        bool is_muted = LLMuteList::getInstance()->isMuted(source_id);
+        is_muted = LLMuteList::getInstance()->isMuted(source_id);
         if (!reason.empty() && !is_muted && RlvActions::canReceiveIM(source_id))
         // </FS:Ansariel>
         {
@@ -6013,6 +6014,10 @@ static void process_money_balance_reply_extended(LLMessageSystem* msg)
     }
     else
     {
+        if (is_muted && gSavedSettings.getBOOL("FSBlockPaymentNotificationFromMutedAvatars"))
+        {
+            return;
+        }
         LLAvatarNameCache::get(name_id, boost::bind(&money_balance_avatar_notify, _1, _2, notification, final_args, payload));
     }
 }

--- a/indra/newview/skins/default/xui/en/panel_preferences_privacy.xml
+++ b/indra/newview/skins/default/xui/en/panel_preferences_privacy.xml
@@ -206,6 +206,14 @@
     name="FSCreateGiveInventoryParticleEffect"
     top_pad="3"
     width="350" />
+   <check_box
+    control_name="FSBlockPaymentNotificationFromMutedAvatars"
+    height="16"
+    label="Don't show payment notifications from muted avatars"
+    layout="topleft"
+    name="FSBlockPaymentNotificationFromMutedAvatars"
+    top_pad="3"
+    width="350" />
 
     <button
      follows="left|top"


### PR DESCRIPTION
This PR adds a privacy option t make payment notifications not show at all if the payment is from muted avatars.

The current implementation removes the "reason", but users can still be harassed by the dialogs - it can be distressing to see a name pop up continuously in certain situations.

