### PR TITLE
DRAFT: Add mechanism to de-risk and warn about suspicious links in IMs

### DIFF
--- a/indra/llui/CMakeLists.txt
+++ b/indra/llui/CMakeLists.txt
@@ -62,6 +62,7 @@ set(llui_SOURCE_FILES
     llnotificationslistener.cpp
     llnotificationsutil.cpp
     llpanel.cpp
+    llphishingfilter.cpp
     llprogressbar.cpp
     llradiogroup.cpp
     llresizebar.cpp
@@ -183,6 +184,7 @@ set(llui_HEADER_FILES
     llnotificationtemplate.h
     llnotificationvisibilityrule.h
     llpanel.h
+    llphishingfilter.h
     llprogressbar.h
     llradiogroup.h
     llresizebar.h
@@ -283,6 +285,7 @@ if(LL_TESTS)
 
   SET(llui_TEST_SOURCE_FILES
       llurlmatch.cpp
+      tests/llphishingfilter_test.cpp
       )
   set_property( SOURCE ${llui_TEST_SOURCE_FILES} PROPERTY LL_TEST_ADDITIONAL_LIBRARIES ${test_libs})
   LL_ADD_PROJECT_UNIT_TESTS(llui "${llui_TEST_SOURCE_FILES}")

--- a/indra/llui/CMakeLists.txt
+++ b/indra/llui/CMakeLists.txt
@@ -285,7 +285,7 @@ if(LL_TESTS)
 
   SET(llui_TEST_SOURCE_FILES
       llurlmatch.cpp
-      tests/llphishingfilter_test.cpp
+      llphishingfilter.cpp
       )
   set_property( SOURCE ${llui_TEST_SOURCE_FILES} PROPERTY LL_TEST_ADDITIONAL_LIBRARIES ${test_libs})
   LL_ADD_PROJECT_UNIT_TESTS(llui "${llui_TEST_SOURCE_FILES}")

--- a/indra/llui/llphishingfilter.cpp
+++ b/indra/llui/llphishingfilter.cpp
@@ -33,6 +33,7 @@
 
 #include <boost/regex.hpp>
 #include <boost/algorithm/string.hpp>
+#include <set>
 
 LLPhishingFilter::LLPhishingFilter()
 {
@@ -55,13 +56,6 @@ S32 LLPhishingFilter::evaluateURLRisk(const std::string& url) const
 		return 0;
 	}
 
-	S32 score = 0;
-
-	// Improved regex for Second Life and Marketplace keywords with common typos/variations
-	// matches secondlife, seconld-lif, second-live, marketplacesecondlife, etc.
-	static const boost::regex sl_pattern("secon[dl]*d+[e]?[-_ \\.]*li[fv][e]?", boost::regex::icase);
-	static const boost::regex mp_pattern("mark[e]?tpl[a]?ce", boost::regex::icase);
-
 	std::string host = getHostname(lower_url);
 	std::string domain = getBaseDomain(lower_url);
 
@@ -72,27 +66,70 @@ S32 LLPhishingFilter::evaluateURLRisk(const std::string& url) const
 		return 0;
 	}
 
-	// Check for keywords in the hostname specifically
-	if (boost::regex_search(host, sl_pattern) || 
-		boost::regex_search(host, mp_pattern) ||
-		domain == "suspicious-url.com")
+	S32 score = 0;
+
+	// Explicit test domain
+	if (domain == "suspicious-url.com")
 	{
-		// High risk: contains SL keywords in hostname but is not on an official domain
-		// Or is the explicit test domain suspicious-url.com
 		score += 100;
 	}
 
-	// Medium risk: known free hosting/dynamic DNS often used for phishing
-	if (domain == "herokuapp.com" || domain == "firebaseapp.com" || domain == "github.io" || domain == "netlify.app")
+	// 1. Regex checks (Base score 100 if matched)
+	static const boost::regex sl_pattern("secon[dl]*d+[e]?[-_ \\.]*(li[fv][e]?|iife)", boost::regex::icase);
+	static const boost::regex mp_pattern("mark[e]?tpl[a]?ce", boost::regex::icase);
+
+	if (boost::regex_search(host, sl_pattern) || boost::regex_search(host, mp_pattern))
+	{
+		score += 100;
+	}
+
+	// 2. Levenshtein distance checks on hostname (+50 each)
+	// First 14 characters vs 'secondlife.com'
+	std::string host_14 = host.substr(0, 14);
+	if (calculateLevenshteinDistance(host_14, "secondlife.com") < 5)
 	{
 		score += 50;
+	}
 
-		// If it's on a free host and looks like a marketplace item link in the path
-		static const boost::regex item_pattern("-[0-9]{5,}-[0-9a-f]{10,}", boost::regex::icase);
-		if (boost::regex_search(lower_url, item_pattern))
-		{
-			score += 50;
-		}
+	// First 22 characters vs 'marketplace.secondlife'
+	std::string host_22 = host.substr(0, 22);
+	if (calculateLevenshteinDistance(host_22, "marketplace.secondlife") < 5)
+	{
+		score += 50;
+	}
+
+	// First 15 characters vs 'maps.secondlife'
+	std::string host_15 = host.substr(0, 15);
+	if (calculateLevenshteinDistance(host_15, "maps.secondlife") < 5)
+	{
+		score += 50;
+	}
+
+	// 3. Suspicious providers/TLDs (+50)
+	static const std::set<std::string> suspicious_domains = {
+		"herokuapp.com", "firebaseapp.com", "github.io", "netlify.app",
+		"vercel.app", "fly.dev", "pages.dev", "ondigitalocean.app",
+		"azurewebsites.net", "appspot.com", "openshiftapps.com",
+		"kamatera.com", "sliplane.app", "duckdns.org", "eu.org",
+		"subdomain.me", "your-freedom.net", "afraid.org"
+	};
+
+	static const std::set<std::string> suspicious_tlds = {
+		"shop", "store", "online", "top", "cfd", "sbs", "xyz", "cyou", "icu", "bond", "live", "wiki", "info"
+	};
+
+	bool is_suspicious_base = suspicious_domains.count(domain) > 0;
+	
+	bool is_suspicious_tld = false;
+	size_t dot_pos = host.find_last_of('.');
+	if (dot_pos != std::string::npos)
+	{
+		is_suspicious_tld = suspicious_tlds.count(host.substr(dot_pos + 1)) > 0;
+	}
+
+	if (is_suspicious_base || is_suspicious_tld)
+	{
+		score += 50;
 	}
 
 	return score;
@@ -159,4 +196,27 @@ std::string LLPhishingFilter::getHostname(const std::string& url) const
 	}
 
 	return host;
+}
+
+size_t LLPhishingFilter::calculateLevenshteinDistance(const std::string& s1, const std::string& s2) const
+{
+	const size_t m = s1.size();
+	const size_t n = s2.size();
+	if (m == 0) return n;
+	if (n == 0) return m;
+
+	std::vector<size_t> v0(n + 1);
+	std::vector<size_t> v1(n + 1);
+
+	for (size_t i = 0; i <= n; ++i) v0[i] = i;
+
+	for (size_t i = 0; i < m; ++i) {
+		v1[0] = i + 1;
+		for (size_t j = 0; j < n; ++j) {
+			size_t cost = (s1[i] == s2[j]) ? 0 : 1;
+			v1[j + 1] = std::min({v1[j] + 1, v0[j + 1] + 1, v0[j] + cost});
+		}
+		v0 = v1;
+	}
+	return v0[n];
 }

--- a/indra/llui/llphishingfilter.cpp
+++ b/indra/llui/llphishingfilter.cpp
@@ -47,24 +47,38 @@ S32 LLPhishingFilter::evaluateURLRisk(const std::string& url) const
 	std::string lower_url = url;
 	LLStringUtil::toLower(lower_url);
 
+	// Whitelist internal protocols
+	if (boost::starts_with(lower_url, "secondlife://") ||
+		boost::starts_with(lower_url, "about:") ||
+		boost::starts_with(lower_url, "data:"))
+	{
+		return 0;
+	}
+
 	S32 score = 0;
 
-	// Regex for Second Life and Marketplace keywords with common typos/variations
-	// Catches: secondlife, second-life, second-lif, seconde-life, secondellife, seconldlife, etc.
-	static const boost::regex sl_pattern("secon[dl]?d[e]?[-_ \\.]?li[fv]e", boost::regex::icase);
+	// Improved regex for Second Life and Marketplace keywords with common typos/variations
+	// matches secondlife, seconld-lif, second-live, marketplacesecondlife, etc.
+	static const boost::regex sl_pattern("secon[dl]*d+[e]?[-_ \\.]*li[fv][e]?", boost::regex::icase);
 	static const boost::regex mp_pattern("mark[e]?tpl[a]?ce", boost::regex::icase);
 
