### PR TITLE
FIRE-36603: Add missing switch case for enumeration coverage

### DIFF
--- a/indra/llui/llbutton.cpp
+++ b/indra/llui/llbutton.cpp
@@ -1238,6 +1238,8 @@ bool LLButton::isLabelTruncated() const
                 text_right -= overlay_width + mImgOverlayLabelSpace;
                 usable_text_width -= overlay_width + mImgOverlayLabelSpace;
                 break;
+            case LLFontGL::HCENTER:
+                break;
         }
     }
 


### PR DESCRIPTION
Change introduced in ec92ff9383a37d280875644b74a56e43644e6600 triggers a compiler error on Linux with gcc-15 for missing enumeration coverage in a switch statement in llbutton.cpp

<img width="1734" height="147" alt="image" src="https://github.com/user-attachments/assets/5a3c636d-c7ff-4c6a-a59d-6d5302e6846d" />

The referenced switch:

<img width="656" height="268" alt="image" src="https://github.com/user-attachments/assets/e3a688d1-7090-4b39-9f59-18ebc50e85dd" />

It's missing a case for ::HCENTER (or, if you prefer, a default case). This PR just adds a do-nothing case which satisfies the requirement and allows compilation to continue.
