### PR TITLE
FIX - Profile Pick save buttons wrongfully enabled while preview mode is active

### DIFF
--- a/indra/newview/llpanelprofile.cpp
+++ b/indra/newview/llpanelprofile.cpp
@@ -2301,6 +2301,13 @@ void LLPanelProfileSecondLife::onHideAgeCallback()
 
 void LLPanelProfileSecondLife::onSaveDescriptionChanges()
 {
+    // <FS:Trish> Fix applying changes when exiting profile causing the preview text to apply if preview mode is active
+    if (mPreview)
+    {
+        onCommitMenu(LLSD("preview"));
+    }
+    // </FS:Trish>
+
     mDescriptionText = mDescriptionEdit->getValue().asString();
     if (!gAgent.getRegionCapability(PROFILE_PROPERTIES_CAP).empty())
     {
@@ -2966,6 +2973,13 @@ void LLPanelProfileFirstLife::onSetDescriptionDirty()
 
 void LLPanelProfileFirstLife::onSaveDescriptionChanges()
 {
+    // <FS:Trish> Fix applying changes when exiting profile causing the preview text to apply if preview mode is active
+    if (mPreview)
+    {
+        onClickPreview();
+    }
+    // </FS:Trish>
+
     mCurrentDescription = mDescriptionEdit->getValue().asString();
     if (!gAgent.getRegionCapability(PROFILE_PROPERTIES_CAP).empty())
     {

--- a/indra/newview/llpanelprofilepicks.cpp
+++ b/indra/newview/llpanelprofilepicks.cpp
@@ -784,6 +784,12 @@ void LLPanelProfilePick::apply()
 {
     if ((mNewPick || getIsLoaded()) && isDirty())
     {
+        // <FS:Trish> Fix applying changes when exiting profile causing the preview text to apply if preview mode is active
+        if (mPreview)
+        {
+            onClickPreview();
+        }
+        // </FS:Trish>
         sendUpdate();
     }
 }
@@ -847,6 +853,13 @@ void LLPanelProfilePick::onClickTeleport()
 
 void LLPanelProfilePick::enableSaveButton(bool enable)
 {
+    //<FS:Trish> Fix Save Buttons being enabled in various cases while preview mode is on
+    if (mPreview)
+    {
+        enable = false;
+    }
+    //</FS:Trish>
+    
     childSetVisible("save_changes_lp", enable);
 
     childSetVisible("save_btn_lp", enable && !mNewPick);


### PR DESCRIPTION
I could not find a JIRA referencing this problem.

## Bug
When using the preview mode within profile picks, the save button is correctly disabled.
However, several actions can cause this to be bypassed. When saving a pick, mPreview mode should be OFF or turned off to prevent the pick from saving while in preview mode. If a pick is saved while in preview, it saves incorrectly (it removes links).

## Reproduction
1) A first case of this bug is when you edit a pick with a link inside, go to preview mode, then close the floater. The pop up that asks you to save or discard the changes will cause the pick to save while in preview mode if you click "Save". Instead, it should turn off preview mode, then save before closing the floater.
2) A second case of this bug is when you edit a pick, go to preview mode, then "Set location". The save buttons are wrongfully re-enabled.

## Fix
For case 1), I've made it so the save & quit will toggle off preview before saving.
For case 2), I gated the function to enable save buttons to cover all cases of it being enabled while preview is on. This is the least invasive change I could find that will remain compatible with future changes from LL