### PR TITLE
Add folder organization to Favorite Wearables

### DIFF
--- a/indra/newview/fsfloaterwearablefavorites.cpp
+++ b/indra/newview/fsfloaterwearablefavorites.cpp
@@ -31,16 +31,20 @@
 #include "fscommon.h"
 #include "llappearancemgr.h"
 #include "llbutton.h"
+#include "llcombobox.h"
 #include "llfiltereditor.h"
 #include "llinventoryfunctions.h"
 #include "llinventoryobserver.h"
 #include "llmenugl.h"
 #include "llmenubutton.h"
+#include "llnotificationsutil.h"
 #include "lltoggleablemenu.h"
 #include "llviewercontrol.h"        // for gSavedSettings
+#include "llviewerinventory.h"
 #include "llviewermenu.h"           // for gMenuHolder
 #include "rlvactions.h"
 #include "rlvlocks.h"
+#include <set>
 
 // Hello Kokua! Have fun yoinking! ;)
 
@@ -88,6 +92,11 @@ LLUUID FSFloaterWearableFavorites::sFolderID = LLUUID();
 FSFloaterWearableFavorites::FSFloaterWearableFavorites(const LLSD& key)
     : LLFloater(key),
     mItemsList(nullptr),
+    mNewFolderBtn(nullptr),
+    mRenameFolderBtn(nullptr),
+    mDeleteFolderBtn(nullptr),
+    mFolderCombo(nullptr),
+    mSelectedFolderID(),
     mInitialized(false),
     mDADCallbackConnection()
 {
@@ -122,6 +131,18 @@ bool FSFloaterWearableFavorites::postBuild()
 
     mRemoveItemBtn = getChild<LLButton>("remove_btn");
     mRemoveItemBtn->setCommitCallback(boost::bind(&FSFloaterWearableFavorites::handleRemove, this));
+
+    mNewFolderBtn = getChild<LLButton>("new_folder_btn");
+    mNewFolderBtn->setCommitCallback(boost::bind(&FSFloaterWearableFavorites::onNewFolder, this));
+
+    mRenameFolderBtn = getChild<LLButton>("rename_folder_btn");
+    mRenameFolderBtn->setCommitCallback(boost::bind(&FSFloaterWearableFavorites::onRenameFolder, this));
+
+    mDeleteFolderBtn = getChild<LLButton>("delete_folder_btn");
+    mDeleteFolderBtn->setCommitCallback(boost::bind(&FSFloaterWearableFavorites::onDeleteFolder, this));
+
+    mFolderCombo = getChild<LLComboBox>("folder_combo");
+    mFolderCombo->setCommitCallback(boost::bind(&FSFloaterWearableFavorites::onFolderChanged, this));
 
     mFilterEditor = getChild<LLFilterEditor>("wearable_filter_input");
     mFilterEditor->setCommitCallback(boost::bind(&FSFloaterWearableFavorites::onFilterEdit, this, _2));
@@ -176,12 +197,19 @@ void FSFloaterWearableFavorites::initialize()
     }
 
     gInventory.addObserver(mCategoriesObserver);
-    mCategoriesObserver->addCategory(sFolderID, boost::bind(&FSFloaterWearableFavorites::updateList, this, sFolderID));
-    mCategoriesObserver->addCategory(cof, boost::bind(&FSFloaterWearableFavorites::updateList, this, sFolderID));
+    mCategoriesObserver->addCategory(sFolderID, boost::bind(&FSFloaterWearableFavorites::refreshFolderCombo, this));
+    mCategoriesObserver->addCategory(
+        cof,
+        [this]()
+        {
+            const LLUUID folder_id = mSelectedFolderID.notNull() ? mSelectedFolderID : sFolderID;
+            updateList(folder_id);
+        });
     category->fetch();
 
     mItemsList->setSortOrder((LLWearableItemsList::ESortOrder)gSavedSettings.getU32("FSWearableFavoritesSortOrder"));
-    updateList(sFolderID);
+    mSelectedFolderID = sFolderID;
+    refreshFolderCombo();
     mItemsList->setDADCallback(boost::bind(&FSFloaterWearableFavorites::onItemDAD, this, _1));
 
     mInitialized = true;
@@ -193,6 +221,15 @@ void FSFloaterWearableFavorites::draw()
     LLFloater::draw();
 
     mRemoveItemBtn->setEnabled(mItemsList->numSelected() > 0);
+    const bool folder_action_enabled = mSelectedFolderID.notNull() && mSelectedFolderID != sFolderID;
+    if (mRenameFolderBtn)
+    {
+        mRenameFolderBtn->setEnabled(folder_action_enabled);
+    }
+    if (mDeleteFolderBtn)
+    {
+        mDeleteFolderBtn->setEnabled(folder_action_enabled);
+    }
 }
 
 //virtual
