### PR TITLE
Fix building RelWithDebInfo due to undeclared identifier isnan

### DIFF
--- a/indra/llinventory/llsettingsbase.cpp
+++ b/indra/llinventory/llsettingsbase.cpp
@@ -764,7 +764,7 @@ void LLSettingsBlender::update(const LLSettingsBase::BlendFactor& blendf)
 F64 LLSettingsBlender::setBlendFactor(const LLSettingsBase::BlendFactor& blendf_in)
 {
     LLSettingsBase::TrackPosition blendf = (F32)blendf_in;
-    llassert(!isnan(blendf));
+    llassert(!llisnan(blendf));
     if (blendf >= 1.0)
     {
         triggerComplete();


### PR DESCRIPTION
Simple swap of isnan to llisnan to fix building RelWithDebinfo on Linux. Specifically with Clang 22.1.3

Contributed with permission and blessing from @XenHat

```
indra/llinventory/llsettingsbase.cpp:767:15: error: use of undeclared identifier 'isnan'
  767 |     llassert(!isnan(blendf));
      |               ^~~~~
````