### PR TITLE
Improved FPS Limiter

### DIFF
--- a/indra/newview/llappviewer.cpp
+++ b/indra/newview/llappviewer.cpp
@@ -1984,7 +1984,7 @@ void LLAppViewer::flushLFSIO()
 // <XenHat> More stable FPS Limiter
 #if LL_WINDOWS
 // Waitable timer sleep for precise sub-millisecond waits on Windows.
-static void precise_wait_us(U64 us)
+static void sleep_remaining_us(U64 remaining_us)
 {
     // Use CreateWaitableTimerW for microsecond-precision sleeps.
     HANDLE timer = CreateWaitableTimerW(NULL, TRUE, NULL);
@@ -1992,53 +1992,28 @@ static void precise_wait_us(U64 us)
     {
         // Relative time: -100ns units, negative means relative to current time.
         LARGE_INTEGER li;
-        li.QuadPart = -(S64)(us * 100);
+        li.QuadPart = -(S64)(remaining_us * 100);
         SetWaitableTimer(timer, &li, 0, NULL, NULL, FALSE);
         WaitForSingleObject(timer, INFINITE);
         CloseHandle(timer);
     }
 }
-#endif
 
-void inline LLAppViewer::frameLimiterBusyLoop(const U64& sleep_us_remaining)
+constexpr U64 SLEEP_THRESHOLD_US = 100;
+#elif LL_LINUX || LL_DARWIN
+static void sleep_remaining_us(U64 remaining_us)
 {
-    const U64 start_count = get_clock_count();
-    const U64 target_ticks = start_count + (sleep_us_remaining * get_timer_info().mClockFrequency.value() / 1000000);
-    // static LLFastTimer::DeclareTimer FTM_FRAME_LIMITER("Limiter Busy Loop");
-    LL_PROFILE_ZONE_NAMED_CATEGORY_APP("sleep3");
-
-#if LL_LINUX || LL_DARWIN
     struct timespec ts;
-    while (get_clock_count() < target_ticks)
-    {
-        U64 now = get_clock_count();
-        U64 remaining_us = target_ticks - now;
-        if (remaining_us > 500)
-        {
-            // Use nanosleep for sub-millisecond precision.
-            ts.tv_sec = S64(remaining_us) / 1000000;
-            ts.tv_nsec = (S64(remaining_us) % 1000000) * 1000;
-            // Ignore EINTR — nanosleep already loops internally in _sleep_loop.
-            nanosleep(&ts, NULL);
-        }
-    }
-#elif LL_WINDOWS
-    while (get_clock_count() < target_ticks)
-    {
-        U64 now = get_clock_count();
-        U64 remaining_us = target_ticks - now;
-        if (remaining_us > 100)
-        {
-            precise_wait_us(remaining_us);
-        }
-    }
-#else
-    while (get_clock_count() < target_ticks)
-    {
-        ms_sleep(1);
-    }
-#endif
+    ts.tv_sec = S64(remaining_us) / 1000000;
+    ts.tv_nsec = (S64(remaining_us) % 1000000) * 1000;
+    nanosleep(&ts, NULL);
 }
