### PR TITLE
Add VoiceBox TTS integration for nearby chat

### DIFF
--- a/indra/newview/CMakeLists.txt
+++ b/indra/newview/CMakeLists.txt
@@ -107,6 +107,7 @@ set(viewer_SOURCE_FILES
     fsavatarsearchmenu.cpp
     fsblocklistmenu.cpp
     fschathistory.cpp
+    fschattts.cpp
     fschatoptionsmenu.cpp
     fscommon.cpp
     fsconsoleutils.cpp
@@ -967,6 +968,7 @@ set(viewer_HEADER_FILES
     fsavatarsearchmenu.h
     fsblocklistmenu.h
     fschathistory.h
+    fschattts.h
     fschatoptionsmenu.h
     fschatparticipants.h
     fsdispatchclassifiedclickthrough.h

--- a/indra/newview/app_settings/settings_per_account.xml
+++ b/indra/newview/app_settings/settings_per_account.xml
@@ -1563,5 +1563,49 @@
             <key>Value</key>
             <map/>
         </map>
+    <key>FSVoiceBoxTTSEnabled</key>
+        <map>
+            <key>Comment</key>
+            <string>Enable VoiceBox TTS for nearby chat</string>
+            <key>Persist</key>
+            <integer>1</integer>
+            <key>Type</key>
+            <string>Boolean</string>
+            <key>Value</key>
+            <integer>0</integer>
+        </map>
+    <key>FSVoiceBoxEndpoint</key>
+        <map>
+            <key>Comment</key>
+            <string>VoiceBox API endpoint URL</string>
+            <key>Persist</key>
+            <integer>1</integer>
+            <key>Type</key>
+            <string>String</string>
+            <key>Value</key>
+            <string>http://localhost:17493</string>
+        </map>
+    <key>FSVoiceBoxProfileID</key>
+        <map>
+            <key>Comment</key>
+            <string>VoiceBox profile UUID to use for TTS</string>
+            <key>Persist</key>
+            <integer>1</integer>
+            <key>Type</key>
+            <string>String</string>
+            <key>Value</key>
+            <string></string>
+        </map>
+    <key>FSVoiceBoxTTSLanguage</key>
+        <map>
+            <key>Comment</key>
+            <string>Language code for TTS (e.g. en, de, fr)</string>
+            <key>Persist</key>
+            <integer>1</integer>
+            <key>Type</key>
+            <string>String</string>
+            <key>Value</key>
+            <string>en</string>
+        </map>
     </map>
 </llsd>

--- a/indra/newview/fschattts.cpp
+++ b/indra/newview/fschattts.cpp
@@ -1,0 +1,255 @@
+#include "llviewerprecompiledheaders.h"
+
+#include "fschattts.h"
+
+#include "llagent.h"
+#include "llchat.h"
+#include "llcorehttputil.h"
+#include "lldir.h"
+#include "lleventcoro.h"
+#include "llfile.h"
+#include "llaudioengine.h"
+#include "llviewercontrol.h"
+#include "llcoros.h"
+
+#include <queue>
+
+FSChatTTS* FSChatTTS::sInstance = nullptr;
+
+FSChatTTS::FSChatTTS()
+{
+    sInstance = this;
+}
+
+FSChatTTS::~FSChatTTS()
+{
+    sInstance = nullptr;
+}
+
+FSChatTTS& FSChatTTS::instance()
+{
+    if (!sInstance)
+    {
+        sInstance = new FSChatTTS();
+    }
+    return *sInstance;
+}
+
+void FSChatTTS::onChatMessage(const LLSD& chat)
+{
+    if (!gSavedPerAccountSettings.getBOOL("FSVoiceBoxTTSEnabled"))
+    {
+        return;
+    }
+
+    S32 source = chat["source"].asInteger();
+    if (source != CHAT_SOURCE_AGENT)
+    {
+        return;
+    }
+
+    LLUUID from_id = chat["from_id"].asUUID();
+    if (from_id.isNull())
+    {
+        return;
+    }
+
+    if (from_id == gAgentID)
+    {
+        return;
+    }
+
+    std::string text = chat["message"].asString();
+    if (text.empty())
+    {
+        return;
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(mMutex);
+        mQueue.push({text, from_id});
+    }
+
+    processQueue();
+}
+
+void FSChatTTS::processQueue()
+{
+    bool expected = false;
+    if (!mProcessing.compare_exchange_strong(expected, true))
+    {
+        return;
+    }
+
+    LLCoros::instance().launch("FSChatTTSCoro",
+        [this]()
+        {
+            while (true)
+            {
+                TTSRequest req;
+                {
+                    std::lock_guard<std::mutex> lock(mMutex);
+                    if (mQueue.empty())
+                    {
+                        mProcessing = false;
+                        return;
+                    }
+                    req = mQueue.front();
+                    mQueue.pop();
+                }
+
+                std::string text = req.text;
+                LL_DEBUGS("VoiceBoxTTS") << "Speaking: " << text << LL_ENDL;
+
+                doTTS(text);
+            }
+        });
+}
+
+void FSChatTTS::doTTS(const std::string& text)
+{
+    std::string endpoint = gSavedPerAccountSettings.getString("FSVoiceBoxEndpoint");
+    std::string profile_id = gSavedPerAccountSettings.getString("FSVoiceBoxProfileID");
+    std::string language = gSavedPerAccountSettings.getString("FSVoiceBoxTTSLanguage");
+
+    if (endpoint.empty() || profile_id.empty())
+    {
+        LL_WARNS("VoiceBoxTTS") << "Missing endpoint or profile_id" << LL_ENDL;
+        return;
+    }
+
+    LLSD body;
+    body["profile"] = profile_id;
+    body["text"] = text;
+    body["language"] = language;
+
+    LLCore::HttpHeaders::ptr_t json_headers = std::make_shared<LLCore::HttpHeaders>();
+    json_headers->append(HTTP_OUT_HEADER_CONTENT_TYPE, "application/json");
+    json_headers->append(HTTP_OUT_HEADER_ACCEPT, "application/json");
+
+    LLCore::HttpRequest::policy_t httpPolicy(LLCore::HttpRequest::DEFAULT_POLICY_ID);
+    auto httpAdapter = std::make_shared<LLCoreHttpUtil::HttpCoroutineAdapter>("VoiceBoxTTS", httpPolicy);
+
+    // Step 1: POST /speak to start generation
+    auto httpRequest = std::make_shared<LLCore::HttpRequest>();
+    std::string speak_url = endpoint + "/speak";
+    LLSD result = httpAdapter->postJsonAndSuspend(httpRequest, speak_url, body, LLCore::HttpOptions::ptr_t(), json_headers);
+
+    LLCore::HttpStatus status = LLCoreHttpUtil::HttpCoroutineAdapter::getStatusFromLLSD(result);
+    if (!status)
+    {
+        LL_WARNS("VoiceBoxTTS") << "POST /speak failed: " << status.toString() << LL_ENDL;
+        return;
+    }
+
+    std::string generation_id = result["id"].asString();
+    if (generation_id.empty())
+    {
+        LL_WARNS("VoiceBoxTTS") << "No generation ID in response" << LL_ENDL;
+        return;
+    }
+    LL_INFOS("VoiceBoxTTS") << "Generation started: " << generation_id << LL_ENDL;
+
+    // Step 2: Poll /history/{id} until completed
+    std::string history_url = endpoint + "/history/" + generation_id;
+    std::string gen_status = result["status"].asString();
+    int attempts = 0;
+
+    while (gen_status != "completed" && attempts < 60)
+    {
+        if (gen_status == "failed" || gen_status == "error")
+        {
+            LL_WARNS("VoiceBoxTTS") << "Generation failed with status: " << gen_status << LL_ENDL;
+            return;
+        }
+
+        if (!gen_status.empty())
+        {
+            LL_DEBUGS("VoiceBoxTTS") << "Generation status: " << gen_status << LL_ENDL;
+        }
+
+        llcoro::suspendUntilTimeout(0.5f);
+
+        auto pollRequest = std::make_shared<LLCore::HttpRequest>();
+        LLSD pollResult = httpAdapter->getJsonAndSuspend(pollRequest, history_url, LLCore::HttpOptions::ptr_t(), json_headers);
+
+        LLCore::HttpStatus pollStatus = LLCoreHttpUtil::HttpCoroutineAdapter::getStatusFromLLSD(pollResult);
+        if (!pollStatus)
+        {
+            LL_WARNS("VoiceBoxTTS") << "Poll failed: " << pollStatus.toString() << LL_ENDL;
+            // Continue polling anyway
+        }
+        else
+        {
+            gen_status = pollResult["status"].asString();
+        }
+
+        attempts++;
+    }
+
+    if (gen_status != "completed")
+    {
+        LL_WARNS("VoiceBoxTTS") << "Generation did not complete after 30s" << LL_ENDL;
+        return;
+    }
+
+    LL_INFOS("VoiceBoxTTS") << "Generation completed" << LL_ENDL;
+
+    // Step 3: GET /audio/{id} to download WAV
+    std::string audio_url = endpoint + "/audio/" + generation_id;
+
+    LLCore::HttpHeaders::ptr_t raw_headers = std::make_shared<LLCore::HttpHeaders>();
+
+    auto audioRequest = std::make_shared<LLCore::HttpRequest>();
+    LLSD audioResult = httpAdapter->getRawAndSuspend(audioRequest, audio_url, LLCore::HttpOptions::ptr_t(), raw_headers);
+
+    LLCore::HttpStatus audioStatus = LLCoreHttpUtil::HttpCoroutineAdapter::getStatusFromLLSD(audioResult);
+    if (!audioStatus)
+    {
+        LL_WARNS("VoiceBoxTTS") << "Audio download failed: " << audioStatus.toString() << LL_ENDL;
+        return;
+    }
+
+    const LLSD::Binary& wav_data = audioResult[LLCoreHttpUtil::HttpCoroutineAdapter::HTTP_RESULTS_RAW].asBinary();
+    if (wav_data.empty())
+    {
+        LL_WARNS("VoiceBoxTTS") << "Empty audio data" << LL_ENDL;
+        return;
+    }
+
+    // Step 4: Save to sound cache and play
+    LLUUID audio_uuid;
+    audio_uuid.generate();
+    std::string uuid_str;
+    audio_uuid.toString(uuid_str);
+
+    std::string wav_path = gDirUtilp->getExpandedFilename(LL_PATH_FS_SOUND_CACHE, uuid_str) + ".dsf";
+
+    {
+        llofstream outfile(wav_path, llofstream::binary);
+        outfile.write(reinterpret_cast<const char*>(wav_data.data()), wav_data.size());
+    }
+
+    if (!gAudiop)
+    {
+        LL_WARNS("VoiceBoxTTS") << "No audio engine available" << LL_ENDL;
+        return;
+    }
+
+    LLAudioData *adp = gAudiop->getAudioData(audio_uuid);
+    if (adp)
+    {
+        adp->setHasLocalData(true);
+        adp->setHasDecodedData(true);
+        adp->setHasCompletedDecode(true);
+        adp->setHasDecodeFailed(false);
+        adp->setHasWAVLoadFailed(false);
+
+        gAudiop->triggerSound(audio_uuid, gAgent.getID(), 1.0f, LLAudioEngine::AUDIO_TYPE_UI);
+        LL_INFOS("VoiceBoxTTS") << "Playing TTS audio" << LL_ENDL;
+    }
+    else
+    {
+        LL_WARNS("VoiceBoxTTS") << "Failed to create audio data" << LL_ENDL;
+    }
+}

--- a/indra/newview/fschattts.h
+++ b/indra/newview/fschattts.h
@@ -1,0 +1,38 @@
+#ifndef FS_FSCHATTTS_H
+#define FS_FSCHATTTS_H
+
+#include "llsd.h"
+#include "lluuid.h"
+#include <queue>
+#include <mutex>
+#include <atomic>
+#include <string>
+
+class FSChatTTS
+{
+public:
+    FSChatTTS();
+    ~FSChatTTS();
+
+    void onChatMessage(const LLSD& chat);
+
+    static FSChatTTS& instance();
+
+private:
+    struct TTSRequest
+    {
+        std::string text;
+        LLUUID from_id;
+    };
+
+    void processQueue();
+    void doTTS(const std::string& text);
+
+    std::queue<TTSRequest> mQueue;
+    std::mutex mMutex;
+    std::atomic<bool> mProcessing{ false };
+
+    static FSChatTTS* sInstance;
+};
+
+#endif

--- a/indra/newview/llfloaterimnearbychathandler.cpp
+++ b/indra/newview/llfloaterimnearbychathandler.cpp
@@ -52,6 +52,7 @@
 // [/RLVa:KB]
 
 #include "fsconsoleutils.h"
+#include "fschattts.h"
 #include "fsfloaternearbychat.h"
 #include "llviewernetwork.h"
 
@@ -530,6 +531,8 @@ LLFloaterIMNearbyChatHandler::LLFloaterIMNearbyChatHandler()
     channel->setCreatePanelCallback(callback);
 
     LLChannelManager::getInstance()->addChannel(channel);
+
+    addNewChatCallback(boost::bind(&FSChatTTS::onChatMessage, &FSChatTTS::instance(), _1));
 
     mChannel = channel->getHandle();
 }

--- a/indra/newview/skins/default/xui/en/panel_preferences_chat.xml
+++ b/indra/newview/skins/default/xui/en/panel_preferences_chat.xml
@@ -2107,6 +2107,104 @@
 		 
 	</panel>
 
+  <!-- Chat: VoiceBox TTS -->
+  <panel
+    top_pad="1"
+    bottom="-1"
+    left="1"
+    right="-1"
+    follows="all"
+    label="VoiceBox TTS"
+    name="tab-VoiceBoxTTS" >
+
+    <check_box
+     control_name="FSVoiceBoxTTSEnabled"
+     follows="left|top"
+     height="16"
+     label="Enable VoiceBox TTS – read nearby chat aloud"
+     layout="topleft"
+     left="20"
+     top="15"
+     name="voicebox_tts_enable"
+     width="450" />
+
+    <text
+     follows="left|top"
+     layout="topleft"
+     left="20"
+     height="14"
+     name="voicebox_endpoint_label"
+     width="150"
+     top_pad="15">
+        VoiceBox API endpoint:
+    </text>
+    <line_editor
+     control_name="FSVoiceBoxEndpoint"
+     follows="left|top"
+     height="20"
+     layout="topleft"
+     left_pad="5"
+     max_length_chars="256"
+     name="voicebox_endpoint"
+     width="300"
+     top_delta="-2" />
+
+    <text
+     follows="left|top"
+     layout="topleft"
+     left="20"
+     height="14"
+     name="voicebox_profile_label"
+     width="150"
+     top_pad="10">
+        TTS Profile:
+    </text>
+    <line_editor
+     control_name="FSVoiceBoxProfileID"
+     follows="left|top"
+     height="20"
+     layout="topleft"
+     left_pad="5"
+     max_length_chars="256"
+     name="voicebox_profile"
+     width="300"
+     top_delta="-2" />
+
+    <text
+     follows="left|top"
+     layout="topleft"
+     left="20"
+     height="14"
+     name="voicebox_language_label"
+     width="150"
+     top_pad="10">
+        Language (e.g. en, de):
+    </text>
+    <line_editor
+     control_name="FSVoiceBoxTTSLanguage"
+     follows="left|top"
+     height="20"
+     layout="topleft"
+     left_pad="5"
+     max_length_chars="10"
+     name="voicebox_language"
+     width="100"
+     top_delta="-2" />
+
+    <text
+     follows="left|top"
+     layout="topleft"
+     left="20"
+     height="14"
+     name="voicebox_tts_note"
+     width="480"
+     top_pad="10">
+        Reads nearby chat from avatars aloud via VoiceBox TTS.
+        Requires a running VoiceBox backend at the endpoint URL.
+     </text>
+
+  </panel>
+
   <!-- Chat: CmdLine -->
   <panel
 	  top_pad="3"


### PR DESCRIPTION
Reads nearby chat aloud via VoiceBox - an open-source, local-first TTS engine.

Features:
- Reads nearby chat from other avatars aloud
- Configurable endpoint, profile, and language per account
- Preferences UI tab under Chat Preferences
- Async generation with polling and automatic playback

Flow: POST /speak -> poll /history/{id} -> GET /audio/{id} -> play via viewer audio engine (FMOD/OpenAL)

Settings:
- FSVoiceBoxTTSEnabled (Boolean)
- FSVoiceBoxEndpoint (String, default http://localhost:17493)
- FSVoiceBoxProfileID (String)
- FSVoiceBoxTTSLanguage (String, default en)