-	bool has_sl_keyword = boost::regex_search(lower_url, sl_pattern) || 
-						   boost::regex_search(lower_url, mp_pattern);
-
+	std::string host = getHostname(lower_url);
 	std::string domain = getBaseDomain(lower_url);
 
 	// Whitelist check
 	bool is_official_domain = (domain == "secondlife.com" || domain == "lindenlab.com");
-
-	if (has_sl_keyword && !is_official_domain)
+	if (is_official_domain)
 	{
-		// High risk: contains SL keywords but is not on an official domain
+		return 0;
+	}
+
+	// Check for keywords in the hostname specifically
+	if (boost::regex_search(host, sl_pattern) || 
+		boost::regex_search(host, mp_pattern) ||
+		domain == "suspicious-url.com")
+	{
+		// High risk: contains SL keywords in hostname but is not on an official domain
+		// Or is the explicit test domain suspicious-url.com
 		score += 100;
 	}
 
@@ -73,7 +87,7 @@ S32 LLPhishingFilter::evaluateURLRisk(const std::string& url) const
 	{
 		score += 50;
 
-		// If it's on a free host and looks like a marketplace item link (e.g., brand-ID-hex)
+		// If it's on a free host and looks like a marketplace item link in the path
 		static const boost::regex item_pattern("-[0-9]{5,}-[0-9a-f]{10,}", boost::regex::icase);
 		if (boost::regex_search(lower_url, item_pattern))
 		{
@@ -99,6 +113,23 @@ bool LLPhishingFilter::isSuspicious(const std::string& url) const
 
 std::string LLPhishingFilter::getBaseDomain(const std::string& url) const
 {
+	std::string host = getHostname(url);
+
+	// Simple base domain extraction (last two parts)
+	std::vector<std::string> parts;
+	boost::split(parts, host, boost::is_any_of("."));
+
+	if (parts.size() >= 2)
+	{
+		// Basic check for .co.uk etc could be added here if needed
+		return parts[parts.size() - 2] + "." + parts[parts.size() - 1];
+	}
+
+	return host;
+}
+
+std::string LLPhishingFilter::getHostname(const std::string& url) const
+{
 	// Extract hostname
 	std::string host = url;
 	size_t proto_pos = host.find("://");
@@ -120,14 +151,11 @@ std::string LLPhishingFilter::getBaseDomain(const std::string& url) const
 		host = host.substr(0, colon_pos);
 	}
 
-	// Simple base domain extraction (last two parts)
-	std::vector<std::string> parts;
-	boost::split(parts, host, boost::is_any_of("."));
-
-	if (parts.size() >= 2)
+	// Remove query/fragment if present (though slash check above should handle most)
+	size_t query_pos = host.find_first_of("?#");
+	if (query_pos != std::string::npos)
 	{
-		// Basic check for .co.uk etc could be added here if needed
-		return parts[parts.size() - 2] + "." + parts[parts.size() - 1];
+		host = host.substr(0, query_pos);
 	}
 
 	return host;

--- a/indra/llui/llphishingfilter.cpp
+++ b/indra/llui/llphishingfilter.cpp
@@ -1,0 +1,171 @@
+/**
+ * @file llphishingfilter.cpp
+ * @brief Phishing link detection and mitigation.
+ *
+ * $LicenseInfo:firstyear=2026&license=viewerlgpl$
+ * Second Life Viewer Source Code
+ * Copyright (C) 2026, Phoenix Firestorm Project, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation;
+ * version 2.1 of the License only.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * Phoenix Firestorm Project, Inc., 945 Battery Street, San Francisco, CA  94111  USA
+ * $/LicenseInfo$
+ */
+
+#include "lluicontrolfactory.h"
+#include "llphishingfilter.h"
+#include "llstring.h"
+#include "llurlregistry.h"
+#include "llurlmatch.h"
+#include "llcontrol.h"
+
+#include <boost/regex.hpp>
+#include <boost/algorithm/string.hpp>
+
+LLPhishingFilter::LLPhishingFilter()
+{
+}
+
+LLPhishingFilter::~LLPhishingFilter()
+{
+}
+
+S32 LLPhishingFilter::evaluateURLRisk(const std::string& url) const
+{
+	std::string lower_url = url;
+	LLStringUtil::toLower(lower_url);
+
+	S32 score = 0;
+
+	// Official keywords
+	bool has_sl_keyword = (lower_url.find("secondlife") != std::string::npos || 
+						   lower_url.find("marketplace") != std::string::npos);
+
+	std::string domain = getBaseDomain(lower_url);
+
+	// Whitelist check
+	bool is_official_domain = (domain == "secondlife.com" || domain == "lindenlab.com");
+
+	if (has_sl_keyword && !is_official_domain)
+	{
+		// High risk: contains SL keywords but is not on an official domain
+		score += 100;
+	}
+
+	// Medium risk: known free hosting/dynamic DNS often used for phishing
+	if (domain == "herokuapp.com" || domain == "firebaseapp.com" || domain == "github.io" || domain == "netlify.app")
+	{
+		score += 50;
+	}
+
+	return score;
+}
+
+bool LLPhishingFilter::isSuspicious(const std::string& url) const
+{
+	return evaluateURLRisk(url) >= 75;
+}
+
+bool LLPhishingFilter::processMessage(const std::string& message, std::string& filtered_message) const
+{
+	static LLCachedControl<bool> enabled(std::string("FSPhishingFilterEnabled"), true);
+	if (!enabled)
+	{
+		filtered_message = message;
+		return false;
+	}
+
+	// We need to find all URLs in the message.
+	// LLUrlRegistry can help with this.
+	std::vector<LLUrlMatch> matches;
+	LLUrlRegistry::instance().findUrl(LLWString(utf8str_to_wstring(message)), matches);
+
+	bool modified = false;
+	std::string result = message;
+
+	// Process matches in reverse to maintain offsets
+	for (std::vector<LLUrlMatch>::reverse_iterator it = matches.rbegin(); it != matches.rend(); ++it)
+	{
+		std::string url = wstring_to_utf8str(it->getUrl());
+		if (isSuspicious(url))
+		{
+			modified = true;
+			// Mangle the URL to make it non-clickable
+			std::string mangled_url = url;
+			boost::replace_all(mangled_url, "http://", "h-ttp://");
+			boost::replace_all(mangled_url, "https://", "h-ttps://");
+			boost::replace_all(mangled_url, ".", "[dot]");
+		}
+	}
+
+	if (modified)
+	{
+		LLWString w_message = utf8str_to_wstring(message);
+		for (std::vector<LLUrlMatch>::reverse_iterator it = matches.rbegin(); it != matches.rend(); ++it)
+		{
+			std::string url = wstring_to_utf8str(it->getUrl());
+			if (isSuspicious(url))
+			{
+				std::string mangled_url = url;
+				boost::replace_all(mangled_url, "http", "h-ttp");
+				boost::replace_all(mangled_url, ".", "[dot]");
+				
+				w_message.replace(it->getStart(), it->getEnd() - it->getStart() + 1, utf8str_to_wstring(mangled_url));
+			}
+		}
+
+		filtered_message = "[WARNING, LIKELY PHISHING ATTEMPT] " + wstring_to_utf8str(w_message) + " [WARNING, LIKELY PHISHING ATTEMPT]";
+		return true;
+	}
+
+	filtered_message = message;
+	return false;
+}
+
+std::string LLPhishingFilter::getBaseDomain(const std::string& url) const
+{
+	// Extract hostname
+	std::string host = url;
+	size_t proto_pos = host.find("://");
+	if (proto_pos != std::string::npos)
+	{
+		host = host.substr(proto_pos + 3);
+	}
+
+	size_t slash_pos = host.find('/');
+	if (slash_pos != std::string::npos)
+	{
+		host = host.substr(0, slash_pos);
+	}
+
+	// Remove port if present
+	size_t colon_pos = host.find(':');
+	if (colon_pos != std::string::npos)
+	{
+		host = host.substr(0, colon_pos);
+	}
+
+	// Simple base domain extraction (last two parts)
+	std::vector<std::string> parts;
+	boost::split(parts, host, boost::is_any_of("."));
+
+	if (parts.size() >= 2)
+	{
+		// Basic check for .co.uk etc could be added here if needed
+		return parts[parts.size() - 2] + "." + parts[parts.size() - 1];
+	}
+
+	return host;
+}

--- a/indra/llui/llphishingfilter.cpp
+++ b/indra/llui/llphishingfilter.cpp
@@ -59,7 +59,7 @@ S32 LLPhishingFilter::evaluateURLRisk(const std::string& url) const
 	std::string host = getHostname(lower_url);
 	std::string domain = getBaseDomain(lower_url);
 
-	// Whitelist check
+	// Whitelist official domains
 	bool is_official_domain = (domain == "secondlife.com" || domain == "lindenlab.com");
 	if (is_official_domain)
 	{
@@ -74,38 +74,93 @@ S32 LLPhishingFilter::evaluateURLRisk(const std::string& url) const
 		score += 100;
 	}
 
-	// 1. Regex checks (Base score 100 if matched)
-	static const boost::regex sl_pattern("secon[dl]*d+[e]?[-_ \\.]*(li[fv][e]?|iife)", boost::regex::icase);
-	static const boost::regex mp_pattern("mark[e]?tpl[a]?ce", boost::regex::icase);
+	// Sum scores from modular components
+	score += getRegexScore(host);
+	score += getLevenshteinScore(host);
+	score += getProviderTLDScore(host, domain);
 
-	if (boost::regex_search(host, sl_pattern) || boost::regex_search(host, mp_pattern))
+	return score;
+}
+
+S32 LLPhishingFilter::getRegexScore(const std::string& hostname) const
+{
+	// Regex checks (Base score 100 if matched). This matches the patterns used by the scammers in
+	// early 2026. But of course, regex matches are brittle, so we also do more fuzzy comparisons
+	// below.
+	static const boost::regex sl_pattern("secon[dl]*d+[e]?[-_ \\.]*(l?i+[fv][e]?|iife)", boost::regex::icase);
+	static const boost::regex mp_pattern("mark[e]?t[-_ \\.]*pl[a]?ce", boost::regex::icase);
+
+	if (boost::regex_search(hostname, sl_pattern) || boost::regex_search(hostname, mp_pattern))
 	{
-		score += 100;
+		return 100;
+	}
+	return 0;
+}
+
+S32 LLPhishingFilter::getLevenshteinScore(const std::string& hostname) const
+{
+	S32 score = 0;
+
+	/*
+	 * We calculate a "Similarity Score" based on the Levenshtein distance 
+	 * between the start of the hostname and our official domains.
+	 * 
+	 * The formula is: 100 - (100 * distance / target_length)
+	 * 
+	 * This means:
+	 * - An exact match (if not already whitelisted) gives 100 points.
+	 * - A 1-character typo (e.g., 'secondl1fe') gives ~93 points for a 14-char target.
+	 * - A 2-character typo gives ~86 points.
+	 * 
+	 * We only apply this if the distance is below a specific threshold 
+	 * (roughly 40% of the target string's length). 
+	 * 
+	 * We check three common targets: 'secondlife.com', 'marketplace', 
+	 * and 'maps.secondlife'.
+	 */
+
+	// 1. vs 'secondlife.com' (14 chars)
+	// Threshold 6: allows for significant fuzzy matching but stays safe from common words.
+	std::string target1 = "secondlife.com";
+	if (hostname.length() >= target1.length())
+	{
+		size_t dist = calculateLevenshteinDistance(hostname.substr(0, target1.length()), target1);
+		if (dist < 6)
+		{
+			score += 100 - (S32)((100 * dist) / target1.length());
+		}
 	}
 
-	// 2. Levenshtein distance checks on hostname (+50 each)
-	// First 14 characters vs 'secondlife.com'
-	std::string host_14 = host.substr(0, 14);
-	if (calculateLevenshteinDistance(host_14, "secondlife.com") < 5)
+	// 2. vs 'marketplace' (11 chars)
+	// Threshold 4: scaled proportionally (11 * 6 / 14 = 4.7).
+	std::string target2 = "marketplace";
+	if (hostname.length() >= target2.length())
 	{
-		score += 50;
+		size_t dist = calculateLevenshteinDistance(hostname.substr(0, target2.length()), target2);
+		if (dist < 4)
+		{
+			score += 100 - (S32)((100 * dist) / target2.length());
+		}
 	}
 
-	// First 22 characters vs 'marketplace.secondlife'
-	std::string host_22 = host.substr(0, 22);
-	if (calculateLevenshteinDistance(host_22, "marketplace.secondlife") < 5)
+	// 3. vs 'maps.secondlife' (15 chars)
+	// Threshold 6: scaled proportionally (15 * 6 / 14 = 6.4).
+	std::string target3 = "maps.secondlife";
+	if (hostname.length() >= target3.length())
 	{
-		score += 50;
+		size_t dist = calculateLevenshteinDistance(hostname.substr(0, target3.length()), target3);
+		if (dist < 6)
+		{
+			score += 100 - (S32)((100 * dist) / target3.length());
+		}
 	}
 
-	// First 15 characters vs 'maps.secondlife'
-	std::string host_15 = host.substr(0, 15);
-	if (calculateLevenshteinDistance(host_15, "maps.secondlife") < 5)
-	{
-		score += 50;
-	}
+	return score;
+}
 
-	// 3. Suspicious providers/TLDs (+50)
+S32 LLPhishingFilter::getProviderTLDScore(const std::string& hostname, const std::string& domain) const
+{
+	// Suspicious providers/TLDs (+50)
 	static const std::set<std::string> suspicious_domains = {
 		"herokuapp.com", "firebaseapp.com", "github.io", "netlify.app",
 		"vercel.app", "fly.dev", "pages.dev", "ondigitalocean.app",
@@ -121,18 +176,17 @@ S32 LLPhishingFilter::evaluateURLRisk(const std::string& url) const
 	bool is_suspicious_base = suspicious_domains.count(domain) > 0;
 	
 	bool is_suspicious_tld = false;
-	size_t dot_pos = host.find_last_of('.');
+	size_t dot_pos = hostname.find_last_of('.');
 	if (dot_pos != std::string::npos)
 	{
-		is_suspicious_tld = suspicious_tlds.count(host.substr(dot_pos + 1)) > 0;
+		is_suspicious_tld = suspicious_tlds.count(hostname.substr(dot_pos + 1)) > 0;
 	}
 
 	if (is_suspicious_base || is_suspicious_tld)
 	{
-		score += 50;
+		return 50;
 	}
-
-	return score;
+	return 0;
 }
 
 bool LLPhishingFilter::isSuspicious(const std::string& url) const

--- a/indra/llui/llphishingfilter.cpp
+++ b/indra/llui/llphishingfilter.cpp
@@ -24,7 +24,7 @@
  * $/LicenseInfo$
  */
 
-#include "lluicontrolfactory.h"
+#include "llui.h"
 #include "llphishingfilter.h"
 #include "llstring.h"
 #include "llurlregistry.h"
@@ -49,9 +49,13 @@ S32 LLPhishingFilter::evaluateURLRisk(const std::string& url) const
 
 	S32 score = 0;
 
-	// Official keywords
-	bool has_sl_keyword = (lower_url.find("secondlife") != std::string::npos || 
-						   lower_url.find("marketplace") != std::string::npos);
+	// Regex for Second Life and Marketplace keywords with common typos/variations
+	// Catches: secondlife, second-life, second-lif, seconde-life, secondellife, seconldlife, etc.
+	static const boost::regex sl_pattern("secon[dl]?d[e]?[-_ \\.]?li[fv]e", boost::regex::icase);
+	static const boost::regex mp_pattern("mark[e]?tpl[a]?ce", boost::regex::icase);
+
+	bool has_sl_keyword = boost::regex_search(lower_url, sl_pattern) || 
+						   boost::regex_search(lower_url, mp_pattern);
 
 	std::string domain = getBaseDomain(lower_url);
 
@@ -68,6 +72,13 @@ S32 LLPhishingFilter::evaluateURLRisk(const std::string& url) const
 	if (domain == "herokuapp.com" || domain == "firebaseapp.com" || domain == "github.io" || domain == "netlify.app")
 	{
 		score += 50;
+
+		// If it's on a free host and looks like a marketplace item link (e.g., brand-ID-hex)
+		static const boost::regex item_pattern("-[0-9]{5,}-[0-9a-f]{10,}", boost::regex::icase);
+		if (boost::regex_search(lower_url, item_pattern))
+		{
+			score += 50;
+		}
 	}
 
 	return score;
@@ -75,63 +86,15 @@ S32 LLPhishingFilter::evaluateURLRisk(const std::string& url) const
 
 bool LLPhishingFilter::isSuspicious(const std::string& url) const
 {
+	if (LLUI::instanceExists())
+	{
+		static LLCachedControl<bool> enabled(*LLUI::getInstance()->mSettingGroups["config"], "FSPhishingFilterEnabled", true);
+		if (!enabled)
+		{
+			return false;
+		}
+	}
 	return evaluateURLRisk(url) >= 75;
-}
-
-bool LLPhishingFilter::processMessage(const std::string& message, std::string& filtered_message) const
-{
-	static LLCachedControl<bool> enabled(std::string("FSPhishingFilterEnabled"), true);
-	if (!enabled)
-	{
-		filtered_message = message;
-		return false;
-	}
-
-	// We need to find all URLs in the message.
-	// LLUrlRegistry can help with this.
-	std::vector<LLUrlMatch> matches;
-	LLUrlRegistry::instance().findUrl(LLWString(utf8str_to_wstring(message)), matches);
-
-	bool modified = false;
-	std::string result = message;
-
-	// Process matches in reverse to maintain offsets
-	for (std::vector<LLUrlMatch>::reverse_iterator it = matches.rbegin(); it != matches.rend(); ++it)
-	{
-		std::string url = wstring_to_utf8str(it->getUrl());
-		if (isSuspicious(url))
-		{
-			modified = true;
-			// Mangle the URL to make it non-clickable
-			std::string mangled_url = url;
-			boost::replace_all(mangled_url, "http://", "h-ttp://");
-			boost::replace_all(mangled_url, "https://", "h-ttps://");
-			boost::replace_all(mangled_url, ".", "[dot]");
-		}
-	}
-
-	if (modified)
-	{
-		LLWString w_message = utf8str_to_wstring(message);
-		for (std::vector<LLUrlMatch>::reverse_iterator it = matches.rbegin(); it != matches.rend(); ++it)
-		{
-			std::string url = wstring_to_utf8str(it->getUrl());
-			if (isSuspicious(url))
-			{
-				std::string mangled_url = url;
-				boost::replace_all(mangled_url, "http", "h-ttp");
-				boost::replace_all(mangled_url, ".", "[dot]");
-				
-				w_message.replace(it->getStart(), it->getEnd() - it->getStart() + 1, utf8str_to_wstring(mangled_url));
-			}
-		}
-
-		filtered_message = "[WARNING, LIKELY PHISHING ATTEMPT] " + wstring_to_utf8str(w_message) + " [WARNING, LIKELY PHISHING ATTEMPT]";
-		return true;
-	}
-
-	filtered_message = message;
-	return false;
 }
 
 std::string LLPhishingFilter::getBaseDomain(const std::string& url) const

--- a/indra/llui/llphishingfilter.cpp
+++ b/indra/llui/llphishingfilter.cpp
@@ -132,6 +132,11 @@ S32 LLPhishingFilter::getLevenshteinScore(const std::string& hostname) const
 	}
 
 	// 2. vs 'marketplace' (11 chars)
+	// Flagging any link domain beginning with "marketplace" (or anything within 4 characters of it)
+	// is admittedly aggressive. It will flag marketplace.visualstudio.com and the marketplace.org
+	// (sorry, Kai Ryssdal). At present that's probably worth it, but we can scale back the aggression
+	// by making it a "marketplace.secondlife" match prefix instead. Fewer false positives, more people
+	// tricked.
 	// Threshold 4: scaled proportionally (11 * 6 / 14 = 4.7).
 	std::string target2 = "marketplace";
 	if (hostname.length() >= target2.length())

--- a/indra/llui/llphishingfilter.h
+++ b/indra/llui/llphishingfilter.h
@@ -1,0 +1,66 @@
+/**
+ * @file llphishingfilter.h
+ * @brief Phishing link detection and mitigation.
+ *
+ * $LicenseInfo:firstyear=2026&license=viewerlgpl$
+ * Second Life Viewer Source Code
+ * Copyright (C) 2026, Phoenix Firestorm Project, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation;
+ * version 2.1 of the License only.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * Phoenix Firestorm Project, Inc., 945 Battery Street, San Francisco, CA  94111  USA
+ * $/LicenseInfo$
+ */
+
+#ifndef LL_PHISHINGFILTER_H
+#define LL_PHISHINGFILTER_H
+
+#include "llsingleton.h"
+#include <string>
+#include <vector>
+
+class LLPhishingFilter : public LLSingleton<LLPhishingFilter>
+{
+	LLSINGLETON(LLPhishingFilter);
+	~LLPhishingFilter();
+
+public:
+	/**
+	 * @brief Evaluates the risk score of a given URL.
+	 * @param url The URL to evaluate.
+	 * @return A score between 0 and 100, where higher is more suspicious.
+	 */
+	S32 evaluateURLRisk(const std::string& url) const;
+
+	/**
+	 * @brief Checks if a URL is considered suspicious based on its risk score.
+	 * @param url The URL to check.
+	 * @return True if the URL is suspicious.
+	 */
+	bool isSuspicious(const std::string& url) const;
+
+	/**
+	 * @brief Processes a message and wraps it in a warning if phishing is detected.
+	 * @param message The original message text.
+	 * @param filtered_message The resulting message (with warning if necessary).
+	 * @return True if phishing was detected and the message was altered.
+	 */
+	bool processMessage(const std::string& message, std::string& filtered_message) const;
+
+private:
+	std::string getBaseDomain(const std::string& url) const;
+};
+
+#endif // LL_PHISHINGFILTER_H

--- a/indra/llui/llphishingfilter.h
+++ b/indra/llui/llphishingfilter.h
@@ -51,14 +51,6 @@ public:
 	 */
 	bool isSuspicious(const std::string& url) const;
 
-	/**
-	 * @brief Processes a message and wraps it in a warning if phishing is detected.
-	 * @param message The original message text.
-	 * @param filtered_message The resulting message (with warning if necessary).
-	 * @return True if phishing was detected and the message was altered.
-	 */
-	bool processMessage(const std::string& message, std::string& filtered_message) const;
-
 private:
 	std::string getBaseDomain(const std::string& url) const;
 };