+
+constexpr U64 SLEEP_THRESHOLD_US = 500;
+#else
+static void sleep_remaining_us(U64 /* remaining_us */) { ms_sleep(1); }
+constexpr U64 SLEEP_THRESHOLD_US = 1;
+#endif
 
 void LLAppViewer::limitFramesPerSecond(LLTimer& frameTimer)
 {
@@ -2051,7 +2026,7 @@ void LLAppViewer::limitFramesPerSecond(LLTimer& frameTimer)
         static LLCachedControl<U32> max_fps(gSavedSettings, "FramePerSecondLimit");
         // Account for overhead and sloppiness
         U32 fps_target = max_fps - 1;
-        if (fsLimitFramerate && LLStartUp::getStartupState() == STATE_STARTED && !gTeleportDisplay && !logoutRequestSent() && fps_target > F_APPROXIMATELY_ZERO)
+        if (LLStartUp::getStartupState() == STATE_STARTED && !gTeleportDisplay && !logoutRequestSent() && fps_target > F_APPROXIMATELY_ZERO)
         {
             // Sleep a while to limit frame rate.
             LL_PROFILE_ZONE_NAMED_CATEGORY_APP("sleep2");
@@ -2067,22 +2042,25 @@ void LLAppViewer::limitFramesPerSecond(LLTimer& frameTimer)
             {
                 const U64 SLEEP_TIME_US = TARGET_FRAME_TIME_US - ELAPSED_TIME_US - 100;  // 100us buffer
 
-                if (SLEEP_TIME_US >= 1000)
-                {
-                    // Sleep bulk milliseconds first
-                    const U32 sleep_ms = (U32)(SLEEP_TIME_US / 1000);
-                    ms_sleep(sleep_ms);
+                // Sleep bulk milliseconds, then busy-wait remainder for microsecond precision.
+                const U32 sleep_ms = (U32)(SLEEP_TIME_US / 1000);
+                if (sleep_ms) ms_sleep(sleep_ms);
 
-                    // Busy-wait for remaining microseconds with yield
-                    const U64 sleep_us_remaining = SLEEP_TIME_US % 1000;
-                    if (sleep_us_remaining > 100)
-                    {
-                        frameLimiterBusyLoop(sleep_us_remaining);
-                    }
-                }
-                else if (SLEEP_TIME_US > 0)
+                const U64 sleep_us_remaining = SLEEP_TIME_US % 1000;
+                if (sleep_us_remaining > 100)
                 {
-                    frameLimiterBusyLoop(SLEEP_TIME_US);
+                    const U64 start_count = get_clock_count();
+                    const U64 target_ticks = start_count + (sleep_us_remaining * get_timer_info().mClockFrequency.value() / 1000000);
+                    LL_PROFILE_ZONE_NAMED_CATEGORY_APP("sleep3");
+
+                    while (get_clock_count() < target_ticks)
+                    {
+                        U64 remaining_us = target_ticks - get_clock_count();
+                        if (remaining_us > SLEEP_THRESHOLD_US)
+                        {
+                            sleep_remaining_us(remaining_us);
+                        }
+                    }
                 }
             }
         }
@@ -2090,7 +2068,7 @@ void LLAppViewer::limitFramesPerSecond(LLTimer& frameTimer)
     else {
         // <FS:Ansariel> FIRE-22297: FPS limiter not working properly on Mac/Linux
         static LLCachedControl<U32> max_fps(gSavedSettings, "FramePerSecondLimit");
-        if (fsLimitFramerate && LLStartUp::getStartupState() == STATE_STARTED && !gTeleportDisplay && !logoutRequestSent() && max_fps > F_APPROXIMATELY_ZERO)
+        if (LLStartUp::getStartupState() == STATE_STARTED && !gTeleportDisplay && !logoutRequestSent() && max_fps > F_APPROXIMATELY_ZERO)
         {
             // Sleep a while to limit frame rate.
             LLPerfStats::RecordSceneTime T ( LLPerfStats::StatType_t::RENDER_FPSLIMIT );

--- a/indra/newview/llappviewer.cpp
+++ b/indra/newview/llappviewer.cpp
@@ -66,10 +66,9 @@
 #include "llconversationlog.h"
 #if LL_WINDOWS
 #include "lldxhardware.h"
-#elif LL_LINUX || LL_DARWIN
-#include <errno.h>
-#include <time.h>
 #endif
+#include <chrono>       // for std::this_thread::sleep_for (FPS limiter)
+#include <thread>       // for std::this_thread::sleep_for (FPS limiter)
 #include "lltexturestats.h"
 #include "lltrace.h"
 #include "lltracethreadrecorder.h"
@@ -1984,6 +1983,8 @@ void LLAppViewer::flushLFSIO()
 // <XenHat> More stable FPS Limiter
 #if LL_WINDOWS
 // Waitable timer sleep for precise sub-millisecond waits on Windows.
+// This is required because the standard sleep function only provides us with a granularity of 1ms,
+// which is barely enough for the kind of precision we're looking for.
 static void sleep_remaining_us(U64 remaining_us)
 {
     // Use CreateWaitableTimerW for microsecond-precision sleeps.
@@ -2001,12 +2002,11 @@ static void sleep_remaining_us(U64 remaining_us)
 
 constexpr U64 SLEEP_THRESHOLD_US = 100;
 #elif LL_LINUX || LL_DARWIN
+// The standard sleep on unix-like platform. Provides micro-second granularity, therefore it can be used
+// as-is.
 static void sleep_remaining_us(U64 remaining_us)
 {
-    struct timespec ts;
-    ts.tv_sec = S64(remaining_us) / 1000000;
-    ts.tv_nsec = (S64(remaining_us) % 1000000) * 1000;
-    nanosleep(&ts, NULL);
+    std::this_thread::sleep_for(std::chrono::microseconds(remaining_us));
 }
 
 constexpr U64 SLEEP_THRESHOLD_US = 500;

--- a/indra/newview/llappviewer.cpp
+++ b/indra/newview/llappviewer.cpp
@@ -1898,23 +1898,8 @@ bool LLAppViewer::doFrame()
                 LLLFSThread::sLocal->pause();
             }
 
-            // <FS:Ansariel> FIRE-22297: FPS limiter not working properly on Mac/Linux
-            static LLCachedControl<U32> max_fps(gSavedSettings, "FramePerSecondLimit");
-            static LLCachedControl<bool> fsLimitFramerate(gSavedSettings, "FSLimitFramerate");
-            if (fsLimitFramerate && LLStartUp::getStartupState() == STATE_STARTED && !gTeleportDisplay && !logoutRequestSent() && max_fps > F_APPROXIMATELY_ZERO)
-            {
-                // Sleep a while to limit frame rate.
-                LLPerfStats::RecordSceneTime T ( LLPerfStats::StatType_t::RENDER_FPSLIMIT );
-                F32 min_frame_time = 1.f / (F32)max_fps;
-                S32 milliseconds_to_sleep = llclamp((S32)((min_frame_time - frameTimer.getElapsedTimeF64()) * 1000.f), 0, 1000);
-                if (milliseconds_to_sleep > 0)
-                {
-                    LL_PROFILE_ZONE_NAMED_CATEGORY_APP("sleep2");
-                    ms_sleep(milliseconds_to_sleep);
-                }
-            }
-            frameTimer.reset();
-            // </FS:Ansariel>
+           limitFramesPerSecond(frameTimer);
+           frameTimer.reset();
             {
                 LL_PROFILE_ZONE_NAMED_CATEGORY_APP("df resumeMainloopTimeout");
                 resumeMainloopTimeout();
@@ -1990,6 +1975,93 @@ void LLAppViewer::flushLFSIO()
             }
             ms_sleep(100);
         }
+    }
+}
+
+void inline LLAppViewer::frameLimiterBusyLoop(const U64& sleep_us_remaining)
+{
+    const U64 start_count = get_clock_count();
+    const U64 target_ticks = start_count + (sleep_us_remaining * get_timer_info().mClockFrequency.value() / 1000000);
+    // static LLFastTimer::DeclareTimer FTM_FRAME_LIMITER("Limiter Busy Loop");
+    LL_PROFILE_ZONE_NAMED_CATEGORY_APP("sleep3");
+    while (get_clock_count() < target_ticks)
+    {
+        sched_yield();
+    }
+}
+
+void LLAppViewer::limitFramesPerSecond(LLTimer& frameTimer)
+{
+    static LLCachedControl<bool> use_new_limiter(gSavedSettings,"FSUseNewLimiterMethod", true);
+    static LLCachedControl<bool> fsLimitFramerate(gSavedSettings, "FSLimitFramerate");
+    if (!fsLimitFramerate) {
+        return;
+    }
+    if (use_new_limiter) {
+        static LLCachedControl<U32> max_fps(gSavedSettings, "FramePerSecondLimit");
+        // Account for overhead and sloppiness
+        U32 fps_target = max_fps - 1;
+        if (fsLimitFramerate && LLStartUp::getStartupState() == STATE_STARTED && !gTeleportDisplay && !logoutRequestSent() && fps_target > F_APPROXIMATELY_ZERO)
+        {
+            // Sleep a while to limit frame rate.
+            LL_PROFILE_ZONE_NAMED_CATEGORY_APP("sleep2");
+            LLPerfStats::RecordSceneTime T ( LLPerfStats::StatType_t::RENDER_FPSLIMIT );
+
+            // Calculate target frame time in microseconds using integer division
+            // This avoids floating-point precision issues
+            const U64 TARGET_FRAME_TIME_US = 1000000ULL / fps_target;
+            const U64 ELAPSED_TIME_US = (U64)(frameTimer.getElapsedTimeF64() * 1000000.0);
+
+            // Check if we need to sleep, accounting for buffer and avoiding underflow
+            if (ELAPSED_TIME_US + 100 < TARGET_FRAME_TIME_US)
+            {
+                const U64 SLEEP_TIME_US = TARGET_FRAME_TIME_US - ELAPSED_TIME_US - 100;  // 100us buffer
+
+                if (SLEEP_TIME_US >= 1000)
+                {
+                    // Sleep bulk milliseconds first
+                    const U32 sleep_ms = (U32)(SLEEP_TIME_US / 1000);
+                    ms_sleep(sleep_ms);
+
+                    // Busy-wait for remaining microseconds with yield
+                    const U64 sleep_us_remaining = SLEEP_TIME_US % 1000;
+                    if (sleep_us_remaining > 100)
+                    {
+                        frameLimiterBusyLoop(sleep_us_remaining);
+                    }
+                }
+                else if (SLEEP_TIME_US > 0)
+                {
+                    frameLimiterBusyLoop(SLEEP_TIME_US);
+                }
+            }
+        }
+    }
+    else {
+        // <FS:Ansariel> FIRE-22297: FPS limiter not working properly on Mac/Linux
+        static LLCachedControl<U32> max_fps(gSavedSettings, "FramePerSecondLimit");
+        if (fsLimitFramerate && LLStartUp::getStartupState() == STATE_STARTED && !gTeleportDisplay && !logoutRequestSent() && max_fps > F_APPROXIMATELY_ZERO)
+        {
+            // Sleep a while to limit frame rate.
+            LLPerfStats::RecordSceneTime T ( LLPerfStats::StatType_t::RENDER_FPSLIMIT );
+            F32 min_frame_time = 1.f / (F32)max_fps;
+            F32 elapsed_time = (F32)frameTimer.getElapsedTimeF64();
+            F32 remaining_time = min_frame_time - elapsed_time;
+
+            if (remaining_time > 0.f)
+            {
+                // Round to nearest millisecond instead of truncating
+                // This reduces the drift from ~4ms to <0.5ms per frame
+                S32 milliseconds_to_sleep = llround(remaining_time * 1000.f);
+                if (milliseconds_to_sleep > 0)
+                {
+                    LL_PROFILE_ZONE_NAMED_CATEGORY_APP("sleep2");
+                    milliseconds_to_sleep = llclamp(milliseconds_to_sleep, 0, 1000);
+                    ms_sleep(milliseconds_to_sleep);
+                }
+            }
+        }
+        // </FS:Ansariel>
     }
 }
 