@@ -285,7 +322,62 @@ LLUUID FSFloaterWearableFavorites::getFavoritesFolder()
 
 void FSFloaterWearableFavorites::updateList(const LLUUID& folder_id)
 {
-    mItemsList->updateList(folder_id);
+    if (folder_id.isNull())
+    {
+        return;
+    }
+
+    // Favorite Wearables folders are implemented as inventory links.
+    // The root view collects descendants recursively, which means the same
+    // wearable can appear multiple times when it is linked into several
+    // folders.  Keep folder views unchanged, but de-duplicate the root
+    // "All Favorites" view by the original linked item UUID.
+    if (folder_id == sFolderID)
+    {
+        LLInventoryModel::cat_array_t cat_array;
+        LLInventoryModel::item_array_t item_array;
+
+        LLFindOutfitItems collector;
+        gInventory.collectDescendentsIf(
+            folder_id,
+            cat_array,
+            item_array,
+            LLInventoryModel::EXCLUDE_TRASH,
+            collector);
+
+        LLInventoryModel::item_array_t unique_items;
+        std::set<LLUUID> seen_linked_items;
+
+        for (const auto& item : item_array)
+        {
+            if (!item)
+            {
+                continue;
+            }
+
+            LLUUID linked_uuid = item->getLinkedUUID();
+            if (linked_uuid.isNull())
+            {
+                linked_uuid = item->getUUID();
+            }
+
+            if (seen_linked_items.insert(linked_uuid).second)
+            {
+                unique_items.push_back(item);
+            }
+        }
+
+        if (unique_items.empty() && gInventory.isCategoryComplete(folder_id))
+        {
+            mItemsList->setNoItemsCommentText(getString("empty_list"));
+        }
+
+        mItemsList->refreshList(unique_items);
+    }
+    else
+    {
+        mItemsList->updateList(folder_id);
+    }
 
     if (gInventory.isCategoryComplete(folder_id))
     {
@@ -293,9 +385,82 @@ void FSFloaterWearableFavorites::updateList(const LLUUID& folder_id)
     }
 }
 
+void FSFloaterWearableFavorites::refreshFolderCombo()
+{
+    if (!mFolderCombo || sFolderID.isNull())
+    {
+        return;
+    }
+
+    LLUUID selected_id = mSelectedFolderID;
+    if (selected_id.isNull())
+    {
+        selected_id = sFolderID;
+    }
+
+    mFolderCombo->clearRows();
+    mFolderCombo->add(getString("root_folder_label"), LLSD(sFolderID.asString()));
+
+    LLInventoryModel::item_array_t* items;
+    LLInventoryModel::cat_array_t* cats;
+    gInventory.getDirectDescendentsOf(sFolderID, cats, items);
+    if (cats)
+    {
+        std::vector<LLViewerInventoryCategory*> sorted_cats;
+        for (const auto& cat : *cats)
+        {
+            if (cat)
+            {
+                sorted_cats.push_back(cat);
+            }
+        }
+
+        std::sort(sorted_cats.begin(), sorted_cats.end(), [](const LLViewerInventoryCategory* lhs, const LLViewerInventoryCategory* rhs)
+        {
+            return LLStringUtil::compareDict(lhs->getName(), rhs->getName()) < 0;
+        });
+
+        for (const auto& cat : sorted_cats)
+        {
+            mFolderCombo->add(cat->getName(), LLSD(cat->getUUID().asString()));
+        }
+    }
+
+    if (!mFolderCombo->selectByValue(LLSD(selected_id.asString())))
+    {
+        selected_id = sFolderID;
+        mFolderCombo->selectByValue(LLSD(selected_id.asString()));
+    }
+
+    LLUUID previous_selected_id = mSelectedFolderID;
+
+    mSelectedFolderID = selected_id;
+
+    // Favorite Wearables v2.0.0:
+    // Preserve the visible folder when inventory updates arrive from Assign to Folder.
+    // This prevents assigning from a subfolder from bouncing the visible list back to All Favorites.
+    if (previous_selected_id != mSelectedFolderID)
+    {
+        updateList(mSelectedFolderID);
+    }
+}
+
 void FSFloaterWearableFavorites::onItemDAD(const LLUUID& item_id)
 {
-    link_inventory_object(sFolderID, item_id, LLPointer<LLInventoryCallback>(nullptr));
+    const LLUUID target_folder = mSelectedFolderID.notNull() ? mSelectedFolderID : sFolderID;
+    LLHandle<LLFloater> floater_handle = getHandle();
+
+    LLPointer<LLInventoryCallback> cb = new LLBoostFuncInventoryCallback([floater_handle, target_folder](const LLUUID& new_item_id)
+    {
+        LLFloater* floater = floater_handle.get();
+        FSFloaterWearableFavorites* self = dynamic_cast<FSFloaterWearableFavorites*>(floater);
+        if (self)
+        {
+            self->updateList(target_folder);
+        }
+    });
+
+    link_inventory_object(target_folder, item_id, cb);
 }
 
 void FSFloaterWearableFavorites::handleRemove()
@@ -303,10 +468,25 @@ void FSFloaterWearableFavorites::handleRemove()
     uuid_vec_t selected_item_ids;
     mItemsList->getSelectedUUIDs(selected_item_ids);
 
