### PR TITLE
FIX - Inspect floater doesn't count PBR render materials

### DIFF
--- a/indra/newview/llfloaterinspect.cpp
+++ b/indra/newview/llfloaterinspect.cpp
@@ -54,6 +54,7 @@
 #include "llviewertexturelist.h"
 // PoundLife END
 #include "llvovolume.h"
+#include "llgltfmaterial.h"
 
 // <FS:Ansariel> FIRE-22292: Configurable columns
 #include "llmenugl.h"
@@ -648,32 +649,54 @@ void LLFloaterInspect::getObjectTextureMemory(LLViewerObject* object, U32& objec
 
     for (U8 j = 0; j < te_count; j++)
     {
-        LLViewerTexture* img = object->getTEImage(j);
-        if (img)
+        LLTextureEntry* te = object->getTE(j);
+        if (!te)
         {
-            calculateTextureMemory(img, object_texture_list, object_texture_memory, object_vram_memory);
+            continue;
         }
 
-        // materials per face
-        if (object->getTE(j)->getMaterialParams().notNull())
+        // If a PBR (GLTF) render material is present, count this instead of legacy textures.
+        if (LLGLTFMaterial* gltf_mat = te->getGLTFRenderMaterial())
         {
-            uuid = object->getTE(j)->getMaterialParams()->getNormalID();
-            if (uuid.notNull())
+            for (U32 i = 0; i < LLGLTFMaterial::GLTF_TEXTURE_INFO_COUNT; ++i)
             {
-                LLViewerTexture* img = gTextureList.getImage(uuid);
-                if (img)
+                const LLUUID& tex_id = gltf_mat->mTextureId[i];
+                if (tex_id.notNull())
                 {
-                    calculateTextureMemory(img, object_texture_list, object_texture_memory, object_vram_memory);
+                    if (LLViewerTexture* img = gTextureList.getImage(tex_id))
+                    {
+                        calculateTextureMemory(img, object_texture_list, object_texture_memory, object_vram_memory);
+                    }
                 }
             }
-
-            uuid = object->getTE(j)->getMaterialParams()->getSpecularID();
-            if (uuid.notNull())
+        }
+        else
+        {
+            // Legacy diffuse per face
+            if (LLViewerTexture* img = object->getTEImage(j))
             {
-                LLViewerTexture* img = gTextureList.getImage(uuid);
-                if (img)
+                calculateTextureMemory(img, object_texture_list, object_texture_memory, object_vram_memory);
+            }
+
+            // Legacy materials per face (normal/specular)
+            if (te->getMaterialParams().notNull())
+            {
+                uuid = te->getMaterialParams()->getNormalID();
+                if (uuid.notNull())
                 {
-                    calculateTextureMemory(img, object_texture_list, object_texture_memory, object_vram_memory);
+                    if (LLViewerTexture* img = gTextureList.getImage(uuid))
+                    {
+                        calculateTextureMemory(img, object_texture_list, object_texture_memory, object_vram_memory);
+                    }
+                }
+
+                uuid = te->getMaterialParams()->getSpecularID();
+                if (uuid.notNull())
+                {
+                    if (LLViewerTexture* img = gTextureList.getImage(uuid))
+                    {
+                        calculateTextureMemory(img, object_texture_list, object_texture_memory, object_vram_memory);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Fixes [FIRE-34365](https://jira.firestormviewer.org/browse/FIRE-34365?jql=text%20~%20inspect%20ORDER%20BY%20created%20DESC)

Currently, the inspect floater does not take PBR into account when analyzing texture details.

This PR makes it so we display render info of the gtlf material (render material, to include overrides), instead of the legacy texture info if there is a material.

It also works if you edit, go to BP tab to see BP textures, and inspect while it's active, you will see the vram usage of the legacy textures instead of the gtlf material.

https://gyazo.com/618bbec8e159c251155bf2d7f7aa9afe
https://gyazo.com/d37945e626fcc7b4de99a79bc5326104