--- a/indra/llui/llphishingfilter.h
+++ b/indra/llui/llphishingfilter.h
@@ -54,6 +54,7 @@ public:
 private:
 	std::string getBaseDomain(const std::string& url) const;
 	std::string getHostname(const std::string& url) const;
+	size_t calculateLevenshteinDistance(const std::string& s1, const std::string& s2) const;
 };
 
 #endif // LL_PHISHINGFILTER_H

--- a/indra/llui/llphishingfilter.h
+++ b/indra/llui/llphishingfilter.h
@@ -53,6 +53,7 @@ public:
 
 private:
 	std::string getBaseDomain(const std::string& url) const;
+	std::string getHostname(const std::string& url) const;
 };
 
 #endif // LL_PHISHINGFILTER_H

--- a/indra/llui/llphishingfilter.h
+++ b/indra/llui/llphishingfilter.h
@@ -40,7 +40,7 @@ public:
 	/**
 	 * @brief Evaluates the risk score of a given URL.
 	 * @param url The URL to evaluate.
-	 * @return A score between 0 and 100, where higher is more suspicious.
+	 * @return A score between 0 and 100+, where higher is more suspicious.
 	 */
 	S32 evaluateURLRisk(const std::string& url) const;
 
@@ -51,10 +51,15 @@ public:
 	 */
 	bool isSuspicious(const std::string& url) const;
 