+    const LLUUID folder_id = mSelectedFolderID.notNull() ? mSelectedFolderID : sFolderID;
+    LLHandle<LLFloater> floater_handle = getHandle();
+
+    LLPointer<LLInventoryCallback> cb = new LLBoostFuncInventoryCallback([floater_handle, folder_id](const LLUUID& item_id)
+    {
+        LLFloater* floater = floater_handle.get();
+        FSFloaterWearableFavorites* self = dynamic_cast<FSFloaterWearableFavorites*>(floater);
+        if (self)
+        {
+            self->updateList(folder_id);
+        }
+    });
+
     for (const auto& id : selected_item_ids)
     {
-        remove_inventory_item(id, LLPointer<LLInventoryCallback>(nullptr));
+        remove_inventory_item(id, cb);
     }
+
+    updateList(folder_id);
 }
 
 void FSFloaterWearableFavorites::onFilterEdit(const std::string& search_string)
@@ -314,6 +494,221 @@ void FSFloaterWearableFavorites::onFilterEdit(const std::string& search_string)
     mItemsList->setFilterSubString(search_string, true);
     mItemsList->setNoItemsCommentText(getString("empty_list"));
     mItemsList->rearrange();
+}
+
+void FSFloaterWearableFavorites::onFolderChanged()
+{
+    if (!mFolderCombo)
+    {
+        return;
+    }
+
+    LLSD selected_value = mFolderCombo->getSelectedValue();
+    LLUUID selected_id(selected_value.asString());
+    if (selected_id.isNull())
+    {
+        selected_id = sFolderID;
+    }
+
+    LLUUID previous_selected_id = mSelectedFolderID;
+
+    mSelectedFolderID = selected_id;
+
+    // Favorite Wearables v2.0.0:
+    // Preserve the visible folder when inventory updates arrive from Assign to Folder.
+    // This prevents assigning from a subfolder from bouncing the visible list back to All Favorites.
+    if (previous_selected_id != mSelectedFolderID)
+    {
+        updateList(mSelectedFolderID);
+    }
+}
+
+void FSFloaterWearableFavorites::onNewFolder()
+{
+    LLNotificationsUtil::add("FSWearableFavoritesNewFolder", LLSD(), LLSD(), boost::bind(&FSFloaterWearableFavorites::onNewFolderCallback, this, _1, _2));
+}
+
+bool FSFloaterWearableFavorites::onNewFolderCallback(const LLSD& notification, const LLSD& response)
+{
+    if (LLNotificationsUtil::getSelectedOption(notification, response) != 0)
+    {
+        return false;
+    }
+
+    std::string folder_name = response["message"].asString();
+    LLStringUtil::trim(folder_name);
+
+    if (folder_name.empty())
+    {
+        return false;
+    }
+
+    if (folder_name.find_first_of("/\\") != std::string::npos)
+    {
+        LLSD args;
+        args["FOLDER_NAME"] = folder_name;
+        LLNotificationsUtil::add("FSWearableFavoritesFolderInvalidName", args);
+        return false;
+    }
+
+    gInventory.createNewCategory(sFolderID, LLFolderType::FT_NONE, folder_name, [this](const LLUUID& new_cat_id)
+    {
+        if (new_cat_id.notNull())
+        {
+            mSelectedFolderID = new_cat_id;
+            refreshFolderCombo();
+            if (mFolderCombo)
+            {
+                mFolderCombo->selectByValue(LLSD(new_cat_id.asString()));
+            }
+            updateList(mSelectedFolderID);
+        }
+    });
+
+    return true;
+}
+
+
+void FSFloaterWearableFavorites::onRenameFolder()
+{
+    if (mSelectedFolderID.isNull() || mSelectedFolderID == sFolderID)
+    {
+        return;
+    }
+
+    LLSD args;
+    if (LLViewerInventoryCategory* cat = gInventory.getCategory(mSelectedFolderID))
+    {
+        args["FOLDER_NAME"] = cat->getName();
+    }
+    LLNotificationsUtil::add("FSWearableFavoritesRenameFolder", args, LLSD(), boost::bind(&FSFloaterWearableFavorites::onRenameFolderCallback, this, _1, _2));
+}
+
+bool FSFloaterWearableFavorites::onRenameFolderCallback(const LLSD& notification, const LLSD& response)
+{
+    if (LLNotificationsUtil::getSelectedOption(notification, response) != 0)
+    {
+        return false;
+    }
+
+    if (mSelectedFolderID.isNull() || mSelectedFolderID == sFolderID)
+    {
+        return false;
+    }
+
+    std::string folder_name = response["message"].asString();
+    LLStringUtil::trim(folder_name);
+
+    if (folder_name.empty())
+    {
+        return false;
+    }
+
+    if (folder_name.find_first_of("/\\") != std::string::npos)
+    {
+        LLSD args;
+        args["FOLDER_NAME"] = folder_name;
+        LLNotificationsUtil::add("FSWearableFavoritesFolderInvalidName", args);
+        return false;
+    }
+
+    const LLUUID folder_id = mSelectedFolderID;
+    LLHandle<LLFloater> floater_handle = getHandle();
+
+    LLSD updates;
+    updates["name"] = folder_name;
+
+    LLPointer<LLInventoryCallback> cb = new LLBoostFuncInventoryCallback([floater_handle, folder_id](const LLUUID& cat_id)
+    {
+        LLFloater* floater = floater_handle.get();
+        FSFloaterWearableFavorites* self = dynamic_cast<FSFloaterWearableFavorites*>(floater);
+        if (self)
+        {
+            self->mSelectedFolderID = folder_id;
+            self->refreshFolderCombo();
+            if (self->mFolderCombo)
+            {
+                self->mFolderCombo->selectByValue(LLSD(folder_id.asString()));
+            }
+            self->updateList(folder_id);
+        }
+    });
+
+    update_inventory_category(folder_id, updates, cb);
+    refreshFolderCombo();
+    updateList(folder_id);
+
+    return true;
+}
+
+void FSFloaterWearableFavorites::onDeleteFolder()
+{
+    if (mSelectedFolderID.isNull() || mSelectedFolderID == sFolderID)
+    {
+        return;
+    }
+
+    LLSD args;
+    LLViewerInventoryCategory* cat = gInventory.getCategory(mSelectedFolderID);
+    if (cat)
+    {
+        args["FOLDER_NAME"] = cat->getName();
+    }
+    else
+    {
+        args["FOLDER_NAME"] = "Selected Folder";
+    }
+
+    LLInventoryModel::item_array_t* items = nullptr;
+    LLInventoryModel::cat_array_t* cats = nullptr;
+    gInventory.getDirectDescendentsOf(mSelectedFolderID, cats, items);
+
+    S32 item_count = items ? (S32)items->size() : 0;
+    S32 folder_count = cats ? (S32)cats->size() : 0;
+    args["ITEM_COUNT"] = item_count;
+    args["FOLDER_COUNT"] = folder_count;
+
+    LLNotificationsUtil::add("FSWearableFavoritesDeleteFolder", args, LLSD(), boost::bind(&FSFloaterWearableFavorites::onDeleteFolderCallback, this, _1, _2));
+}
+
+bool FSFloaterWearableFavorites::onDeleteFolderCallback(const LLSD& notification, const LLSD& response)
+{
+    if (LLNotificationsUtil::getSelectedOption(notification, response) != 0)
+    {
+        return false;
+    }
+
+    if (mSelectedFolderID.isNull() || mSelectedFolderID == sFolderID)
+    {
+        return false;
+    }
+
+    const LLUUID folder_id = mSelectedFolderID;
+    LLHandle<LLFloater> floater_handle = getHandle();
+
+    LLPointer<LLInventoryCallback> cb = new LLBoostFuncInventoryCallback([floater_handle](const LLUUID& deleted_id)
+    {
+        LLFloater* floater = floater_handle.get();
+        FSFloaterWearableFavorites* self = dynamic_cast<FSFloaterWearableFavorites*>(floater);
+        if (self)
+        {
+            self->mSelectedFolderID = FSFloaterWearableFavorites::sFolderID;
+            self->refreshFolderCombo();
+            if (self->mFolderCombo)
+            {
+                self->mFolderCombo->selectByValue(LLSD(FSFloaterWearableFavorites::sFolderID.asString()));
+            }
+            self->updateList(FSFloaterWearableFavorites::sFolderID);
+        }
+    });
+
+    remove_inventory_category(folder_id, cb);
+
+    mSelectedFolderID = sFolderID;
+    refreshFolderCombo();
+    updateList(sFolderID);
+
+    return true;
 }
 
 void FSFloaterWearableFavorites::onOptionsMenuItemClicked(const LLSD& userdata)