--- a/indra/newview/llappviewer.cpp
+++ b/indra/newview/llappviewer.cpp
@@ -1898,7 +1898,7 @@ bool LLAppViewer::doFrame()
                 LLLFSThread::sLocal->pause();
             }
 
-           limitFramesPerSecond(frameTimer);
+           limitFramesPerSecond(frameTimer); // </XenHat> More stable FPS Limiter
            frameTimer.reset();
             {
                 LL_PROFILE_ZONE_NAMED_CATEGORY_APP("df resumeMainloopTimeout");
@@ -1978,6 +1978,7 @@ void LLAppViewer::flushLFSIO()
     }
 }
 
+// <XenHat> More stable FPS Limiter
 void inline LLAppViewer::frameLimiterBusyLoop(const U64& sleep_us_remaining)
 {
     const U64 start_count = get_clock_count();
@@ -2064,6 +2065,7 @@ void LLAppViewer::limitFramesPerSecond(LLTimer& frameTimer)
         // </FS:Ansariel>
     }
 }
+// </XenHat>
 
 bool LLAppViewer::cleanup()
 {

--- a/indra/newview/llappviewer.cpp
+++ b/indra/newview/llappviewer.cpp
@@ -66,6 +66,9 @@
 #include "llconversationlog.h"
 #if LL_WINDOWS
 #include "lldxhardware.h"
+#elif LL_LINUX || LL_DARWIN
+#include <errno.h>
+#include <time.h>
 #endif
 #include "lltexturestats.h"
 #include "lltrace.h"
@@ -1979,16 +1982,62 @@ void LLAppViewer::flushLFSIO()
 }
 
 // <XenHat> More stable FPS Limiter
