### PR TITLE
fix for macOS build

### DIFF
--- a/indra/llui/llfolderviewmodel.h
+++ b/indra/llui/llfolderviewmodel.h
@@ -378,7 +378,7 @@ protected:
     virtual bool hasParent() override { return mParent != NULL; }
 
     // <FS:ND/>
-    virtual LLFolderViewModelItem* getParent() const { return mParent; }
+    virtual LLFolderViewModelItem* getParent() const override { return mParent; }
 
     S32                         mSortVersion;
     bool                        mPassedFilter;

--- a/indra/newview/llwearableitemslist.cpp
+++ b/indra/newview/llwearableitemslist.cpp
@@ -575,9 +575,9 @@ void FSPanelCOFWearableOutfitListItem::updateItemWeight(U32 item_weight)
 }
 
 //virtual
-void FSPanelCOFWearableOutfitListItem::updateItem(const std::string& name, EItemState item_state)
+void FSPanelCOFWearableOutfitListItem::updateItem(const std::string& name, bool favorite, EItemState item_state)
 {
-    LLPanelWearableOutfitItem::updateItem(name, item_state);
+    LLPanelWearableOutfitItem::updateItem(name, favorite, item_state);
     mWeightCtrl->setVisible(true);
     reshapeWidgets();
 }

--- a/indra/newview/llwearableitemslist.h
+++ b/indra/newview/llwearableitemslist.h
@@ -256,7 +256,7 @@ public:
 
     void updateItemWeight(U32 item_weight);
 
-    /*virtual*/ void updateItem(const std::string& name, EItemState item_state = IS_DEFAULT);
+    /*virtual*/ void updateItem(const std::string& name, bool favorite, EItemState item_state = IS_DEFAULT);
 
     /*virtual*/ void onMouseLeave(S32 x, S32 y, MASK mask);
 


### PR DESCRIPTION
It wasn't building on my Mac Mini M4 so here are a few fixes that will help with that.

Note to the PR reviewer: I noticed something that is potentially a typo or a merge error in llfolderviewmodel.h:

LLFolderViewModelItem* getParent() appears twice.

Once as ```virtual const LLFolderViewModelItem* getParent() override { return mParent; };```
Once as ````virtual LLFolderViewModelItem* getParent() const override { return mParent; }```

It's perfectly valid, but it's suspicious.