### PR TITLE
Add 'Delete from outfit' context menu entry

### DIFF
--- a/indra/newview/llinventoryfunctions.cpp
+++ b/indra/newview/llinventoryfunctions.cpp
@@ -1170,6 +1170,22 @@ void reset_inventory_filter()
     }
 }
 
+
+// <AS:Chanayane> Delete from outfit context menu entry
+void delete_from_outfit(const uuid_vec_t& ids)
+{
+    for (const LLUUID& item_uuid : ids)
+    {
+        LLViewerInventoryItem* item = gInventory.getItem(item_uuid);
+        if (item && item->getIsLinkType())
+        {
+            gInventory.removeItem(item_uuid);
+        }
+    }
+}
+// </AS:Chanayane>
+
+
 void open_marketplace_listings()
 {
     LLFloaterReg::showInstance("marketplace_listings");

--- a/indra/newview/llinventoryfunctions.h
+++ b/indra/newview/llinventoryfunctions.h
@@ -73,6 +73,10 @@ void show_task_item_profile(const LLUUID& item_uuid, const LLUUID& object_id);
 void show_item_original(const LLUUID& item_uuid);
 void reset_inventory_filter();
 
+// <AS:Chanayane> Delete from outfit context menu entry
+void delete_from_outfit(const uuid_vec_t& ids);
+// </AS:Chanayane>
+
 // Nudge the listing categories in the inventory to signal that their marketplace status changed
 void update_marketplace_category(const LLUUID& cat_id, bool perform_consistency_enforcement = true, bool skip_clear_listing = false);
 // Nudge all listing categories to signal that their marketplace status changed

--- a/indra/newview/llwearableitemslist.cpp
+++ b/indra/newview/llwearableitemslist.cpp
@@ -1141,6 +1141,9 @@ LLContextMenu* LLWearableItemsList::ContextMenu::createMenu()
     registrar.add("Wearable.Edit", boost::bind(handle_item_edit, selected_id));
     registrar.add("Wearable.CreateNew", boost::bind(createNewWearable, selected_id));
     registrar.add("Wearable.ShowOriginal", boost::bind(show_item_original, selected_id));
+    // <AS:Chanayane> Delete from outfit context menu entry
+    registrar.add("Wearable.DeleteFromOutfit", boost::bind(delete_from_outfit, ids));
+    // </AS:Chanayane>
     registrar.add("Wearable.TakeOffDetach",
                   //boost::bind(&LLAppearanceMgr::removeItemsFromAvatar, LLAppearanceMgr::getInstance(), ids, no_op)); // <FS:Ansariel> [SL:KB] - Patch: Appearance-Misc
                   boost::bind(&LLAppearanceMgr::removeItemsFromAvatar, LLAppearanceMgr::getInstance(), ids));
@@ -1301,6 +1304,10 @@ void LLWearableItemsList::ContextMenu::updateItemsVisibility(LLContextMenu* menu
     setMenuItemEnabled(menu, "create_new",          LLAppearanceMgr::instance().canAddWearables(ids));
     setMenuItemVisible(menu, "show_original",       !standalone);
     setMenuItemEnabled(menu, "show_original",       n_items == 1 && n_links == n_items);
+// <AS:Chanayane> Delete from outfit context menu entry
+    setMenuItemVisible(menu, "delete_from_outfit",  n_links > 0);
+    setMenuItemEnabled(menu, "delete_from_outfit",  n_links > 0);
+// </AS:Chanayane>
     setMenuItemVisible(menu, "take_off",            mask == MASK_CLOTHING && n_worn == n_items);
     setMenuItemVisible(menu, "detach",              mask == MASK_ATTACHMENT && n_worn == n_items);
     setMenuItemVisible(menu, "take_off_or_detach",  mask == (MASK_ATTACHMENT|MASK_CLOTHING));

--- a/indra/newview/skins/default/xui/en/menu_wearable_list_item.xml
+++ b/indra/newview/skins/default/xui/en/menu_wearable_list_item.xml
@@ -91,6 +91,16 @@
          function="RLV.EnableIfNot"
          parameter="showinv"/>
     </menu_item_call>
+<!-- [AS:Chanayane] Delete from outfit context menu entry -->
+   <menu_item_call
+   label="Delete from outfit"
+   layout="topleft"
+   visible="false"
+   name="delete_from_outfit">
+      <on_click
+      function="Wearable.DeleteFromOutfit" />
+   </menu_item_call>
+<!-- [/AS:Chanayane] -->
     <menu_item_call
      label="Create New"
      layout="topleft"


### PR DESCRIPTION
This adds a context menu entry when right clicking on an item in an outfit, in the Appearance window, Outfits tab.
This is useful for when you mistakenly added some HUD or anything else you didn't want in your outfit.
This is simpler than going inside the inventory and deleting the links from the outfit folder.
This only deletes the links of course, not the real inventory item.
There is currently no confirmation, it deletes the links right away.

<img width="582" height="606" alt="AyaneStormOS-Special_uZHnABbWQp" src="https://github.com/user-attachments/assets/4ecb9d20-0413-4a49-b08b-76bc1e2939d0" />

