### PR TITLE
Add byte counter to notecard preview

### DIFF
--- a/indra/newview/llpreviewnotecard.cpp
+++ b/indra/newview/llpreviewnotecard.cpp
@@ -27,7 +27,7 @@
 #include "llviewerprecompiledheaders.h"
 
 #include "llpreviewnotecard.h"
-#include "llnotecard.h"
+#include "llnotecard.h" // <FS> Byte counter
 
 #include "llinventory.h"
 
@@ -61,7 +61,7 @@
 #include "lllineeditor.h"
 #include "lluictrlfactory.h"
 #include "llviewerassetupload.h"
-#include "lluistring.h"
+#include "lluistring.h" // <FS> Needed for the Byte Counter
 
 // [SL:KB] - Patch: UI-FloaterSearchReplace | Checked: 2010-11-05 (Catznip-2.3.0a) | Added: Catznip-2.3.0a
 #include "llfloatersearchreplace.h"
@@ -79,6 +79,7 @@ LLPreviewNotecard::LLPreviewNotecard(const LLSD& key) //const LLUUID& item_id,
     // <FS:Ansariel> FIRE-24306: Retain cursor position when saving notecards
     ,mCursorPos(0)
     ,mScrollPos(0)
+    ,mByteCounterTemplate("")  // <FS> Initialize empty for Byte Counter
     // <FS:Ansariel> FIRE-29425: User-selectable font and size for notecards
     ,mFontNameChangedCallbackConnection()
     ,mFontSizeChangedCallbackConnection()
@@ -127,14 +128,21 @@ bool LLPreviewNotecard::postBuild()
 
     mEditBtn = getChild<LLButton>("Edit");
     mEditBtn->setCommitCallback(boost::bind(&LLPreviewNotecard::openInExternalEditor, this));
-	
-	// Byte counter
-	mByteCounter = getChild<LLTextBox>("byte_counter");
-	if (mByteCounter)
-	{
-		mByteCounterTemplate = mByteCounter->getText();
-	}
-	mEditor->setKeystrokeCallback([this](LLTextEditor*) { mByteCounterDirty = true; });
+
+    // <FS> Byte counter
+    mByteCounter = getChild<LLTextBox>("byte_counter");
+    if (mByteCounter)
+    {
+        mByteCounterTemplate = mByteCounter->getText();
+        if (mByteCounterTemplate.empty())
+            mByteCounterTemplate = "Bytes: [BYTES] / [MAX]";
+        LLUIString init_text(mByteCounterTemplate);
+        init_text.setArg("[BYTES]", "0");
+        init_text.setArg("[MAX]", std::to_string(LLNotecard::MAX_SIZE));
+        mByteCounter->setText(init_text.getString());
+    }
+    mEditor->setKeystrokeCallback([this](LLTextEditor*) { mByteCounterDirty = true; });
+    // </FS>
 
     // <FS:Ansariel> FIRE-13969: Search button
     getChild<LLButton>("Search")->setClickedCallback(boost::bind(&LLPreviewNotecard::onSearchButtonClicked, this));
@@ -166,28 +174,35 @@ bool LLPreviewNotecard::saveItem()
     return saveIfNeeded(item);
 }
 
-// Byte counter
-// - Neremyn
+// <FS:Neremyn> Byte counter
 void LLPreviewNotecard::updateByteCounter()
 {
     if (!mEditor || !mByteCounter) return;
 
+    mByteCounterDirty = false;
+
+    const size_t MAX_BYTES = LLNotecard::MAX_SIZE;
+
     std::string text = mEditor->getText();
     size_t bytes = text.size(); // Assumes UTF-8 encoding where size() == bytes
 
-    const size_t MAX_BYTES = LLNotecard::MAX_SIZE;
-	
-	auto getColorForByteCount = [MAX_BYTES, bytes]() -> LLColor4
-	{
-		if (bytes >= MAX_BYTES)
-			return LLColor4::red;
-		
-		if (bytes > (MAX_BYTES * 8 / 10))
-			return LLColor4::yellow;
-		
-		return LLColor4::white;
-	};
-	mByteCounter->setColor(getColorForByteCount()); 
+    auto getColorForByteCount = [MAX_BYTES, bytes]() -> LLColor4
+    {
+        if (bytes >= MAX_BYTES)
+            return LLColor4::red;
+
+        if (bytes > (MAX_BYTES * 8 / 10))
+            return LLColor4::yellow;
+
+        return LLColor4::white;
+    };
+    mByteCounter->setColor(getColorForByteCount());
+
+    // Ensure template is valid
+    if (mByteCounterTemplate.empty())
+    {
+        mByteCounterTemplate = "Bytes: [BYTES] / [MAX]";
+    }
 
     LLUIString ui_text(mByteCounterTemplate);
     ui_text.setArg("[BYTES]", std::to_string(bytes));
@@ -195,6 +210,7 @@ void LLPreviewNotecard::updateByteCounter()
 
     mByteCounter->setText(ui_text.getString());
 }
