### PR TITLE
[FIRE-35748] Disable Draw Distance VRAM Optimization and add it as a toggle

### DIFF
--- a/indra/newview/app_settings/settings.xml
+++ b/indra/newview/app_settings/settings.xml
@@ -24163,7 +24163,7 @@ Change of this parameter will affect the layout of buttons in notification toast
     <key>FSDrawDistanceVRAMOptimization</key>
     <map>
       <key>Comment</key>
-      <string>Enables an optimization that shrinks your draw distance when VRAM becomes very low</string>
+      <string>Enables a feature that reduces your draw distance when VRAM becomes full</string>
       <key>Persist</key>
       <integer>1</integer>
       <key>Type</key>

--- a/indra/newview/app_settings/settings.xml
+++ b/indra/newview/app_settings/settings.xml
@@ -24160,6 +24160,17 @@ Change of this parameter will affect the layout of buttons in notification toast
       <key>Value</key>
       <integer>0</integer>
     </map>
+    <key>FSDrawDistanceVRAMOptimization</key>
+    <map>
+      <key>Comment</key>
+      <string>Enables an optimization that shrinks your draw distance when VRAM becomes very low</string>
+      <key>Persist</key>
+      <integer>1</integer>
+      <key>Type</key>
+      <string>Boolean</string>
+      <key>Value</key>
+      <integer>0</integer>
+    </map>
     <key>FSdataQAtest</key>
       <map>
       <key>Comment</key>

--- a/indra/newview/llviewerdisplay.cpp
+++ b/indra/newview/llviewerdisplay.cpp
@@ -222,6 +222,11 @@ void display_update_camera()
     // Cut draw distance in half when customizing avatar,
     // but on the viewer only.
     F32 final_far = gAgentCamera.mDrawDistance;
+
+    // <FS:TJ> [FIRE-35748] Only enable the LL Draw Distance VRAM optimization when the setting is enabled
+    static LLCachedControl<bool> use_vram_optimization(gSavedSettings, "FSDrawDistanceVRAMOptimization", false);
+    // </FS:TJ>
+
     if (gCubeSnapshot)
     {
         final_far = gSavedSettings.getF32("RenderReflectionProbeDrawDistance");
@@ -230,7 +235,10 @@ void display_update_camera()
     {
         final_far *= 0.5f;
     }
-    else if (LLViewerTexture::sDesiredDiscardBias > 2.f)
+    // <FS:TJ> [FIRE-35748] Only enable the LL Draw Distance VRAM optimization when the setting is enabled
+    //else if (LLViewerTexture::sDesiredDiscardBias > 2.f)
+    else if (use_vram_optimization && LLViewerTexture::sDesiredDiscardBias > 2.f)
+    // </FS:TJ>
     {
         final_far = llmax(32.f, final_far / (LLViewerTexture::sDesiredDiscardBias - 1.f));
     }

--- a/indra/newview/skins/default/xui/en/menu_viewer.xml
+++ b/indra/newview/skins/default/xui/en/menu_viewer.xml
@@ -4794,6 +4794,16 @@
                  parameter="RenderAttachedParticles" />
             </menu_item_check>
             <menu_item_check
+             label="Draw Distance VRAM Optimization"
+             name="Draw Distance VRAM Optimization">
+                <menu_item_check.on_check
+                 function="CheckControl"
+                 parameter="FSDrawDistanceVRAMOptimization" />
+                <menu_item_check.on_click
+                 function="ToggleControl"
+                 parameter="FSDrawDistanceVRAMOptimization" />
+            </menu_item_check>
+            <menu_item_check
              label="Collect Font Vertex Buffers"
              name="Collect Font Vertex Buffers">
                 <menu_item_check.on_check

--- a/indra/newview/skins/default/xui/en/menu_viewer.xml
+++ b/indra/newview/skins/default/xui/en/menu_viewer.xml
@@ -4794,8 +4794,8 @@
                  parameter="RenderAttachedParticles" />
             </menu_item_check>
             <menu_item_check
-             label="Draw Distance VRAM Optimization"
-             name="Draw Distance VRAM Optimization">
+             label="Reduce Draw Distance when VRAM is full"
+             name="Reduce Draw Distance when VRAM is full">
                 <menu_item_check.on_check
                  function="CheckControl"
                  parameter="FSDrawDistanceVRAMOptimization" />

--- a/indra/newview/skins/default/xui/en/panel_preferences_graphics1.xml
+++ b/indra/newview/skins/default/xui/en/panel_preferences_graphics1.xml
@@ -1531,6 +1531,7 @@ If you do not understand the distinction then leave this control alone."
          layout="topleft"
          left="20"
          top_pad="9"
+         width="220"
          label="Enable Attached Lights (Face Lights)"
          tool_tip="This will enable any lights, such as face lights, avatars have attached to them. Useful for turning off facelights when necessary."
          name="Render Attached Lights">
@@ -1542,10 +1543,10 @@ If you do not understand the distinction then leave this control alone."
          parameter="RenderAttachedLights"/>
         </check_box>
         <check_box
-         follows="top|left"
          layout="topleft"
-         left="20"
-         top_pad="9"
+         left_pad="20"
+         top_delta="0"
+         width="200"
          label="Render Attached Particles"
          name="Render Attached Particles">
          <check_box.on_check
@@ -1555,6 +1556,15 @@ If you do not understand the distinction then leave this control alone."
          function="Advanced.HandleAttachedLightParticles"
          parameter="RenderAttachedParticles"/>
         </check_box>
+        <check_box
+         control_name="FSDrawDistanceVRAMOptimization"
+         follows="top|left"
+         layout="topleft"
+         left="20"
+         top_pad="9"
+         label="Enable Draw Distance VRAM Optimization"
+         name="Draw Distance VRAM Optimization"
+         tool_tip="Enables an optimization that shrinks your draw distance when your VRAM becomes very low"/>
         <slider
          control_name="PrecachingDelay"
          decimal_digits="0"

--- a/indra/newview/skins/default/xui/en/panel_preferences_graphics1.xml
+++ b/indra/newview/skins/default/xui/en/panel_preferences_graphics1.xml
@@ -1562,9 +1562,9 @@ If you do not understand the distinction then leave this control alone."
          layout="topleft"
          left="20"
          top_pad="9"
-         label="Enable Draw Distance VRAM Optimization"
-         name="Draw Distance VRAM Optimization"
-         tool_tip="Enables an optimization that shrinks your draw distance when your VRAM becomes very low"/>
+         label="Reduce Draw Distance when VRAM is full"
+         name="Reduce Draw Distance when VRAM is full"
+         tool_tip="Enables a feature that reduces your draw distance when VRAM becomes full"/>
         <slider
          control_name="PrecachingDelay"
          decimal_digits="0"


### PR DESCRIPTION
Disables the Draw Distance VRAM optimization that LL implemented to be on by default, that way when your VRAM gets very low, the draw distance doesn't plummet for seemingly no reason and people have reported it believing it to be a bug.

Added a toggle under Preferences->Graphics->Renderer to turn this optimisation back on
Also added the toggle to the Developer->Rendering menu