--- a/indra/newview/fsfloaterwearablefavorites.h
+++ b/indra/newview/fsfloaterwearablefavorites.h
@@ -34,6 +34,7 @@
 #include <optional>
 
 class LLButton;
+class LLComboBox;
 class LLFilterEditor;
 class LLMenuButton;
 class LLInventoryCategoriesObserver;
@@ -91,11 +92,19 @@ private:
     void initialize();
 
     void updateList(const LLUUID& folder_id);
+    void refreshFolderCombo();
 
     void onItemDAD(const LLUUID& item_id);
     void handleRemove();
     void onFilterEdit(const std::string& search_string);
     void onDoubleClick();
+    void onFolderChanged();
+    void onNewFolder();
+    bool onNewFolderCallback(const LLSD& notification, const LLSD& response);
+    void onRenameFolder();
+    bool onRenameFolderCallback(const LLSD& notification, const LLSD& response);
+    void onDeleteFolder();
+    bool onDeleteFolderCallback(const LLSD& notification, const LLSD& response);
 
     void onOptionsMenuItemClicked(const LLSD& userdata);
     bool onOptionsMenuItemChecked(const LLSD& userdata);
@@ -110,6 +119,11 @@ private:
 
     FSWearableFavoritesItemsList*   mItemsList;
     LLButton*                       mRemoveItemBtn;
+    LLButton*                       mNewFolderBtn;
+    LLButton*                       mRenameFolderBtn;
+    LLButton*                       mDeleteFolderBtn;
+    LLComboBox*                     mFolderCombo;
+    LLUUID                          mSelectedFolderID;
     LLFilterEditor*                 mFilterEditor;
     LLMenuButton*                   mOptionsButton;
     LLHandle<LLView>                mOptionsMenuHandle;