+// </FS>
 
 void LLPreviewNotecard::setEnabled(bool enabled)
 {
@@ -222,11 +238,12 @@ void LLPreviewNotecard::draw()
     bool changed = !mEditor->isPristine();
 
     mSaveBtn->setEnabled(changed && getEnabled());
-	if (mByteCounterDirty) // Byte counter
-	{
-		updateByteCounter();
-		mByteCounterDirty = false;
-	}
+    // <FS> Byte counter
+    if (mByteCounterDirty)
+    {
+        updateByteCounter();
+    }
+    // </FS>
     LLPreview::draw();
 }
 
@@ -497,6 +514,9 @@ void LLPreviewNotecard::onLoadComplete(const LLUUID& asset_uuid,
             preview->setEnabled(modifiable);
             preview->syncExternal();
             preview->mAssetStatus = PREVIEW_ASSET_LOADED;
+            // <FS> Byte counter
+            preview->updateByteCounter();
+            // </FS>
 
             // <FS:Ansariel> FIRE-24306: Retain cursor position when saving notecards
             preview->mEditor->setCursorPos(preview->mCursorPos);
@@ -946,6 +966,7 @@ bool LLPreviewNotecard::loadNotecardText(const std::string& filename)
     LLStringUtil::replaceTabsWithSpaces(text, LLTextEditor::spacesPerTab());
 
     mEditor->setText(text);
+    mByteCounterDirty = true; // <FS> Byte counter
     delete[] buffer;
 
     return true;

--- a/indra/newview/llpreviewnotecard.cpp
+++ b/indra/newview/llpreviewnotecard.cpp
@@ -27,6 +27,7 @@
 #include "llviewerprecompiledheaders.h"
 
 #include "llpreviewnotecard.h"
+#include "llnotecard.h"
 
 #include "llinventory.h"
 
@@ -60,6 +61,7 @@
 #include "lllineeditor.h"
 #include "lluictrlfactory.h"
 #include "llviewerassetupload.h"
+#include "lluistring.h"
 
 // [SL:KB] - Patch: UI-FloaterSearchReplace | Checked: 2010-11-05 (Catznip-2.3.0a) | Added: Catznip-2.3.0a
 #include "llfloatersearchreplace.h"
@@ -125,6 +127,14 @@ bool LLPreviewNotecard::postBuild()
 
     mEditBtn = getChild<LLButton>("Edit");
     mEditBtn->setCommitCallback(boost::bind(&LLPreviewNotecard::openInExternalEditor, this));
+	
+	// Byte counter
+	mByteCounter = getChild<LLTextBox>("byte_counter");
+	if (mByteCounter)
+	{
+		mByteCounterTemplate = mByteCounter->getText();
+	}
+	mEditor->setKeystrokeCallback([this](LLTextEditor*) { mByteCounterDirty = true; });
 
     // <FS:Ansariel> FIRE-13969: Search button
     getChild<LLButton>("Search")->setClickedCallback(boost::bind(&LLPreviewNotecard::onSearchButtonClicked, this));
@@ -156,6 +166,36 @@ bool LLPreviewNotecard::saveItem()
     return saveIfNeeded(item);
 }
 