+#if LL_WINDOWS
+// Waitable timer sleep for precise sub-millisecond waits on Windows.
+static void precise_wait_us(U64 us)
+{
+    // Use CreateWaitableTimerW for microsecond-precision sleeps.
+    HANDLE timer = CreateWaitableTimerW(NULL, TRUE, NULL);
+    if (timer)
+    {
+        // Relative time: -100ns units, negative means relative to current time.
+        LARGE_INTEGER li;
+        li.QuadPart = -(S64)(us * 100);
+        SetWaitableTimer(timer, &li, 0, NULL, NULL, FALSE);
+        WaitForSingleObject(timer, INFINITE);
+        CloseHandle(timer);
+    }
+}
+#endif
+
 void inline LLAppViewer::frameLimiterBusyLoop(const U64& sleep_us_remaining)
 {
     const U64 start_count = get_clock_count();
     const U64 target_ticks = start_count + (sleep_us_remaining * get_timer_info().mClockFrequency.value() / 1000000);
     // static LLFastTimer::DeclareTimer FTM_FRAME_LIMITER("Limiter Busy Loop");
     LL_PROFILE_ZONE_NAMED_CATEGORY_APP("sleep3");
+
+#if LL_LINUX || LL_DARWIN
+    struct timespec ts;
     while (get_clock_count() < target_ticks)
     {
-        sched_yield();
+        U64 now = get_clock_count();
+        U64 remaining_us = target_ticks - now;
+        if (remaining_us > 500)
+        {
+            // Use nanosleep for sub-millisecond precision.
+            ts.tv_sec = S64(remaining_us) / 1000000;
+            ts.tv_nsec = (S64(remaining_us) % 1000000) * 1000;
+            // Ignore EINTR — nanosleep already loops internally in _sleep_loop.
+            nanosleep(&ts, NULL);
+        }
     }
+#elif LL_WINDOWS
+    while (get_clock_count() < target_ticks)
+    {
+        U64 now = get_clock_count();
+        U64 remaining_us = target_ticks - now;
+        if (remaining_us > 100)
+        {
+            precise_wait_us(remaining_us);
+        }
+    }
+#else
+    while (get_clock_count() < target_ticks)
+    {
+        ms_sleep(1);
+    }
+#endif
 }
 
 void LLAppViewer::limitFramesPerSecond(LLTimer& frameTimer)

