### PR TITLE
IMPROVEMENT - NearbyChatControl styling

### DIFF
--- a/indra/newview/fsnearbychatcontrol.cpp
+++ b/indra/newview/fsnearbychatcontrol.cpp
@@ -36,6 +36,7 @@
 #include "llchatmentionhelper.h"
 #include "llemojihelper.h"
 #include "llfloaterchatmentionpicker.h"
+#include "llfocusmgr.h"
 #include "llscrollcontainer.h"
 #include "llworld.h"
 #include "rlvactions.h"
@@ -46,7 +47,11 @@ FSNearbyChatControl::FSNearbyChatControl(const FSNearbyChatControl::Params& p) :
     LLChatEntry(p),
     mDefault(p.is_default),
     mTextPadLeft(p.text_pad_left),
-    mTextPadRight(p.text_pad_right)
+    mTextPadRight(p.text_pad_right),
+    mBackgroundPad(p.background_pad),
+    mBgImage(p.background_image),
+    mBgImageDisabled(p.background_image_disabled),
+    mBgImageFocused(p.background_image_focused)
 {
     //<FS:TS> FIRE-11373: Autoreplace doesn't work in nearby chat bar
     setAutoreplaceCallback(boost::bind(&LLAutoReplace::autoreplaceCallback, LLAutoReplace::getInstance(), _1, _2, _3, _4, _5));
@@ -55,6 +60,7 @@ FSNearbyChatControl::FSNearbyChatControl(const FSNearbyChatControl::Params& p) :
 
     setCommitOnFocusLost(false);
     setPassDelete(true);
+    mBGVisible = false;
     setFont(LLViewerChat::getChatFont());
     enableSingleLineMode(true);
 
@@ -89,6 +95,18 @@ void FSNearbyChatControl::onKeystroke(LLTextEditor* caller)
     FSNearbyChat::handleChatBarKeystroke(caller);
 }
 
+void FSNearbyChatControl::paste()
+{
+    LLChatEntry::paste();
+
+    // Keep nearby chat on one visual line by flattening paragraph markers from paste.
+    S32 cursor_pos = getCursorPos();
+    LLWString content = getWText();
+    LLWStringUtil::replaceChar(content, llwchar(182), llwchar('\n'));
+    setWText(content);
+    setCursorPos(cursor_pos);
+}
+
 // send our focus status to the LLNearbyChat hub
 void FSNearbyChatControl::onFocusReceived()
 {
@@ -121,6 +139,7 @@ void FSNearbyChatControl::setFocus(bool focus)
 void FSNearbyChatControl::draw()
 {
     applyTextPadding();
+    drawBackground();
     LLChatEntry::draw();
 }
 
@@ -129,6 +148,73 @@ void FSNearbyChatControl::setTextPadding(S32 left, S32 right)
     mTextPadLeft = left;
     mTextPadRight = right;
     applyTextPadding();
+}
+
+void FSNearbyChatControl::drawBackground()
+{
+    LLUIImage* image = nullptr;
+
+    if (getReadOnly())
+    {
+        image = mBgImageDisabled;
+    }
+    else if (hasFocus())
+    {
+        image = mBgImageFocused;
+    }
+    else
+    {
+        image = mBgImage;
+    }
+
+    if (!image)
+    {
+        return;
+    }
+
+    LLRect background_rect = getLocalRect();
+    background_rect.stretch(-mBackgroundPad);
+    if (background_rect.getWidth() <= 0 || background_rect.getHeight() <= 0)
+    {
+        return;
+    }
+
+    const F32 alpha = getCurrentTransparency();
+    if (hasFocus())
+    {
+        LLColor4 focus_color = gFocusMgr.getFocusColor();
+        focus_color.setAlpha(alpha);
+        image->drawBorder(
+            background_rect.mLeft,
+            background_rect.mBottom,
+            background_rect.getWidth(),
+            background_rect.getHeight(),
+            focus_color,
+            gFocusMgr.getFocusFlashWidth());
+    }
+
+    LLColor4 image_color = LLColor4::white;
+    image_color.setAlpha(alpha);
+    image->draw(background_rect, image_color);
+
+    // LLLineEditor-style subtle inner shade ring.
+    if (background_rect.getWidth() > 2 && background_rect.getHeight() > 2)
+    {
+        LLRect inner_border_rect = background_rect;
+        inner_border_rect.stretch(-1);
+
+        LLColor4 inner_shade = LLColor4::black;
+        const F32 inner_alpha = getReadOnly() ? 0.12f : (hasFocus() ? 0.10f : 0.16f);
+        inner_shade.setAlpha(alpha * inner_alpha);
+
+        image->drawBorder(
+            inner_border_rect.mLeft,
+            inner_border_rect.mBottom,
+            inner_border_rect.getWidth(),
+            inner_border_rect.getHeight(),
+            inner_shade,
+            1);
+    }
 }
 
 void FSNearbyChatControl::applyTextPadding()

