### PR TITLE
FIX - Inspect floater VRAM estimate can overshoot by a lot

### DIFF
--- a/indra/newview/llfloaterinspect.cpp
+++ b/indra/newview/llfloaterinspect.cpp
@@ -721,6 +721,16 @@ void LLFloaterInspect::calculateTextureMemory(LLViewerTexture* texture, uuid_vec
     U32 vram_memory = (texture->getFullHeight() * texture->getFullWidth() * 32 / 8);
     U32 texture_memory = (texture->getFullHeight() * texture->getFullWidth() * texture->getComponents());
 
+    // Use actual GL memory instead of a fixed RGBA32 estimate if possible.
+    if (texture->hasGLTexture())
+    {
+        const S32 vram_bytes = texture->getTextureMemory().value();
+        if (vram_bytes > 0)
+        {
+            vram_memory = static_cast<U32>(vram_bytes);
+        }
+    }
+
     if (std::find(mTextureList.begin(), mTextureList.end(), uuid) == mTextureList.end())
     {
         mTextureList.push_back(uuid);


### PR DESCRIPTION
The inspect floater VRAM's way of calculating VRAM usage is to currently guess the vram usage by doing width * height * 32bit (cause textures are RGBA32) / 8 to convert to bytes. This is a "worst possible outcome" estimate. This can boost the reported VRAM usage by two times in some use cases. This estimation exaggeration can make 2k PBR materials look disproportionally bad on paper.

The floater should just take the actual (allocated GL) memory instead, for a closer estimate. This reports a much more accurate number.

just one example with one of my objects, but you can try with your own.
before with fixed estimate: https://gyazo.com/f405634ad5911aa2ca26861c64b68f36
now with memory read: https://gyazo.com/1d78c2eaf67253316afd9edc4a404e79