+// Byte counter
+// - Neremyn
+void LLPreviewNotecard::updateByteCounter()
+{
+    if (!mEditor || !mByteCounter) return;
+
+    std::string text = mEditor->getText();
+    size_t bytes = text.size(); // Assumes UTF-8 encoding where size() == bytes
+
+    const size_t MAX_BYTES = LLNotecard::MAX_SIZE;
+	
+	auto getColorForByteCount = [MAX_BYTES, bytes]() -> LLColor4
+	{
+		if (bytes >= MAX_BYTES)
+			return LLColor4::red;
+		
+		if (bytes > (MAX_BYTES * 8 / 10))
+			return LLColor4::yellow;
+		
+		return LLColor4::white;
+	};
+	mByteCounter->setColor(getColorForByteCount()); 
+
+    LLUIString ui_text(mByteCounterTemplate);
+    ui_text.setArg("[BYTES]", std::to_string(bytes));
+    ui_text.setArg("[MAX]", std::to_string(MAX_BYTES));
+
+    mByteCounter->setText(ui_text.getString());
+}
+
 void LLPreviewNotecard::setEnabled(bool enabled)
 {
     if (mEditor)
@@ -182,7 +222,11 @@ void LLPreviewNotecard::draw()
     bool changed = !mEditor->isPristine();
 
     mSaveBtn->setEnabled(changed && getEnabled());
-
+	if (mByteCounterDirty) // Byte counter
+	{
+		updateByteCounter();
+		mByteCounterDirty = false;
+	}
     LLPreview::draw();
 }
 

--- a/indra/newview/llpreviewnotecard.h
+++ b/indra/newview/llpreviewnotecard.h
@@ -99,6 +99,9 @@ protected:
     void updateTitleButtons() override;
     void loadAsset() override;
     bool saveIfNeeded(LLInventoryItem* copyitem = NULL, bool sync = true);
+	
+	// Byte counter
+	void updateByteCounter();
 
     void deleteNotecard();
 
@@ -137,6 +140,11 @@ protected:
     LLButton* mEditBtn = nullptr;
     LLButton* mDeleteBtn = nullptr;
     LLUICtrl* mLockBtn = nullptr;
+
+	// Byte counter
+	LLTextBox* mByteCounter = nullptr;
+	std::string mByteCounterTemplate;
+	bool mByteCounterDirty = true;
 
     LLUUID mAssetID;
 

--- a/indra/newview/llpreviewnotecard.h
+++ b/indra/newview/llpreviewnotecard.h
@@ -99,9 +99,9 @@ protected:
     void updateTitleButtons() override;
     void loadAsset() override;
     bool saveIfNeeded(LLInventoryItem* copyitem = NULL, bool sync = true);
-	
-	// Byte counter
-	void updateByteCounter();
+
+    // <FS> Byte Counter
+    void updateByteCounter();
 
     void deleteNotecard();
 
@@ -141,10 +141,11 @@ protected:
     LLButton* mDeleteBtn = nullptr;
     LLUICtrl* mLockBtn = nullptr;
 
-	// Byte counter
-	LLTextBox* mByteCounter = nullptr;
-	std::string mByteCounterTemplate;
-	bool mByteCounterDirty = true;
+    // <FS> Byte counter
+    LLTextBox* mByteCounter = nullptr;
+    std::string mByteCounterTemplate;
+    bool mByteCounterDirty = false;
+    // </FS>
 
     LLUUID mAssetID;
 

--- a/indra/newview/skins/default/xui/en/floater_preview_notecard.xml
+++ b/indra/newview/skins/default/xui/en/floater_preview_notecard.xml
@@ -106,6 +106,16 @@
      name="Edit"
      top="332"
      width="100" />
+	<text
+		name="byte_counter"
+		layout="topleft"
+		left="150"   
+		top="336"   
+		height="16"
+		width="200"
+		follows="left|bottom"
+		initial_value="Bytes: [BYTES] / [MAX]"
+	/>
     <button
      follows="right|bottom"
      height="22"

--- a/indra/newview/skins/default/xui/en/floater_preview_notecard.xml
+++ b/indra/newview/skins/default/xui/en/floater_preview_notecard.xml
@@ -106,16 +106,16 @@
      name="Edit"
      top="332"
      width="100" />
-	<text
-		name="byte_counter"
-		layout="topleft"
-		left="150"   
-		top="336"   
-		height="16"
-		width="200"
-		follows="left|bottom"
-		initial_value="Bytes: [BYTES] / [MAX]"
-	/>
+    <text
+     name="byte_counter"
+     layout="topleft"
+     left="150"
+     top="336"
+     height="16"
+     width="200"
+     follows="left|bottom"
+     initial_value="Bytes: [BYTES] / [MAX]"
+    />
     <button
      follows="right|bottom"
      height="22"

