### PR TITLE
MAX_BYTES not required to be captured

### DIFF
--- a/indra/newview/llpreviewnotecard.cpp
+++ b/indra/newview/llpreviewnotecard.cpp
@@ -186,7 +186,7 @@ void LLPreviewNotecard::updateByteCounter()
     std::string text = mEditor->getText();
     size_t bytes = text.size(); // Assumes UTF-8 encoding where size() == bytes
 
-    auto getColorForByteCount = [MAX_BYTES, bytes]() -> LLColor4
+    auto getColorForByteCount = [bytes]() -> LLColor4
     {
         if (bytes >= MAX_BYTES)
             return LLColor4::red;


### PR DESCRIPTION
Removed capture of MAX_BYTES to placate compiler.

## Firestorm Pull Request Checklist
Thank you for contributing to the Phoenix Firestorm Project.
We will endeavour to review you changes and accept/reject/request changes as soon as possible. 
Please read and follow the [Firestorm Pull Request Guidelines](https://github.com/firestormviewer/phoenix-firestorm/blob/master/FS_PR_GUIDELINES.md) to reduce the likelihood that we need to ask for "Bureaucratic" changes to make the code comply with our workflows.
