### PR TITLE
Fix "delete from outfit" context menu appearing in favorite wearables menu

### DIFF
--- a/indra/newview/llwearableitemslist.cpp
+++ b/indra/newview/llwearableitemslist.cpp
@@ -1204,6 +1204,15 @@ void LLWearableItemsList::ContextMenu::updateItemsVisibility(LLContextMenu* menu
     bool rlvCanRemove = !RlvActions::isRlvEnabled();
 // [/RLVa:KB]
 
+// <FS:Trish> Fix for "Delete from outfit" context menu option showing in favorites window.
+    bool   is_outfit_menu   = false;
+    LLUUID outfit_folder_id = gInventory.findCategoryUUIDForType(LLFolderType::FT_MY_OUTFITS);
+    if (!ids.empty())
+    {
+        is_outfit_menu = gInventory.isObjectDescendentOf(ids.front(), outfit_folder_id);
+    }
+// </FS:Trish>
+
     for (uuid_vec_t::const_iterator it = ids.begin(); it != ids.end(); ++it)
     {
         LLUUID id = *it;
@@ -1315,8 +1324,8 @@ void LLWearableItemsList::ContextMenu::updateItemsVisibility(LLContextMenu* menu
     setMenuItemVisible(menu, "show_original",       !standalone);
     setMenuItemEnabled(menu, "show_original",       n_items == 1 && n_links == n_items);
 // <AS:Chanayane> Delete from outfit context menu entry
-    setMenuItemVisible(menu, "delete_from_outfit",  n_links > 0);
-    setMenuItemEnabled(menu, "delete_from_outfit",  n_links > 0);
+    setMenuItemVisible(menu, "delete_from_outfit", n_links > 0 && is_outfit_menu);
+    setMenuItemEnabled(menu, "delete_from_outfit", n_links > 0 && is_outfit_menu);
 // </AS:Chanayane>
     setMenuItemVisible(menu, "favorites_add",       can_favorite);
     setMenuItemVisible(menu, "favorites_remove",    can_unfavorite);


### PR DESCRIPTION
Hi, first off, I'm new to compiling FS and to the viewer codebase in general, so I tried to tackle a simple thing first. Don't hesitate to correct me if there's a better way to do this and I'll adjust the PR.

Associated JIRA: None that I could find.

Bug: Since the addition of "Delete from outfit" to the context menu, when right clicking an object in your Appearance window, you can delete the link from an outfit from there. The favorites wearable window uses the same ContextMenu creation logic and would also populate the context menu with "Delete from outfit". This is confusing and did nothing as favorite wearables are links not within an outfit. 

Expected behavior: The delete from outfit option should only be made available from within the appearance window (or any outfit folders, rather).

Fix: Added a check to make the option only visible if the items are children of an outfit. 


Bug present on Beta 7.2.2.79281: 
<img width="310" height="205" alt="036fa72fd2b862023bdace315d42cc05" src="https://github.com/user-attachments/assets/482050b3-468e-42f7-9ea3-e7b103667266" />

With the fix: 
<img width="278" height="244" alt="5841698ae3b271b85f21113b125113a6" src="https://github.com/user-attachments/assets/b4c25985-3b4d-41f3-9a0a-6df9ffd7ec7f" />