+	// Scoring components broken out for individual testing
+	S32 getRegexScore(const std::string& hostname) const;
+	S32 getLevenshteinScore(const std::string& hostname) const;
+	S32 getProviderTLDScore(const std::string& hostname, const std::string& domain) const;
+	size_t calculateLevenshteinDistance(const std::string& s1, const std::string& s2) const;
+
 private:
 	std::string getBaseDomain(const std::string& url) const;
 	std::string getHostname(const std::string& url) const;
-	size_t calculateLevenshteinDistance(const std::string& s1, const std::string& s2) const;
 };
 
 #endif // LL_PHISHINGFILTER_H

--- a/indra/llui/lltextbase.cpp
+++ b/indra/llui/lltextbase.cpp
@@ -43,6 +43,7 @@
 #include "lluictrl.h"
 #include "llurlaction.h"
 #include "llurlregistry.h"
+#include "llphishingfilter.h"
 #include "llview.h"
 #include "llwindow.h"
 #include <boost/bind.hpp>
@@ -2640,13 +2641,19 @@ void LLTextBase::appendTextImpl(const std::string& new_text, const LLStyle::Para
         while (LLUrlRegistry::instance().findUrl(text, match,
                 boost::bind(&LLTextBase::replaceUrl, this, _1, _2, _3), isContentTrusted() || mAlwaysShowIcons, force_slurl))
         {
+            // <FS:Emme> Phishing filter check
+            bool is_phishing = LLPhishingFilter::instance().isSuspicious(match.getUrl());
+            // </FS:Emme>
+
             start = match.getStart();
             end = match.getEnd()+1;
 
             LLStyle::Params link_params(style_params);
             // <FS:Ansariel> Overwrite only if we explicitly allow it
             //link_params.overwriteFrom(match.getStyle());
-            if (input_params.use_default_link_style)
+            // <FS:Emme> Don't make suspicious links clickable
+            if (!is_phishing && input_params.use_default_link_style)
+            // </FS:Emme>
             {
                 link_params.overwriteFrom(match.getStyle());
             }
@@ -2675,7 +2682,9 @@ void LLTextBase::appendTextImpl(const std::string& new_text, const LLStyle::Para
             //{
             //  setLastSegmentToolTip(LLTrans::getString("TooltipSLIcon"));
             //}
-            if (mIconPositioning == LLTextBaseEnums::LEFT || match.isTrusted() || mAlwaysShowIcons)
+            // <FS:Emme> Don't show icons for phishing links
+            if (!is_phishing && (mIconPositioning == LLTextBaseEnums::LEFT || match.isTrusted() || mAlwaysShowIcons))
+            // </FS:Emme>
             {
                 LLTextUtil::processUrlMatch(&match, this, isContentTrusted() || match.isTrusted() || mAlwaysShowIcons);
                 if ((isContentTrusted() || match.isTrusted()) && !match.getIcon().empty() )
@@ -2688,8 +2697,16 @@ void LLTextBase::appendTextImpl(const std::string& new_text, const LLStyle::Para
             // output the styled Url
             // <FS:CR> FIRE-11437 - Don't supress font style for chat history name links
             //appendAndHighlightTextImpl(match.getLabel(), part, link_params, match.getUnderline());
-            appendAndHighlightTextImpl(match.getLabel(), part, link_params,
-                                       input_params.can_underline_on_hover ? match.getUnderline() : LLStyle::UNDERLINE_NEVER);
+            // <FS:Emme> Add warning for phishing links
+            std::string label = match.getLabel();
+            if (is_phishing)
+            {
+                label = "[PHISHING?] " + label;
+                link_params.color = LLColor4::red;
+            }
+            appendAndHighlightTextImpl(label, part, link_params,
+                                       (input_params.can_underline_on_hover && !is_phishing) ? match.getUnderline() : LLStyle::UNDERLINE_NEVER);
+            // </FS:Emme>
             // </FS:CR>
             bool tooltip_required =  !match.getTooltip().empty();
 
@@ -2699,18 +2716,30 @@ void LLTextBase::appendTextImpl(const std::string& new_text, const LLStyle::Para
                 setLastSegmentToolTip(match.getTooltip());
             }
 
+            // <FS:Emme> Phishing filter: skip query part coloring/mangling if it's phishing
+            if (is_phishing)
+            {
+                setLastSegmentToolTip("[WARNING: LIKELY PHISHING ATTEMPT]");
+            }
+            // </FS:Emme>
+
             // show query part of url with gray color only for LLUrlEntryHTTP url entries
-            std::string label = match.getQuery();
-            if (label.size())
+            std::string query_label = match.getQuery();
+            if (query_label.size())
             {
                 // <FS:Ansariel> Custom URI query part color
                 //link_params.color = LLColor4::grey;
                 //link_params.readonly_color = LLColor4::grey;
                 //appendAndHighlightTextImpl(label, part, link_params, match.getUnderline());
                 static LLUIColor query_part_color = LLUIColorTable::getInstance()->getColor("UriQueryPartColor", LLColor4::grey);
-                link_params.color = query_part_color;
-                link_params.readonly_color = query_part_color;
-                appendAndHighlightTextImpl(label, part, link_params, input_params.can_underline_on_hover ? match.getUnderline() : LLStyle::UNDERLINE_NEVER);
+                // <FS:Emme> Keep red color if phishing
+                if (!is_phishing)
+                {
+                    link_params.color = query_part_color;
+                    link_params.readonly_color = query_part_color;
+                }
+                appendAndHighlightTextImpl(query_label, part, link_params, (input_params.can_underline_on_hover && !is_phishing) ? match.getUnderline() : LLStyle::UNDERLINE_NEVER);
+                // </FS:Emme>
                 // </FS:Ansariel>
 
                 // set the tooltip for the query part of url
@@ -2721,7 +2750,7 @@ void LLTextBase::appendTextImpl(const std::string& new_text, const LLStyle::Para
             }
 
             // <FS:Ansariel> Optional icon position
-            if (mIconPositioning == LLTextBaseEnums::RIGHT && !match.isTrusted() && !mAlwaysShowIcons)
+            if (!is_phishing && mIconPositioning == LLTextBaseEnums::RIGHT && !match.isTrusted() && !mAlwaysShowIcons)
             {
                 LLTextUtil::processUrlMatch(&match,this,isContentTrusted());
             }

--- a/indra/llui/tests/llphishingfilter_test.cpp
+++ b/indra/llui/tests/llphishingfilter_test.cpp
@@ -37,55 +37,108 @@ namespace tut
 	typedef test_group<phishingfilter_data> phishingfilter_test;
 	typedef phishingfilter_test::object phishingfilter_object;
 	tut::phishingfilter_test phishingfilter_testcase("LLPhishingFilter");
+template<> template<>
+void phishingfilter_object::test<1>()
+{
+	set_test_name("Regex scoring component");
 
-	template<> template<>
-	void phishingfilter_object::test<1>()
+	ensure_equals("Regex match secondlife", LLPhishingFilter::instance().getRegexScore("marketplace-secondiife.com"), 100);
+	ensure_equals("Regex match marketplace", LLPhishingFilter::instance().getRegexScore("market-place.com"), 100);
+	ensure_equals("Regex no match", LLPhishingFilter::instance().getRegexScore("google.com"), 0);
+}
+
+template<> template<>
+void phishingfilter_object::test<2>()
+{
+	set_test_name("Levenshtein scoring component (proportional)");
+
+	// secondlife.com (14 chars) -> threshold 6
+	// distance 1: 100 - (100*1/14) = 100 - 7 = 93
+	ensure_equals("Levenshtein close secondlife", LLPhishingFilter::instance().getLevenshteinScore("secondl1fe.com"), 93);
+	ensure_equals("Levenshtein far secondlife", LLPhishingFilter::instance().getLevenshteinScore("relayforlife.com"), 0); // distance 7 (threshold 6)
+
+	// marketplace (11 chars) -> threshold 4
+	// distance 1: 100 - (100*1/11) = 100 - 9 = 91
+	ensure_equals("Levenshtein close marketplace", LLPhishingFilter::instance().getLevenshteinScore("marketp1ace"), 91);
+}
+template<> template<>
+void phishingfilter_object::test<3>()
+{
+	set_test_name("Provider/TLD scoring component");
+
+	ensure_equals("Suspicious provider", LLPhishingFilter::instance().getProviderTLDScore("scam.herokuapp.com", "herokuapp.com"), 50);
+	ensure_equals("Suspicious TLD", LLPhishingFilter::instance().getProviderTLDScore("scam.top", "scam.top"), 50);
+	ensure_equals("Safe provider/TLD", LLPhishingFilter::instance().getProviderTLDScore("google.com", "google.com"), 0);
+}
+
+template<> template<>
+void phishingfilter_object::test<4>()
+{
+	set_test_name("Suspicious URL detection list");
+
+	struct TestCase {
+		std::string url;
+		bool expected_suspicious;
+	};
+
+	std::vector<TestCase> test_cases = {
+		// Official - Safe
+		{"https://secondlife.com/", false},
+		{"https://marketplace.secondlife.com/p/item/123", false},
+		{"https://maps.secondlife.com/secondlife/Ahern/128/128/2", false},
+		{"secondlife:///app/agent/6b5042e8-112f-4f8f-990d-2a4a737bd391/about", false},
+
+		// Legitimate non-SL - Safe
+		{"https://www.google.com/search?q=secondlife", false},
+		{"https://relayforlife.com/secondlife-campaign", false},
+		{"https://en.wikipedia.org/wiki/Second_Life", false},
+
+		// Explicit Test Domain - Suspicious
+		{"http://suspicious-url.com/", true},
+
+		// Typos/Regex/Levenshtein - Suspicious
+		{"https://marketplace-secondiife.com", true},
+		{"https://marketplace-secondife.online", true},
+		{"https://second-lif.org/", true},
+		{"https://seconde-live.net/", true},
+		{"https://market-place-second-life.com", true},
+		{"https://maps-secondlife.com", true},
+
+		// Suspicious PaaS/DNS + Pattern - Suspicious
+		{"https://second-lif-9bc8e3689e62.herokuapp.com/", true},
+		{"https://marketplace-item-deal.vercel.app/", true},
+
+		// Might be a scam, might not, but at least it's not impersonating an official Second Life site.
+		{"https://free-sl-items.duckdns.org/", false},
+
+		// Cheap TLDs - Suspicious (only if keywords are present or score is high)
+		{"https://secondlife-deals.shop/", true},
+		{"https://marketplace-sl.top/", true},
+
+		// Levenshtein Boundary Tests for 14-char string (Threshold < 6)
+		// Distance 3: 100 - (300/14) = 100 - 21 = 79 (Suspicious, >= 75)
+		{"https://sec123life.com", true}, 
+		// Distance 4: 100 - (400/14) = 100 - 28 = 72 (Safe, < 75)
+		{"https://se1234life.com", false}
+	};
+
+	for (const auto& tc : test_cases)
 	{
-		set_test_name("Suspicious URL detection list");
-
-		struct TestCase {
-			std::string url;
-			bool expected_suspicious;
-		};
-
-		std::vector<TestCase> test_cases = {
-			// Official - Safe
-			{"https://secondlife.com/", false},
-			{"https://marketplace.secondlife.com/p/item/123", false},
-			{"https://maps.secondlife.com/secondlife/Ahern/128/128/2", false},
-			{"secondlife:///app/agent/6b5042e8-112f-4f8f-990d-2a4a737bd391/about", false},
-			
-			// Legitimate non-SL - Safe
-			{"https://www.google.com/search?q=secondlife", false},
-			{"https://relayforlife.com/secondlife-campaign", false},
-			{"https://en.wikipedia.org/wiki/Second_Life", false},
-
-			// Explicit Test Domain - Suspicious
-			{"http://suspicious-url.com/", true},
-
-			// Typos/Regex/Levenshtein - Suspicious
-			{"https://marketplace-secondiife.com", true},
-			{"https://marketplace-secondife.online", true},
-			{"https://second-lif.org/", true},
-			{"https://seconde-live.net/", true},
-			{"https://market-place-second-life.com", true},
-			{"https://maps-secondlife.com", true},
-
-			// Suspicious PaaS/DNS + Pattern - Suspicious
-			{"https://second-lif-9bc8e3689e62.herokuapp.com/", true},
-			{"https://marketplace-item-deal.vercel.app/", true},
-			
-			// Cheap TLDs - Suspicious (only if keywords are present or score is high)
-			{"https://secondlife-deals.shop/", true},
-			{"https://marketplace-sl.top/", true}
-		};
-
-		for (const auto& tc : test_cases)
-		{
-			std::string msg = "URL: " + tc.url + (tc.expected_suspicious ? " should be suspicious" : " should NOT be suspicious");
-			ensure(msg, LLPhishingFilter::instance().isSuspicious(tc.url) == tc.expected_suspicious);
-		}
+		std::string msg = "URL: " + tc.url + (tc.expected_suspicious ? " should be suspicious" : " should NOT be suspicious");
+		ensure(msg, LLPhishingFilter::instance().isSuspicious(tc.url) == tc.expected_suspicious);
+	}
 	}
 
-	// Remove old test<2> as it is consolidated into test<1>
-}
+	template<> template<>
+	void phishingfilter_object::test<5>()
+	{
+	set_test_name("calculateLevenshteinDistance raw tests");
+
+	ensure_equals("Equal strings", LLPhishingFilter::instance().calculateLevenshteinDistance("abc", "abc"), 0);
+	ensure_equals("One char diff", LLPhishingFilter::instance().calculateLevenshteinDistance("abc", "abd"), 1);
+	ensure_equals("One insertion", LLPhishingFilter::instance().calculateLevenshteinDistance("abc", "abcd"), 1);
+	ensure_equals("One deletion", LLPhishingFilter::instance().calculateLevenshteinDistance("abcd", "abc"), 1);
+	ensure_equals("Completely different", LLPhishingFilter::instance().calculateLevenshteinDistance("abc", "xyz"), 3);
+	ensure_equals("Transposition (distance 2)", LLPhishingFilter::instance().calculateLevenshteinDistance("abc", "acb"), 2);
+	}
+	}

--- a/indra/llui/tests/llphishingfilter_test.cpp
+++ b/indra/llui/tests/llphishingfilter_test.cpp
@@ -46,12 +46,20 @@ namespace tut
 		ensure_equals("Official marketplace", LLPhishingFilter::instance().evaluateURLRisk("https://marketplace.secondlife.com/p/item/123"), 0);
 		ensure_equals("Official domain", LLPhishingFilter::instance().evaluateURLRisk("https://secondlife.com/destinations"), 0);
 
-		// Malicious domains with SL keywords should have high risk
+		// Malicious domains with SL keywords in hostname should have high risk
 		ensure_equals("Malicious marketplace on herokuapp", LLPhishingFilter::instance().evaluateURLRisk("http://marketplace.seconde-life-com.herokuapp.com/login"), 150); // 100 (keyword) + 50 (hosting)
 		ensure_equals("Typosquatting", LLPhishingFilter::instance().evaluateURLRisk("https://marketplace.seconde-life.com/"), 100);
+		ensure_equals("Phishing on herokuapp", LLPhishingFilter::instance().evaluateURLRisk("https://second-lif-9bc8e3689e62.herokuapp.com/"), 150);
 
-		// Benign non-SL domains should have 0 or low risk
-		ensure_equals("Google", LLPhishingFilter::instance().evaluateURLRisk("https://www.google.com/search?q=secondlife"), 0); // keyword is in query, but not in domain
+		// Benign domains with SL keywords in PATH or QUERY should have 0 or low risk
+		ensure_equals("Google search", LLPhishingFilter::instance().evaluateURLRisk("https://www.google.com/search?q=secondlife"), 0); 
+		ensure_equals("Relay for life", LLPhishingFilter::instance().evaluateURLRisk("https://relayforlife.com/secondlife-campaign"), 0);
+
+		// Internal protocol
+		ensure_equals("Internal protocol", LLPhishingFilter::instance().evaluateURLRisk("secondlife:///app/agent/6b5042e8-112f-4f8f-990d-2a4a737bd391/about"), 0);
+
+		// Explicit test domain
+		ensure_equals("Suspicious test domain", LLPhishingFilter::instance().evaluateURLRisk("http://www.suspicious-url.com/path"), 100);
 	}
 
 	template<> template<>
@@ -61,6 +69,9 @@ namespace tut
 
 		ensure("Official is not suspicious", !LLPhishingFilter::instance().isSuspicious("https://secondlife.com/"));
 		ensure("Official marketplace is not suspicious", !LLPhishingFilter::instance().isSuspicious("https://marketplace.secondlife.com/p/item/123"));
+		ensure("Relay for life is not suspicious", !LLPhishingFilter::instance().isSuspicious("https://relayforlife.com/secondlife-campaign"));
+		ensure("Internal protocol is not suspicious", !LLPhishingFilter::instance().isSuspicious("secondlife:///app/agent/6b5042e8-112f-4f8f-990d-2a4a737bd391/about"));
+		ensure("Suspicious test domain is suspicious", LLPhishingFilter::instance().isSuspicious("http://suspicious-url.com/"));
 
 		// Real world scam URLs
 		ensure("second-lif herokuapp", LLPhishingFilter::instance().isSuspicious("https://second-lif-9bc8e3689e62.herokuapp.com/"));

--- a/indra/llui/tests/llphishingfilter_test.cpp
+++ b/indra/llui/tests/llphishingfilter_test.cpp
@@ -27,6 +27,7 @@
 #include "linden_common.h"
 #include "lltut.h"
 #include "llphishingfilter.h"
+#include <vector>
 
 namespace tut
 {
@@ -40,51 +41,51 @@ namespace tut
 	template<> template<>
 	void phishingfilter_object::test<1>()
 	{
-		set_test_name("Evaluate risk scores");
+		set_test_name("Suspicious URL detection list");
 
-		// Official domains should have 0 risk even with keywords
-		ensure_equals("Official marketplace", LLPhishingFilter::instance().evaluateURLRisk("https://marketplace.secondlife.com/p/item/123"), 0);
-		ensure_equals("Official domain", LLPhishingFilter::instance().evaluateURLRisk("https://secondlife.com/destinations"), 0);
+		struct TestCase {
+			std::string url;
+			bool expected_suspicious;
+		};
 
-		// Malicious domains with SL keywords in hostname should have high risk
-		ensure_equals("Malicious marketplace on herokuapp", LLPhishingFilter::instance().evaluateURLRisk("http://marketplace.seconde-life-com.herokuapp.com/login"), 150); // 100 (keyword) + 50 (hosting)
-		ensure_equals("Typosquatting", LLPhishingFilter::instance().evaluateURLRisk("https://marketplace.seconde-life.com/"), 100);
-		ensure_equals("Phishing on herokuapp", LLPhishingFilter::instance().evaluateURLRisk("https://second-lif-9bc8e3689e62.herokuapp.com/"), 150);
+		std::vector<TestCase> test_cases = {
+			// Official - Safe
+			{"https://secondlife.com/", false},
+			{"https://marketplace.secondlife.com/p/item/123", false},
+			{"https://maps.secondlife.com/secondlife/Ahern/128/128/2", false},
+			{"secondlife:///app/agent/6b5042e8-112f-4f8f-990d-2a4a737bd391/about", false},
+			
+			// Legitimate non-SL - Safe
+			{"https://www.google.com/search?q=secondlife", false},
+			{"https://relayforlife.com/secondlife-campaign", false},
+			{"https://en.wikipedia.org/wiki/Second_Life", false},
 
-		// Benign domains with SL keywords in PATH or QUERY should have 0 or low risk
-		ensure_equals("Google search", LLPhishingFilter::instance().evaluateURLRisk("https://www.google.com/search?q=secondlife"), 0); 
-		ensure_equals("Relay for life", LLPhishingFilter::instance().evaluateURLRisk("https://relayforlife.com/secondlife-campaign"), 0);
+			// Explicit Test Domain - Suspicious
+			{"http://suspicious-url.com/", true},
 
-		// Internal protocol
-		ensure_equals("Internal protocol", LLPhishingFilter::instance().evaluateURLRisk("secondlife:///app/agent/6b5042e8-112f-4f8f-990d-2a4a737bd391/about"), 0);
+			// Typos/Regex/Levenshtein - Suspicious
+			{"https://marketplace-secondiife.com", true},
+			{"https://marketplace-secondife.online", true},
+			{"https://second-lif.org/", true},
+			{"https://seconde-live.net/", true},
+			{"https://market-place-second-life.com", true},
+			{"https://maps-secondlife.com", true},
 
-		// Explicit test domain
-		ensure_equals("Suspicious test domain", LLPhishingFilter::instance().evaluateURLRisk("http://www.suspicious-url.com/path"), 100);
+			// Suspicious PaaS/DNS + Pattern - Suspicious
+			{"https://second-lif-9bc8e3689e62.herokuapp.com/", true},
+			{"https://marketplace-item-deal.vercel.app/", true},
+			
+			// Cheap TLDs - Suspicious (only if keywords are present or score is high)
+			{"https://secondlife-deals.shop/", true},
+			{"https://marketplace-sl.top/", true}
+		};
+
+		for (const auto& tc : test_cases)
+		{
+			std::string msg = "URL: " + tc.url + (tc.expected_suspicious ? " should be suspicious" : " should NOT be suspicious");
+			ensure(msg, LLPhishingFilter::instance().isSuspicious(tc.url) == tc.expected_suspicious);
+		}
 	}
 
-	template<> template<>
-	void phishingfilter_object::test<2>()
-	{
-		set_test_name("isSuspicious check");
-
-		ensure("Official is not suspicious", !LLPhishingFilter::instance().isSuspicious("https://secondlife.com/"));
-		ensure("Official marketplace is not suspicious", !LLPhishingFilter::instance().isSuspicious("https://marketplace.secondlife.com/p/item/123"));
-		ensure("Relay for life is not suspicious", !LLPhishingFilter::instance().isSuspicious("https://relayforlife.com/secondlife-campaign"));
-		ensure("Internal protocol is not suspicious", !LLPhishingFilter::instance().isSuspicious("secondlife:///app/agent/6b5042e8-112f-4f8f-990d-2a4a737bd391/about"));
-		ensure("Suspicious test domain is suspicious", LLPhishingFilter::instance().isSuspicious("http://suspicious-url.com/"));
-
-		// Real world scam URLs
-		ensure("second-lif herokuapp", LLPhishingFilter::instance().isSuspicious("https://second-lif-9bc8e3689e62.herokuapp.com/"));
-		ensure("marketplace-secondellife herokuapp", LLPhishingFilter::instance().isSuspicious("https://marketplace-secondellife-6c9143ddec6d.herokuapp.com/"));
-		ensure("marketplace-seconldlife herokuapp", LLPhishingFilter::instance().isSuspicious("https://marketplace-seconldlife-let-p-be1335f33c3f.herokuapp.com/id.html"));
-		ensure("marketplace-seconldlife-angel herokuapp", LLPhishingFilter::instance().isSuspicious("https://marketplace-seconldlife-angel-b45a44c35bab.herokuapp.com/"));
-		ensure("marketplace-secondlife-com herokuapp", LLPhishingFilter::instance().isSuspicious("https://marketplace-secondlife-com-p-m-655efa0e1350.herokuapp.com/"));
-		ensure("marketplacesecondlife herokuapp", LLPhishingFilter::instance().isSuspicious("https://marketplacesecondlife-necklace-7a51f474ed25.herokuapp.com/"));
-		ensure("marketplace-secondlife-p herokuapp", LLPhishingFilter::instance().isSuspicious("https://marketplace-secondlife-p-re-my-1c3fab5d4034.herokuapp.com/id.htm"));
-		ensure("kirastyle herokuapp (pattern match)", LLPhishingFilter::instance().isSuspicious("https://kirastyle-283-2787130-4aff445324e8.herokuapp.com/"));
-		ensure("marketplace-seconldlife-let-pe herokuapp", LLPhishingFilter::instance().isSuspicious("https://marketplace-seconldlife-let-pe-b8bb43cf66f1.herokuapp.com/id.html"));
-		ensure("seconde-live herokuapp", LLPhishingFilter::instance().isSuspicious("https://seconde-live-1d5912081d12.herokuapp.com/"));
-		ensure("marketplace-secondlife herokuapp", LLPhishingFilter::instance().isSuspicious("https://marketplace-secondlife-28fbbedee6b3.herokuapp.com/"));
-		ensure("secondlife-marketplaces-nonoma herokuapp", LLPhishingFilter::instance().isSuspicious("https://secondlife-marketplaces-nonoma-6e7834ae410b.herokuapp.com/"));
-	}
+	// Remove old test<2> as it is consolidated into test<1>
 }

--- a/indra/llui/tests/llphishingfilter_test.cpp
+++ b/indra/llui/tests/llphishingfilter_test.cpp
@@ -1,0 +1,65 @@
+/**
+ * @file llphishingfilter_test.cpp
+ * @brief Unit tests for LLPhishingFilter
+ *
+ * $LicenseInfo:firstyear=2026&license=viewerlgpl$
+ * Second Life Viewer Source Code
+ * Copyright (C) 2026, Phoenix Firestorm Project, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation;
+ * version 2.1 of the License only.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * Phoenix Firestorm Project, Inc., 945 Battery Street, San Francisco, CA  94111  USA
+ * $/LicenseInfo$
+ */
+
+#include "linden_common.h"
+#include "lltut.h"
+#include "llphishingfilter.h"
+
+namespace tut
+{
+	struct phishingfilter_data
+	{
+	};
+	typedef test_group<phishingfilter_data> phishingfilter_test;
+	typedef phishingfilter_test::object phishingfilter_object;
+	tut::phishingfilter_test phishingfilter_testcase("LLPhishingFilter");
+
+	template<> template<>
+	void phishingfilter_object::test<1>()
+	{
+		set_test_name("Evaluate risk scores");
+
+		// Official domains should have 0 risk even with keywords
+		ensure_equals("Official marketplace", LLPhishingFilter::instance().evaluateURLRisk("https://marketplace.secondlife.com/p/item/123"), 0);
+		ensure_equals("Official domain", LLPhishingFilter::instance().evaluateURLRisk("https://secondlife.com/destinations"), 0);
+
+		// Malicious domains with SL keywords should have high risk
+		ensure_equals("Malicious marketplace on herokuapp", LLPhishingFilter::instance().evaluateURLRisk("http://marketplace.seconde-life-com.herokuapp.com/login"), 150); // 100 (keyword) + 50 (hosting)
+		ensure_equals("Typosquatting", LLPhishingFilter::instance().evaluateURLRisk("https://marketplace.seconde-life.com/"), 100);
+
+		// Benign non-SL domains should have 0 or low risk
+		ensure_equals("Google", LLPhishingFilter::instance().evaluateURLRisk("https://www.google.com/search?q=secondlife"), 0); // keyword is in query, but not in domain
+	}
+
+	template<> template<>
+	void phishingfilter_object::test<2>()
+	{
+		set_test_name("isSuspicious check");
+
+		ensure("Official is not suspicious", !LLPhishingFilter::instance().isSuspicious("https://secondlife.com/"));
+		ensure("Phishing is suspicious", LLPhishingFilter::instance().isSuspicious("http://marketplace-secondlife.com.herokuapp.com/"));
+	}
+}

--- a/indra/llui/tests/llphishingfilter_test.cpp
+++ b/indra/llui/tests/llphishingfilter_test.cpp
@@ -60,6 +60,20 @@ namespace tut
 		set_test_name("isSuspicious check");
 
 		ensure("Official is not suspicious", !LLPhishingFilter::instance().isSuspicious("https://secondlife.com/"));
-		ensure("Phishing is suspicious", LLPhishingFilter::instance().isSuspicious("http://marketplace-secondlife.com.herokuapp.com/"));
+		ensure("Official marketplace is not suspicious", !LLPhishingFilter::instance().isSuspicious("https://marketplace.secondlife.com/p/item/123"));
+
+		// Real world scam URLs
+		ensure("second-lif herokuapp", LLPhishingFilter::instance().isSuspicious("https://second-lif-9bc8e3689e62.herokuapp.com/"));
+		ensure("marketplace-secondellife herokuapp", LLPhishingFilter::instance().isSuspicious("https://marketplace-secondellife-6c9143ddec6d.herokuapp.com/"));
+		ensure("marketplace-seconldlife herokuapp", LLPhishingFilter::instance().isSuspicious("https://marketplace-seconldlife-let-p-be1335f33c3f.herokuapp.com/id.html"));
+		ensure("marketplace-seconldlife-angel herokuapp", LLPhishingFilter::instance().isSuspicious("https://marketplace-seconldlife-angel-b45a44c35bab.herokuapp.com/"));
+		ensure("marketplace-secondlife-com herokuapp", LLPhishingFilter::instance().isSuspicious("https://marketplace-secondlife-com-p-m-655efa0e1350.herokuapp.com/"));
+		ensure("marketplacesecondlife herokuapp", LLPhishingFilter::instance().isSuspicious("https://marketplacesecondlife-necklace-7a51f474ed25.herokuapp.com/"));
+		ensure("marketplace-secondlife-p herokuapp", LLPhishingFilter::instance().isSuspicious("https://marketplace-secondlife-p-re-my-1c3fab5d4034.herokuapp.com/id.htm"));
+		ensure("kirastyle herokuapp (pattern match)", LLPhishingFilter::instance().isSuspicious("https://kirastyle-283-2787130-4aff445324e8.herokuapp.com/"));
+		ensure("marketplace-seconldlife-let-pe herokuapp", LLPhishingFilter::instance().isSuspicious("https://marketplace-seconldlife-let-pe-b8bb43cf66f1.herokuapp.com/id.html"));
+		ensure("seconde-live herokuapp", LLPhishingFilter::instance().isSuspicious("https://seconde-live-1d5912081d12.herokuapp.com/"));
+		ensure("marketplace-secondlife herokuapp", LLPhishingFilter::instance().isSuspicious("https://marketplace-secondlife-28fbbedee6b3.herokuapp.com/"));
+		ensure("secondlife-marketplaces-nonoma herokuapp", LLPhishingFilter::instance().isSuspicious("https://secondlife-marketplaces-nonoma-6e7834ae410b.herokuapp.com/"));
 	}
 }

--- a/indra/newview/app_settings/settings_firestorm.xml
+++ b/indra/newview/app_settings/settings_firestorm.xml
@@ -49,6 +49,18 @@
       <integer>0</integer>
     </map>
 
+    <key>FSPhishingFilterEnabled</key>
+    <map>
+      <key>Comment</key>
+      <string>Enable phishing link detection and mitigation in instant messages.</string>
+      <key>Persist</key>
+      <integer>1</integer>
+      <key>Type</key>
+      <string>Boolean</string>
+      <key>Value</key>
+      <integer>1</integer>
+    </map>
+
   <key>OpenSidePanelsInFloaters</key>
   <map>
     <key>Comment</key>

--- a/indra/newview/llimview.cpp
+++ b/indra/newview/llimview.cpp
@@ -65,6 +65,7 @@
 #include "llviewerwindow.h"
 #include "llnotifications.h"
 #include "llnotificationsutil.h"
+#include "llphishingfilter.h"
 // <FS:Ansariel> [FS communication UI]
 //#include "llfloaterimnearbychat.h"
 #include "fsfloaternearbychat.h"
@@ -3517,6 +3518,14 @@ void LLIMMgr::addMessage(
         }
     }
     // </FS:Zi>
