### PR TITLE
Use APP_NAME expansion for logos_lbl on all languages

### DIFF
--- a/indra/newview/skins/default/xui/az/panel_progress.xml
+++ b/indra/newview/skins/default/xui/az/panel_progress.xml
@@ -7,7 +7,7 @@
           <layout_stack name="vertical_centering2">
             <layout_panel name="panel_icons">
               <text name="logos_lbl">
-                Second Life istifadə edir:
+                [APP_NAME] istifadə edir:
               </text>
             </layout_panel>
           </layout_stack>

--- a/indra/newview/skins/default/xui/de/panel_progress.xml
+++ b/indra/newview/skins/default/xui/de/panel_progress.xml
@@ -7,7 +7,7 @@
 					<layout_stack name="vertical_centering2">
 						<layout_panel name="panel_icons">
 							<text name="logos_lbl">
-								Second Life verwendet
+								[APP_NAME] verwendet
 							</text>
 						</layout_panel>
 					</layout_stack>

--- a/indra/newview/skins/default/xui/en/panel_progress.xml
+++ b/indra/newview/skins/default/xui/en/panel_progress.xml
@@ -162,7 +162,7 @@
                          line_spacing.pixels="2"
                          name="logos_lbl"
                          text_color="LoginProgressBoxTextColor">
-                          Second Life uses
+                          [APP_NAME] uses
                         </text>
                       </layout_panel>
                     </layout_stack>

--- a/indra/newview/skins/default/xui/es/panel_progress.xml
+++ b/indra/newview/skins/default/xui/es/panel_progress.xml
@@ -7,7 +7,7 @@
 					<layout_stack name="vertical_centering2">
 						<layout_panel name="panel_icons">
 							<!-- <text name="logos_lbl">
-								Second Life uses
+								[APP_NAME] uses
 							</text> -->
 						</layout_panel>
 					</layout_stack>

--- a/indra/newview/skins/default/xui/fr/panel_progress.xml
+++ b/indra/newview/skins/default/xui/fr/panel_progress.xml
@@ -7,7 +7,7 @@
 					<layout_stack name="vertical_centering2">
 						<layout_panel name="panel_icons">
 							<text name="logos_lbl">
-								Second Life utilise
+								[APP_NAME] utilise
 							</text>
 						</layout_panel>
 					</layout_stack>

--- a/indra/newview/skins/default/xui/it/panel_progress.xml
+++ b/indra/newview/skins/default/xui/it/panel_progress.xml
@@ -7,7 +7,7 @@
 					<layout_stack name="vertical_centering2">
 						<layout_panel name="panel_icons">
 							<!-- <text name="logos_lbl">
-								Second Life uses
+								[APP_NAME] uses
 							</text> -->
 						</layout_panel>
 					</layout_stack>

--- a/indra/newview/skins/default/xui/pl/panel_progress.xml
+++ b/indra/newview/skins/default/xui/pl/panel_progress.xml
@@ -7,7 +7,7 @@
 					<layout_stack name="vertical_centering2">
 						<layout_panel name="panel_icons">
 							<text name="logos_lbl">
-								Second Life używa
+								[APP_NAME] używa
 							</text>
 						</layout_panel>
 					</layout_stack>

--- a/indra/newview/skins/default/xui/pt/panel_progress.xml
+++ b/indra/newview/skins/default/xui/pt/panel_progress.xml
@@ -7,7 +7,7 @@
 					<layout_stack name="vertical_centering2">
 						<layout_panel name="panel_icons">
 							<!-- <text name="logos_lbl">
-								Second Life uses
+								[APP_NAME] uses
 							</text> -->
 						</layout_panel>
 					</layout_stack>

--- a/indra/newview/skins/default/xui/ru/panel_progress.xml
+++ b/indra/newview/skins/default/xui/ru/panel_progress.xml
@@ -7,7 +7,7 @@
           <layout_stack name="vertical_centering2">
             <layout_panel name="panel_icons">
               <text name="logos_lbl">
-                Вторая Жизнь использует
+                [APP_NAME] использует
               </text>
             </layout_panel>
           </layout_stack>

--- a/indra/newview/skins/default/xui/zh/panel_progress.xml
+++ b/indra/newview/skins/default/xui/zh/panel_progress.xml
@@ -7,7 +7,7 @@
 					<layout_stack name="vertical_centering2">
 						<layout_panel name="panel_icons">
 							<text name="logos_lbl">
-								Second Life 使用
+								[APP_NAME] 使用
 							</text>
 						</layout_panel>
 					</layout_stack>


### PR DESCRIPTION
Usage of the technologies is a viewer side thing so it makes sense to label it as such; SL dropped use of fmod a while ago as well. Japanese language file already did this so this just unifies the rest of them. Did the commented ones as well just in case someone wants to use them again in future.