### PR TITLE
FIX - FIRE-32688 patch was not adjusting intended debug setting

### DIFF
--- a/indra/newview/llvocache.cpp
+++ b/indra/newview/llvocache.cpp
@@ -492,7 +492,7 @@ void LLVOCacheEntry::updateDebugSettings()
         }
         if( (U32)high_mem_bound_MB > 2048 )
         {
-            gSavedSettings.setU32("SceneLoadLowMemoryBound", 2048);
+            gSavedSettings.setU32("SceneLoadHighMemoryBound", 2048);
         }
     }
     // </FS:Beq>


### PR DESCRIPTION
Came across this while looking to fix a different item.

The patch to fix FIRE-32688 was intended to reset the SceneLoadLowMemoryBound and SceneLoadHighMemoryBound debug settings to LL defaults, but it was incorrectly adjusting SceneLoadLowMemoryBound instead of SceneLoadHighMemoryBound  for the second check