+
+    // <FS:Emme> Phishing filter support
+    std::string filtered_msg;
+    if (LLPhishingFilter::instance().processMessage(msg, filtered_msg))
+    {
+        msg = filtered_msg;
+    }
+    // </FS:Emme>
 
     LLUUID other_participant_id = target_id;
     std::string message_display_name = (display_name.empty()) ? from : std::string(display_name);

--- a/indra/newview/llimview.cpp
+++ b/indra/newview/llimview.cpp
@@ -3519,14 +3519,6 @@ void LLIMMgr::addMessage(
     }
     // </FS:Zi>
 
-    // <FS:Emme> Phishing filter support
-    std::string filtered_msg;
-    if (LLPhishingFilter::instance().processMessage(msg, filtered_msg))
-    {
-        msg = filtered_msg;
-    }
-    // </FS:Emme>
-
     LLUUID other_participant_id = target_id;
     std::string message_display_name = (display_name.empty()) ? from : std::string(display_name);
     if (display_id.isNull() && (display_name.empty()))

--- a/indra/newview/skins/default/xui/en/panel_preferences_firestorm.xml
+++ b/indra/newview/skins/default/xui/en/panel_preferences_firestorm.xml
@@ -363,6 +363,16 @@
          height="16"
          name="UseAntiSpam"
          width="200" />