--- a/indra/newview/llappviewer.h
+++ b/indra/newview/llappviewer.h
@@ -113,6 +113,8 @@ public:
                    const LLSD& substitutions = LLSD()); // Display an error dialog and forcibly quit.
     void earlyExitNoNotify(); // Do not display error dialog then forcibly quit.
     void abortQuit();  // Called to abort a quit request.
+    void limitFramesPerSecond(LLTimer& frameTimer); // Limits frames per second using sleep and busy-wait for precision
+    void frameLimiterBusyLoop(const U64& sleep_us_remaining); // Busy loop for the fps limiter
 
     bool quitRequested() { return mQuitRequested; }
     bool logoutRequestSent() { return mLogoutRequestSent; }


### PR DESCRIPTION
This introduces a new hybrid FPS Limiter logic based on sleep/yield and busy loop for maximum stability.
The motivation behind this change is my desire to have a pleasant experience with a VRR (Variable Refresh Rate) monitor, which was difficult with the previous FPS Limiter method:
 - The FPS Limiter was quite inaccurate, and the resulting instability appeared to make every further iteration of the limiting code more unstable by over- and undershooting the target, possibly due to the 1 millisecond accuracy restriction.
 - While undershooting the target wasn't a problem, overshooting was, as it caused stutter from going outside the VRR window.
 - The FPS Limiter was increasingly inaccurate the higher the engine FPS was, likely also due to the millisecond accuracy limit.

The new approach now uses a hybrid busy loop and sleep-based approach to achieve maximum inter-frame stability and consistency.

Observed results seem to reduce the FPS variation from a range between 1 and 200 (!) to ~~1 to 2~~ less than 5 frames.

I have left the old FPS limiter code in place behind a setting to help debugging and testing the code, with the new behavior enabled by default.

I only tested this on Linux x86_64 with AMD Graphics, but it _should_ still work on other platforms.
**Testing required**.

Disclaimer: A local instance of Qwen3 was used to help design this.
I have reviewed the code manually and performed optimizations by hand where it made sense.

Note: Beyond 200 FPS, all things go awry, this limiter is no different. I cannot guarantee the limiter's accuracy in that case.

https://github.com/user-attachments/assets/c59b6e16-5450-4361-95a9-6d36a8d5b243