--- a/indra/newview/fsnearbychatcontrol.h
+++ b/indra/newview/fsnearbychatcontrol.h
@@ -32,6 +32,8 @@
 #include "fschatparticipants.h"
 #include "rlvhandler.h"
 
+class LLUIImage;
+
 class FSNearbyChatControl : public LLChatEntry, public FSChatParticipants
 {
 public:
@@ -40,8 +42,20 @@ public:
         Optional<bool> is_default;
         Optional<S32>  text_pad_left;
         Optional<S32>  text_pad_right;
+        Optional<S32>  background_pad;
+        Optional<LLUIImage*> background_image;
+        Optional<LLUIImage*> background_image_disabled;
+        Optional<LLUIImage*> background_image_focused;
 
-        Params() : is_default("default", false), text_pad_left("text_pad_left", 0), text_pad_right("text_pad_right", 0) {}
+        Params()
+            : is_default("default", false),
+              text_pad_left("text_pad_left", 0),
+              text_pad_right("text_pad_right", 0),
+              background_pad("background_pad", 1),
+              background_image("background_image"),
+              background_image_disabled("background_image_disabled"),
+              background_image_focused("background_image_focused")
+        {}
     };
 
     FSNearbyChatControl(const Params& p);
@@ -51,6 +65,7 @@ public:
     void onFocusLost() override;
     void setFocus(bool focus) override;
     void draw() override;
+    void paste() override;
 
     bool handleKeyHere(KEY key, MASK mask) override;
 
@@ -64,6 +79,7 @@ private:
     // Typing in progress, expand gestures etc.
     void onKeystroke(LLTextEditor* caller);
 
+    void drawBackground();
     void applyTextPadding();
 
     // Unfocus and autohide chat bar accordingly if we are the default chat bar
@@ -75,6 +91,10 @@ private:
     bool                        mDefault;
     S32                         mTextPadLeft;
     S32                         mTextPadRight;
+    S32                         mBackgroundPad;
+    LLUIImage*                  mBgImage;
+    LLUIImage*                  mBgImageDisabled;
+    LLUIImage*                  mBgImageFocused;
     boost::signals2::connection mRlvBehaviorCallbackConnection;
     boost::signals2::connection mEmojiHelperSettingConnection;
 };

--- a/indra/newview/skins/default/xui/en/widgets/fs_nearby_chat_control.xml
+++ b/indra/newview/skins/default/xui/en/widgets/fs_nearby_chat_control.xml
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes" ?>
 <chat_editor
+  background_pad="0"
+  background_image="TextField_Off"
+  background_image_disabled="TextField_Disabled"
+  background_image_focused="TextField_Active"
+  h_pad="0"
   max_length="3070"
   v_pad="0"
   valign="center"


### PR DESCRIPTION
see FIRE-36492

A couple of extra changes to bring the style and behavior of the nearby chat bar closer to it's old LineEntry style.

- Fixed pasting multiline text not introducing a new line
- Re-added the unfocused vs focused style.
- Reduced padding to be more compact like before.