--- a/indra/newview/skins/default/xui/ja/floater_preview_notecard.xml
+++ b/indra/newview/skins/default/xui/ja/floater_preview_notecard.xml
@@ -17,6 +17,10 @@
 	</text_editor>
 	<button name="Search" tool_tip="検索と置き換えを表示します。"/>
 	<button label="編集…" label_selected="編集" name="Edit"/>
+	<text
+		name="byte_counter"
+		initial_value="バイト: [BYTES] / [MAX]"
+	/>
 	<button label="保存" label_selected="保存" name="Save"/>
 	<button label="削除" label_selected="削除" name="Delete"/>
 </floater>

--- a/indra/newview/skins/default/xui/ru/floater_preview_notecard.xml
+++ b/indra/newview/skins/default/xui/ru/floater_preview_notecard.xml
@@ -17,6 +17,10 @@
 	</text_editor>
 	<button name="Search" tool_tip="Поиск и Замена" />
 	<button label="Pедактировать..." label_selected="Редактировать" name="Edit"/>
+	<text
+		name="byte_counter"
+		initial_value="Байт: [BYTES] / [MAX]"
+	/>
 	<button label="Сохранить" label_selected="Сохранить" name="Save"/>
 	<button label="Удалить" label_selected="Удалить" name="Delete"/>
 </floater>

--- a/indra/newview/skins/default/xui/zh/floater_preview_notecard.xml
+++ b/indra/newview/skins/default/xui/zh/floater_preview_notecard.xml
@@ -17,6 +17,10 @@
 	</text_editor>
 	<button tool_tip="尋找和替換" name="Search" />
 	<button label="編輯…" label_selected="編輯" name="Edit" />
+	<text
+		name="byte_counter"
+		initial_value="字节: [BYTES] / [MAX]"
+	/>
 	<button label="儲存" label_selected="儲存" name="Save" />
 	<button label="刪除" label_selected="刪除" name="Delete" />
 </floater>


### PR DESCRIPTION
This PR implements live byte counter to the notecard editor UI that displays current byte usage against the maximum allowed size (LLNotecard::MAX_SIZE, 65536 bytes).

## Changes
### llpreviewnotecard.h
- Added LLTextBox* mByteCounter and std::string mByteCounterTemplate member variables
- Added bool mByteCounterDirty = true member variable
- Declared updateByteCounter() method

### llpreviewnotecard.cpp
- In postBuild(): retrieves the byte_counter widget, caches its template string, and registers a keystroke callback via setKeystrokeCallback that sets mByteCounterDirty = true
- Added updateByteCounter(): gets the current text from the editor, calculates byte size, compares against LLNotecard::MAX_SIZE, sets the label color (white -> yellow at 80% -> red at 100%), and updates the label text with current and max values substituted into the template
- In draw(): checks mByteCounterDirty and only calls updateByteCounter() when set, then clears the flag

### floater_preview_notecard.xml (and locale overrides for ja, ru, zh)
- Added a byte_counter text element with the template string "Bytes: [BYTES] / [MAX]"

## Files Modified
- indra/newview/llpreviewnotecard.cpp
- indra/newview/llpreviewnotecard.h
- indra/newview/skins/default/xui/en/floater_preview_notecard.xml
- indra/newview/skins/default/xui/ja/floater_preview_notecard.xml
- indra/newview/skins/default/xui/ru/floater_preview_notecard.xml
- indra/newview/skins/default/xui/zh/floater_preview_notecard.xml

## Testing
- Compiles without errors and warnings on Windows 10 (VS2022 x64)
- Counts correctly, including 3-byte and 4-byte characters.

## Caveat
- When embedding items inside the notecard the counter doesn't update until a key stroke - setKeystrokeCallback 
  Decided to leave it as it's and not modify the editor class, which is more invasive
  Alternatively, mByteCounterDirty can be dropped and updateByteCounter() can be called every frame from draw(). Performance impact is negligible but perhaps not every likes this approach.

## Use Case
- Provides visual feedback on byte usage, warning the user as they approach the notecard size limit.