### PR TITLE
es/strings.xml: Fix broken tag

### DIFF
--- a/indra/newview/skins/default/xui/es/strings.xml
+++ b/indra/newview/skins/default/xui/es/strings.xml
@@ -4587,7 +4587,7 @@ Si sigues recibiendo este mensaje, contacta con [SUPPORT_SITE].
 	<string name="bot_warning">
 		Estás conversando con un bot, [NAME]. No compartas información personal.
 Más información en https://second.life/scripted-agents.
-	</string
+	</string>
 	<string name="inventory_item_offered_rlv">
 		Ofrecido ítem de inventario a [NAME]
 	</string>


### PR DESCRIPTION
This fixes a broken string tag in the es/strings.xml file which was causing crash on startup for Spanish users.

Saw this reported by Damian Zhaoying in the preview group chat. I don't see a JIRA for this, but please let me know if you want me to file one.

![image](https://github.com/user-attachments/assets/f0a86de5-419e-46b7-b3b2-6d194c85d363)
