### PR TITLE
fix kakadu version in autobuild.xml

### DIFF
--- a/autobuild.xml
+++ b/autobuild.xml
@@ -1367,7 +1367,7 @@
         <key>copyright</key>
         <string>Kakadu software</string>
         <key>version</key>
-        <string>8.4.1</string>
+        <string>8.5.0</string>
         <key>name</key>
         <string>kdu</string>
         <key>description</key>


### PR DESCRIPTION
Fixed the Kakadu version in autobuild.xml (8.4.1 -> 8.5.0)

I will try to build with the new 8.6.0 soon.