+        <check_box
+         top_pad="3"
+         left="10"
+         label="Enable Phishing Filter"
+         control_name="FSPhishingFilterEnabled"
+         follows="left|top"
+         height="16"
+         name="phishingfilter"
+         width="200"
+         tool_tip="Detect and mitigate suspected phishing links in instant messages." />
         <!-- FS:TS FIRE-23138: Enable spam protection for user's objects -->
         <check_box
          left="20"


### PR DESCRIPTION
# Overview

I think the viewer can do more to reduce the harm of phishing scams that we've seen in group messages lately. This is one approach, matching on some common deceptive patterns and commonly-used free app hosts, and making them less likely to be clicked without hiding them entirely.

# Visual Display of Phishing Links

A message with a suspicious URL in it would pop up to the recipient in red, with `[PHISHING?]` prepended to it:

<img width="388" height="184" alt="phish2" src="https://github.com/user-attachments/assets/6ee1f738-c1f1-4890-8a7f-f1eab194352b" />

And in the IM chat window the link would have the same warning prepended, and not be clickable. (I couldn't figure out how to make it red there.) This means that for the attack to succeed, the victim has to actively copy/paste the URL.

<img width="600" height="84" alt="phish3" src="https://github.com/user-attachments/assets/c8a29cfc-bd5a-4ffb-92ae-f3ebd6f0d749" />

The behavior can be disabled by un-checking this box:

<img width="662" height="564" alt="phish4" src="https://github.com/user-attachments/assets/25cf9d44-ee26-4dee-a622-75295e0c883e" />

# Detecting Phishing Links

The solution contained in this PR uses a scoring system with a few signals to infer phishing-ness.

1. **Is the link trying to impersonate secondlife.com or marketplace.secondlife.com?** (I've also thrown in maps.secondlife.com as that's the other kind of official link that people share a lot.) Here we use a Levenshtein distance comparison of the beginning of the domain name. Emphasis is placed mostly on the beginning, as that's what users are most likely to see before they click. There's also a regex-based piece to this (which is what I started with), but it could arguably be dropped if the less-brittle distance comparison is doing its job. I'm also considering switching to Jaro Winkler distance, as that automatically adds weight to similarity at the beginning of the compared strings. If the scammers want to evade this, they'll have to give up some of the effectiveness of their URLs.
2. **Is the domain on a free PaaS or dirt cheap TLD?** There is a finite number of these in the world. They come and go, but not every day.

# Q&A

## Doesn't this just start us down a cat and mouse game that we can never win?

"Winning" is not a binary. Much of security comes down to reducing the likelihood of a successful attack and raising the costs of the attackers. There are only so many free app hosts out there, and only so many ways to mis-spell "marketplace" and "secondlife" before your phishing URL stops looking believable. We can't catch all scammy links with a hard-coded solution, but we can catch most of them that are impersonating `secondlife.com` and `marketplace.secondlife.com`.

## Shouldn't this be done on the server?

Yeah, it should be. Linden Labs could scan all IMs for URLs and run them against something like the [Google Safe Browsing API](https://developers.google.com/safe-browsing/reference/rpc) before anyone sees the message. My testing has shown they're already doing *something* like that, because some of the old phishing links in my chat logs that I've tried to send to my alt ended up with the message getting dropped before my alt could even see the message. On the other hand, a lot of the links from old logs still work, even ones that Google identifies as unsafe at https://transparencyreport.google.com/safe-browsing/search .

## Shouldn't we put the patterns in a database?

Yeah, probably. Scammers will probably always be faster to switch tactics than Firestorm developers want to push out new releases.

In addition to the domain prefixes that this looks for (secondlife.com, marketplace), there are other pretty-commonly-shared domains in SL that scammers would likely hop to next (gyazo, primfeed, flickr), though they're less juicy targets monetarily. Putting those prefixes in an online database or even a text file on Github would make sense, along with the list of free PaaSes and sketchy TLDs.