--- a/indra/newview/llwearableitemslist.cpp
+++ b/indra/newview/llwearableitemslist.cpp
@@ -28,12 +28,16 @@
 
 #include "llwearableitemslist.h"
 
+#include "fsfloaterwearablefavorites.h"
+
 #include "lliconctrl.h"
 #include "llmenugl.h" // for LLContextMenu
+#include "llnotificationsutil.h"
 
 #include "llagentwearables.h"
 #include "llappearancemgr.h"
 #include "llinventoryicon.h"
+#include "llinventoryfunctions.h"
 #include "llgesturemgr.h"
 #include "lltransutil.h"
 #include "llviewerattachmenu.h"
@@ -45,6 +49,7 @@
 // [/RLVa:KB]
 #include "lltextbox.h"
 #include "llresmgr.h"
+#include "llviewerinventory.h"
 
 bool LLFindOutfitItems::operator()(LLInventoryCategory* cat,
                                    LLInventoryItem* item)
@@ -1130,6 +1135,125 @@ void LLWearableItemsList::ContextMenu::show(LLView* spawning_view, LLWearableTyp
     mParent = NULL; // to avoid dereferencing an invalid pointer
 }
 
+static bool favorite_folder_contains_linked_item(const LLUUID& folder_id, const LLUUID& linked_id)
+{
+    LLInventoryModel::item_array_t* items = nullptr;
+    LLInventoryModel::cat_array_t* cats = nullptr;
+    gInventory.getDirectDescendentsOf(folder_id, cats, items);
+
+    if (!items)
+    {
+        return false;
+    }
+
+    for (const auto& item : *items)
+    {
+        if (!item)
+        {
+            continue;
+        }
+
+        if (item->getUUID() == linked_id || item->getLinkedUUID() == linked_id)
+        {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+static void assign_to_favorite_folder(const uuid_vec_t& ids, const LLSD& userdata)
+{
+    LLUUID target_folder(userdata.asString());
+    if (target_folder.isNull() || ids.empty())
+    {
+        return;
+    }
+
+    for (const LLUUID& id : ids)
+    {
+        LLViewerInventoryItem* item = gInventory.getItem(id);
+        if (!item)
+        {
+            continue;
+        }
+
+        LLUUID linked_id = item->getLinkedUUID();
+        if (linked_id.isNull())
+        {
+            linked_id = id;
+        }
+
+        if (favorite_folder_contains_linked_item(target_folder, linked_id))
+        {
+            continue;
+        }
+
+        LLPointer<LLInventoryCallback> cb;
+        link_inventory_object(target_folder, linked_id, cb);
+    }
+}
+
+static void populate_assign_to_folder_menu(LLContextMenu* menu)
+{
+    // Match the pattern used by LLViewerAttachMenu::populateMenus().
+    // Submenus from menu_wearable_list_item.xml are children of gMenuHolder,
+    // so looking only under the local menu can leave the submenu empty/disabled.
+    if (!menu || !gMenuHolder)
+    {
+        return;
+    }
+
+    LLContextMenu* assign_menu = gMenuHolder->getChild<LLContextMenu>("favorites_assign_folder");
+    if (!assign_menu)
+    {
+        return;
+    }
+
+    assign_menu->empty();
+
+    const LLUUID root_folder = FSFloaterWearableFavorites::getFavoritesFolder();
+    if (root_folder.isNull())
+    {
+        return;
+    }
+
+    LLInventoryModel::item_array_t* items = nullptr;
+    LLInventoryModel::cat_array_t* cats = nullptr;
+    gInventory.getDirectDescendentsOf(root_folder, cats, items);
+    if (!cats)
+    {
+        return;
+    }
+
+    std::vector<LLViewerInventoryCategory*> sorted_cats;
+    for (const auto& cat : *cats)
+    {
+        if (cat)
+        {
+            sorted_cats.push_back(cat);
+        }
+    }
+
+    std::sort(sorted_cats.begin(), sorted_cats.end(), [](const LLViewerInventoryCategory* lhs, const LLViewerInventoryCategory* rhs)
+    {
+        return LLStringUtil::compareDict(lhs->getName(), rhs->getName()) < 0;
+    });
+
+    for (const auto& cat : sorted_cats)
+    {
+        LLMenuItemCallGL::Params p;
+        p.name = "assign_to_folder_" + cat->getUUID().asString();
+        p.label = cat->getName();
+        p.on_click.function_name = "Attachment.AssignFolder";
+        p.on_click.parameter = LLSD(cat->getUUID().asString());
+        p.enabled.set(true);
+
+        LLMenuItemCallGL* item = LLUICtrlFactory::create<LLMenuItemCallGL>(p);
+        assign_menu->addChild(item);
+    }
+}
+
 // virtual
 LLContextMenu* LLWearableItemsList::ContextMenu::createMenu()
 {
@@ -1161,12 +1285,14 @@ LLContextMenu* LLWearableItemsList::ContextMenu::createMenu()
                   //boost::bind(&LLAppearanceMgr::removeItemsFromAvatar, LLAppearanceMgr::getInstance(), ids, no_op)); // <FS:Ansariel> [SL:KB] - Patch: Appearance-Misc
                   boost::bind(&LLAppearanceMgr::removeItemsFromAvatar, LLAppearanceMgr::getInstance(), ids));
     registrar.add("Attachment.Favorite", boost::bind(toggle_favorites, ids));
+    registrar.add("Attachment.AssignFolder", boost::bind(assign_to_favorite_folder, ids, _2));
     registrar.add("Attachment.Touch", boost::bind(handle_attachment_touch, selected_id));
     registrar.add("Attachment.Profile", boost::bind(show_item_profile, selected_id));
     registrar.add("Object.Attach", boost::bind(LLViewerAttachMenu::attachObjects, ids, _2));
 
     // Create the menu.
     LLContextMenu* menu = createFromFile("menu_wearable_list_item.xml");
+    populate_assign_to_folder_menu(menu);
 
     // Determine which items should be visible/enabled.
     updateItemsVisibility(menu);
@@ -1331,6 +1457,8 @@ void LLWearableItemsList::ContextMenu::updateItemsVisibility(LLContextMenu* menu
     setMenuItemEnabled(menu, "delete_from_outfit", n_links > 0 && is_outfit_menu);
 // </AS:Chanayane>
     setMenuItemVisible(menu, "favorites_add",       can_favorite);
+    setMenuItemVisible(menu, "favorites_assign_folder", true);
+    setMenuItemEnabled(menu, "favorites_assign_folder", true);
     setMenuItemVisible(menu, "favorites_remove",    can_unfavorite);
     setMenuItemVisible(menu, "take_off",            mask == MASK_CLOTHING && n_worn == n_items);
     setMenuItemVisible(menu, "detach",              mask == MASK_ATTACHMENT && n_worn == n_items);

--- a/indra/newview/llwearableitemslist.cpp
+++ b/indra/newview/llwearableitemslist.cpp
@@ -1135,6 +1135,7 @@ void LLWearableItemsList::ContextMenu::show(LLView* spawning_view, LLWearableTyp
     mParent = NULL; // to avoid dereferencing an invalid pointer
 }
 
+// <FS:Amy> Favorite Wearables folder assignment
 static bool favorite_folder_contains_linked_item(const LLUUID& folder_id, const LLUUID& linked_id)
 {
     LLInventoryModel::item_array_t* items = nullptr;
@@ -1253,6 +1254,7 @@ static void populate_assign_to_folder_menu(LLContextMenu* menu)
         assign_menu->addChild(item);
     }
 }
+// </FS:Amy>
 
 // virtual
 LLContextMenu* LLWearableItemsList::ContextMenu::createMenu()
@@ -1285,14 +1287,14 @@ LLContextMenu* LLWearableItemsList::ContextMenu::createMenu()
                   //boost::bind(&LLAppearanceMgr::removeItemsFromAvatar, LLAppearanceMgr::getInstance(), ids, no_op)); // <FS:Ansariel> [SL:KB] - Patch: Appearance-Misc
                   boost::bind(&LLAppearanceMgr::removeItemsFromAvatar, LLAppearanceMgr::getInstance(), ids));
     registrar.add("Attachment.Favorite", boost::bind(toggle_favorites, ids));
-    registrar.add("Attachment.AssignFolder", boost::bind(assign_to_favorite_folder, ids, _2));
+    registrar.add("Attachment.AssignFolder", boost::bind(assign_to_favorite_folder, ids, _2)); // </FS:Amy> Favorite Wearables folder assignment
     registrar.add("Attachment.Touch", boost::bind(handle_attachment_touch, selected_id));
     registrar.add("Attachment.Profile", boost::bind(show_item_profile, selected_id));
     registrar.add("Object.Attach", boost::bind(LLViewerAttachMenu::attachObjects, ids, _2));
 
     // Create the menu.
     LLContextMenu* menu = createFromFile("menu_wearable_list_item.xml");
-    populate_assign_to_folder_menu(menu);
+    populate_assign_to_folder_menu(menu); // </FS:Amy> Favorite Wearables folder assignment submenu
 
     // Determine which items should be visible/enabled.
     updateItemsVisibility(menu);
@@ -1457,8 +1459,8 @@ void LLWearableItemsList::ContextMenu::updateItemsVisibility(LLContextMenu* menu
     setMenuItemEnabled(menu, "delete_from_outfit", n_links > 0 && is_outfit_menu);
 // </AS:Chanayane>
     setMenuItemVisible(menu, "favorites_add",       can_favorite);
-    setMenuItemVisible(menu, "favorites_assign_folder", true);
-    setMenuItemEnabled(menu, "favorites_assign_folder", true);
+    setMenuItemVisible(menu, "favorites_assign_folder", true); // </FS:Amy> Favorite Wearables folder assignment
+    setMenuItemEnabled(menu, "favorites_assign_folder", true); // </FS:Amy> Favorite Wearables folder assignment
     setMenuItemVisible(menu, "favorites_remove",    can_unfavorite);
     setMenuItemVisible(menu, "take_off",            mask == MASK_CLOTHING && n_worn == n_items);
     setMenuItemVisible(menu, "detach",              mask == MASK_ATTACHMENT && n_worn == n_items);

--- a/indra/newview/skins/default/xui/en/floater_fs_wearable_favorites.xml
+++ b/indra/newview/skins/default/xui/en/floater_fs_wearable_favorites.xml
@@ -3,10 +3,10 @@
  positioning="cascading"
  can_close="true"
  can_resize="true"
- height="350"
+ height="390"
  help_topic="fs_wearable_favorites"
- min_height="150"
- min_width="175"
+ min_height="190"
+ min_width="230"
  layout="topleft"
  name="floater_fs_wearable_favorites"
  save_rect="true"
@@ -14,80 +14,121 @@
  single_instance="true"
  reuse_instance="true"
  title="Favorite Wearables"
- width="310">
+ width="330">
 
-	<floater.string name="empty_list">
-		Drag wearable items here to add to list.
-	</floater.string>
-	<floater.string name="search_no_items">
-		No matching items found.
-	</floater.string>
+        <floater.string name="empty_list">
+                Drag wearable items here to add to list.
+        </floater.string>
+        <floater.string name="search_no_items">
+                No matching items found.
+        </floater.string>
+        <floater.string name="root_folder_label">
+                All Favorites
+        </floater.string>
 
-	<panel
-	 follows="left|top|right"
-	 height="27"
-	 layout="topleft"
-	 left="2"
-	 name="buttons_panel"
-	 right="-1"
-	 top="2">
-		<filter_editor
-		 follows="left|top|right"
-		 height="23"
-		 layout="topleft"
-		 left="3"
-		 label="Filter Wearables"
-		 max_length_chars="300"
-		 name="wearable_filter_input"
-		 top="1"
-		 right="-70" />
-		<menu_button
-		 follows="right"
-		 height="25"
-		 image_hover_unselected="Toolbar_Middle_Over"
-		 image_overlay="Conv_toolbar_sort"
-		 image_selected="Toolbar_Middle_Selected"
-		 image_unselected="Toolbar_Middle_Off"
-		 layout="topleft"
-		 left_pad="2"
-		 name="options_btn"
-		 tool_tip="Wearable favorites options"
-		 top_delta="0"
-		 width="31" />
-		<button
-		 follows="right"
-		 height="25"
-		 image_hover_unselected="Toolbar_Middle_Over"
-		 image_overlay="TrashItem_Off"
-		 image_selected="Toolbar_Middle_Selected"
-		 image_unselected="Toolbar_Middle_Off"
-		 left_pad="2"
-		 layout="topleft"
-		 name="remove_btn"
-		 tool_tip="Remove wearable from favorites list"
-		 top_delta="0"
-		 width="31"/>
-	</panel>
+        <panel
+         follows="left|top|right"
+         height="58"
+         layout="topleft"
+         left="2"
+         name="buttons_panel"
+         right="-1"
+         top="2">
+                <filter_editor
+                 follows="left|top|right"
+                 height="23"
+                 layout="topleft"
+                 left="3"
+                 label="Filter Wearables"
+                 max_length_chars="300"
+                 name="wearable_filter_input"
+                 top="1"
+                 right="-171" />
+                <menu_button
+                 follows="right"
+                 height="25"
+                 image_hover_unselected="Toolbar_Middle_Over"
+                 image_overlay="Conv_toolbar_sort"
+                 image_selected="Toolbar_Middle_Selected"
+                 image_unselected="Toolbar_Middle_Off"
+                 layout="topleft"
+                 left_pad="2"
+                 name="options_btn"
+                 tool_tip="Wearable favorites options"
+                 top_delta="0"
+                 width="31" />
+                <button
+                 follows="right"
+                 height="25"
+                 image_hover_unselected="Toolbar_Middle_Over"
+                 image_overlay="TrashItem_Off"
+                 image_selected="Toolbar_Middle_Selected"
+                 image_unselected="Toolbar_Middle_Off"
+                 left_pad="2"
+                 layout="topleft"
+                 name="remove_btn"
+                 tool_tip="Remove wearable from favorites list"
+                 top_delta="0"
+                 width="31"/>
+                <button
+                 follows="right"
+                 height="25"
+                 label="+"
+                 layout="topleft"
+                 left_pad="2"
+                 name="new_folder_btn"
+                 tool_tip="Create new favorites folder"
+                 top_delta="0"
+                 width="31"/>
+                <button
+                 follows="right"
+                 height="25"
+                 label="R"
+                 layout="topleft"
+                 left_pad="2"
+                 name="rename_folder_btn"
+                 tool_tip="Rename selected favorites folder"
+                 top_delta="0"
+                 width="31"/>
+                <button
+                 follows="right"
+                 height="25"
+                 label="D"
+                 layout="topleft"
+                 left_pad="2"
+                 name="delete_folder_btn"
+                 tool_tip="Delete selected favorites folder"
+                 top_delta="0"
+                 width="31"/>
+                <combo_box
+                 follows="left|top|right"
+                 height="23"
+                 layout="topleft"
+                 left="3"
+                 name="folder_combo"
+                 top_pad="5"
+                 right="-4"/>
+        </panel>
 
-	<panel
-	 layout="topleft"
-	 follows="all"
-	 name="panel_fs_wearable_favorites"
-	 top="32"
-	 left="2"
-	 bottom="-2"
-	 right="-1">
-		<fs_wearable_favorites_items_list
-		 layout="topleft"
-		 follows="all"
-		 name="favorites_list"
-		 multi_select="true"
-		 standalone="true"
-		 show_create_new="false"
-		 top="0"
-		 left="0"
-		 bottom="-1"
-		 right="-1"
-		 worn_indication_enabled="true" />
-	</panel>
+        <panel
+         layout="topleft"
+         follows="all"
+         name="panel_fs_wearable_favorites"
+         top="63"
+         left="2"
+         bottom="-2"
+         right="-1">
+                <fs_wearable_favorites_items_list
+                 layout="topleft"
+                 follows="all"
+                 name="favorites_list"
+                 multi_select="true"
+                 standalone="true"
+                 show_create_new="false"
+                 top="0"
+                 left="0"
+                 bottom="-1"
+                 right="-1"
+                 worn_indication_enabled="true" />
+        </panel>
 </floater>

--- a/indra/newview/skins/default/xui/en/menu_wearable_list_item.xml
+++ b/indra/newview/skins/default/xui/en/menu_wearable_list_item.xml
@@ -87,6 +87,10 @@
        <on_click
         function="Attachment.Favorite" />
     </menu_item_call>
+    <context_menu
+     label="Assign to Folder"
+     layout="topleft"
+     name="favorites_assign_folder" />
     <menu_item_call
      label="Remove from favorites"
      layout="topleft"

--- a/indra/newview/skins/default/xui/en/notifications.xml
+++ b/indra/newview/skins/default/xui/en/notifications.xml
@@ -15338,4 +15338,82 @@ You can enable saving transcripts under Preferences &gt; Privacy &gt; Logs &amp;
             yestext="OK"/>
     </notification>
   <!-- </FS:minerjr> [FIRE-36763] -->
+
+  <!-- <FS:Amy> Favorite Wearables folders -->
+  <notification
+   icon="alertmodal.tga"
+   name="FSWearableFavoritesNewFolder"
+   type="alertmodal">
+Enter a name for the new Favorite Wearables folder:
+    <form name="form">
+      <input name="message" type="text" default="true">
+New Folder
+      </input>
+      <button
+       default="true"
+       index="0"
+       name="OK"
+       text="OK"/>
+      <button
+       index="1"
+       name="Cancel"
+       text="Cancel"/>
+    </form>
+  </notification>
+
+  <notification
+   icon="alertmodal.tga"
+   name="FSWearableFavoritesRenameFolder"
+   type="alertmodal">
+Enter a new name for Favorite Wearables folder [FOLDER_NAME]:
+    <form name="form">
+      <input name="message" type="text" default="true">
+[FOLDER_NAME]
+      </input>
+      <button
+       default="true"
+       index="0"
+       name="OK"
+       text="OK"/>
+      <button
+       index="1"
+       name="Cancel"
+       text="Cancel"/>
+    </form>
+  </notification>
+
+
+
+  <notification
+   icon="alertmodal.tga"
+   name="FSWearableFavoritesDeleteFolder"
+   type="alertmodal">
+Delete Favorite Wearables folder "[FOLDER_NAME]"?
+
+This removes the folder and its favorite links only. Original inventory items are not deleted.
+    <form name="form">
+      <button
+       default="true"
+       index="0"
+       name="Delete"
+       text="Delete"/>
+      <button
+       index="1"
+       name="Cancel"
+       text="Cancel"/>
+    </form>
+  </notification>
+
+  <notification
+   icon="alertmodal.tga"
+   name="FSWearableFavoritesFolderInvalidName"
+   type="alertmodal">
+Could not create Favorite Wearables folder "[FOLDER_NAME]".
+Folder names cannot contain / or \.
+    <usetemplate
+     name="okbutton"
+     yestext="OK"/>
+  </notification>
+  <!-- </FS:Amy> Favorite Wearables folders -->
+
 </notifications>


### PR DESCRIPTION
Adds folder organization support to the Favorite Wearables floater.

This allows users to create folders under `#Wearable Favorites`, select folders from the Favorite Wearables floater, drag/drop favorites into folders, and use a right-click `Assign to Folder` submenu to assign favorite wearables to folders.

Existing Favorite Wearables behavior remains available through the root “All Favorites” view.

### Summary

- Adds folder selector to Favorite Wearables
- Adds create/rename/delete folder support
- Adds de-duplicated All Favorites view
- Adds right-click `Assign to Folder` submenu
- Preserves current folder view after assigning items
- Uses existing inventory links; does not alter original wearable items

### Testing

Tested on Windows 11 with Firestorm 7.2.5 source build.

Verified:
- Create folder
- Rename folder
- Delete folder
- Drag/drop favorite into folder
- Assign favorite to folder via right-click menu
- Assigning from one folder does not switch view back to All Favorites
- Duplicate assignment prevention
- Existing Favorite Wearables root view still works

### Notes

No server-side changes.
No inventory migration required.
Existing users can continue using Favorite Wearables as before.