### PR TITLE
Cap automatic texture memory on Apple Silicon

### DIFF
--- a/indra/newview/CMakeLists.txt
+++ b/indra/newview/CMakeLists.txt
@@ -744,6 +744,7 @@ set(viewer_SOURCE_FILES
     lltexturefetch.cpp
     lltextureinfo.cpp
     lltextureinfodetails.cpp
+    lltexturememorybudget.cpp
     lltexturestats.cpp
     lltextureview.cpp
     llthumbnailctrl.cpp
@@ -1599,6 +1600,7 @@ set(viewer_HEADER_FILES
     lltexturefetch.h
     lltextureinfo.h
     lltextureinfodetails.h
+    lltexturememorybudget.h
     lltexturestats.h
     lltextureview.h
     llthumbnailctrl.h
@@ -3012,6 +3014,7 @@ if (LL_TESTS)
     lldateutil.cpp
 #    llmediadataclient.cpp
     lllogininstance.cpp
+    lltexturememorybudget.cpp
 #    llremoteparcelrequest.cpp
     llviewerhelputil.cpp
     llversioninfo.cpp

--- a/indra/newview/app_settings/settings.xml
+++ b/indra/newview/app_settings/settings.xml
@@ -11542,7 +11542,7 @@ Change of this parameter will affect the layout of buttons in notification toast
       <key>Type</key>
       <string>U32</string>
       <key>Value</key>
-      <integer>2</integer>
+      <integer>1</integer>
   </map>
   <key>RenderMinFreeMainMemoryThreshold</key>
   <map>

--- a/indra/newview/app_settings/settings.xml
+++ b/indra/newview/app_settings/settings.xml
@@ -11542,7 +11542,7 @@ Change of this parameter will affect the layout of buttons in notification toast
       <key>Type</key>
       <string>U32</string>
       <key>Value</key>
-      <integer>1</integer>
+      <integer>2</integer>
   </map>
   <key>RenderMinFreeMainMemoryThreshold</key>
   <map>

--- a/indra/newview/llappviewer.cpp
+++ b/indra/newview/llappviewer.cpp
@@ -67,6 +67,7 @@
 #if LL_WINDOWS
 #include "lldxhardware.h"
 #endif
+#include "lltexturememorybudget.h"
 #include "lltexturestats.h"
 #include "lltrace.h"
 #include "lltracethreadrecorder.h"
@@ -4310,17 +4311,19 @@ LLSD LLAppViewer::getViewerInfo() const
     // </FS:PP>
 
     // <FS:Ansariel> Include VRAM budget
-    if (gSavedSettings.getBOOL("FSLimitTextureVRAMUsage"))
+    U32 budget = gSavedSettings.getU32("RenderMaxVRAMBudget");
+    if (!gSavedSettings.getBOOL("FSLimitTextureVRAMUsage"))
     {
-        auto budget = gSavedSettings.getU32("RenderMaxVRAMBudget");
-        info["VRAM_BUDGET"] = std::to_string(budget) + " MB";
-        info["VRAM_BUDGET_ENGLISH"] = std::to_string(budget) + " MB";
+        const U32 physical_memory_mb =
+            gSysMemory.getPhysicalMemoryKB().valueInUnits<LLUnits::Megabytes>();
+        budget = LLTextureMemoryBudget::getAutomaticBudgetMB(
+            gGLManager.mVRAM,
+            gSavedSettings.getU32("RenderTextureVRAMDivisor"),
+            physical_memory_mb,
+            LLTextureMemoryBudget::USES_UNIFIED_MEMORY);
     }
-    else
-    {
-        info["VRAM_BUDGET"] = LLTrans::getString("Unlimited");
-        info["VRAM_BUDGET_ENGLISH"] = "Unlimited";
-    }
+    info["VRAM_BUDGET"] = std::to_string(budget) + " MB";
+    info["VRAM_BUDGET_ENGLISH"] = std::to_string(budget) + " MB";
     // </FS:Ansariel>
 
     return info;

--- a/indra/newview/lltexturememorybudget.cpp
+++ b/indra/newview/lltexturememorybudget.cpp
@@ -1,0 +1,54 @@
+/**
+ * @file lltexturememorybudget.cpp
+ * @brief Helpers for calculating the viewer's automatic texture memory budget.
+ *
+ * $LicenseInfo:firstyear=2026&license=viewerlgpl$
+ * Second Life Viewer Source Code
+ * Copyright (C) 2026, Linden Research, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation;
+ * version 2.1 of the License only.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * Linden Research, Inc., 945 Battery Street, San Francisco, CA  94111  USA
+ * $/LicenseInfo$
+ */
+
+#include "llviewerprecompiledheaders.h"
+
+#include "lltexturememorybudget.h"
+
+#include <algorithm>
+
+U32 LLTextureMemoryBudget::getAutomaticBudgetMB(U32 detected_vram_mb,
+                                                U32 configured_divisor,
+                                                U32 physical_memory_mb,
+                                                bool uses_unified_memory)
+{
+    const U32 divisor = std::max(configured_divisor, 1U);
+    U32 budget = std::max(detected_vram_mb / divisor, MIN_AUTOMATIC_BUDGET_MB);
+
+    if (uses_unified_memory && physical_memory_mb > 0)
+    {
+        // The driver's reported VRAM is part of system RAM on unified-memory
+        // Macs. Keep the automatic texture budget small enough to leave room
+        // for CPU-side texture copies, the OpenGL translation layer, the rest
+        // of the viewer, and the operating system.
+        const U32 unified_memory_cap =
+            std::max(physical_memory_mb / UNIFIED_MEMORY_BUDGET_DIVISOR,
+                     MIN_AUTOMATIC_BUDGET_MB);
+        budget = std::min(budget, unified_memory_cap);
+    }
+
+    return budget;
+}

--- a/indra/newview/lltexturememorybudget.h
+++ b/indra/newview/lltexturememorybudget.h
@@ -1,0 +1,48 @@
+/**
+ * @file lltexturememorybudget.h
+ * @brief Helpers for calculating the viewer's automatic texture memory budget.
+ *
+ * $LicenseInfo:firstyear=2026&license=viewerlgpl$
+ * Second Life Viewer Source Code
+ * Copyright (C) 2026, Linden Research, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation;
+ * version 2.1 of the License only.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * Linden Research, Inc., 945 Battery Street, San Francisco, CA  94111  USA
+ * $/LicenseInfo$
+ */
+
+#ifndef LL_LLTEXTUREMEMORYBUDGET_H
+#define LL_LLTEXTUREMEMORYBUDGET_H
+
+#include "stdtypes.h"
+
+namespace LLTextureMemoryBudget
+{
+    constexpr U32 MIN_AUTOMATIC_BUDGET_MB = 1024;
+    constexpr U32 UNIFIED_MEMORY_BUDGET_DIVISOR = 8;
+#if LL_DARWIN && LL_ARM64
+    constexpr bool USES_UNIFIED_MEMORY = true;
+#else
+    constexpr bool USES_UNIFIED_MEMORY = false;
+#endif
+
+    U32 getAutomaticBudgetMB(U32 detected_vram_mb,
+                             U32 configured_divisor,
+                             U32 physical_memory_mb,
+                             bool uses_unified_memory);
+}
+
+#endif // LL_LLTEXTUREMEMORYBUDGET_H

--- a/indra/newview/llviewertexture.cpp
+++ b/indra/newview/llviewertexture.cpp
@@ -529,16 +529,19 @@ void LLViewerTexture::updateClass()
     F32 budget = (F32)max_vram_budget;
     if (!max_vram_budget_enabled)
     {
-        static const U32 physical_memory_mb =
-            gSysMemory.getPhysicalMemoryKB().valueInUnits<LLUnits::Megabytes>();
-        budget = (F32)LLTextureMemoryBudget::getAutomaticBudgetMB(
-            gGLManager.mVRAM,
-            tex_vram_divisor(),
-            physical_memory_mb,
-            LLTextureMemoryBudget::USES_UNIFIED_MEMORY);
+        budget = llmax(1024.f,
+                       (F32)gGLManager.mVRAM /
+                           (tex_vram_divisor() > 0 ? tex_vram_divisor() : 1));
 
         if (LLTextureMemoryBudget::USES_UNIFIED_MEMORY)
         {
+            static const U32 physical_memory_mb =
+                gSysMemory.getPhysicalMemoryKB().valueInUnits<LLUnits::Megabytes>();
+            budget = (F32)LLTextureMemoryBudget::getAutomaticBudgetMB(
+                gGLManager.mVRAM,
+                tex_vram_divisor(),
+                physical_memory_mb,
+                true);
             LL_INFOS_ONCE("TextureMemory")
                 << "Automatic unified-memory texture budget capped at "
                 << budget << " MB (detected VRAM: " << gGLManager.mVRAM

--- a/indra/newview/llviewertexture.cpp
+++ b/indra/newview/llviewertexture.cpp
@@ -49,6 +49,7 @@
 #include "llimagegl.h"
 #include "lldrawpool.h"
 #include "lltexturefetch.h"
+#include "lltexturememorybudget.h"
 #include "llviewertexturelist.h"
 #include "llviewercontrol.h"
 #include "pipeline.h"
@@ -510,10 +511,8 @@ void LLViewerTexture::updateClass()
     }
 
     LLViewerMediaTexture::updateClass();
-    // This is a divisor used to determine how much VRAM from our overall VRAM budget to use.
-    // This is **cumulative** on whatever the detected or manually set VRAM budget is.
-    // If we detect 2048MB of VRAM, this will, by default, only use 1024.
-    // If you set 1024MB of VRAM, this will, by default, use 512.
+    // This is a divisor used to determine how much detected VRAM to use when
+    // automatic budgeting is enabled.
     // -Geenz 2025-03-03
     static LLCachedControl<U32> tex_vram_divisor(gSavedSettings, "RenderTextureVRAMDivisor", 2);
     static LLCachedControl<U32> max_vram_budget(gSavedSettings, "RenderMaxVRAMBudget", 0);
@@ -527,11 +526,26 @@ void LLViewerTexture::updateClass()
     F32 used = (F32)ll_round(texture_bytes_alloc + vertex_bytes_alloc);
 
     // <FS:Ansariel> Expose max texture VRAM setting
-    // But when manual control is not enabled, use the VRAM divisor.
-    // While we're at it, assume we have 1024 to play with at minimum when the divisor is in use.  Works more elegantly with the logic below this.
-    // -Geenz 2025-03-21
-    // F32 budget = max_vram_budget == 0 ? llmax(1024, (F32)gGLManager.mVRAM / tex_vram_divisor) : (F32)max_vram_budget;
-    F32 budget = !max_vram_budget_enabled ? llmax(1024, (F32)gGLManager.mVRAM / (tex_vram_divisor() > 0.f ? tex_vram_divisor() : 1.f)) : (F32)max_vram_budget;
+    F32 budget = (F32)max_vram_budget;
+    if (!max_vram_budget_enabled)
+    {
+        static const U32 physical_memory_mb =
+            gSysMemory.getPhysicalMemoryKB().valueInUnits<LLUnits::Megabytes>();
+        budget = (F32)LLTextureMemoryBudget::getAutomaticBudgetMB(
+            gGLManager.mVRAM,
+            tex_vram_divisor(),
+            physical_memory_mb,
+            LLTextureMemoryBudget::USES_UNIFIED_MEMORY);
+
+        if (LLTextureMemoryBudget::USES_UNIFIED_MEMORY)
+        {
+            LL_INFOS_ONCE("TextureMemory")
+                << "Automatic unified-memory texture budget capped at "
+                << budget << " MB (detected VRAM: " << gGLManager.mVRAM
+                << " MB, physical memory: " << physical_memory_mb << " MB)"
+                << LL_ENDL;
+        }
+    }
 
     // Try to leave at least half a GB for everyone else and for bias,
     // but keep at least 768MB for ourselves

--- a/indra/newview/tests/lltexturememorybudget_test.cpp
+++ b/indra/newview/tests/lltexturememorybudget_test.cpp
@@ -1,0 +1,72 @@
+/**
+ * @file lltexturememorybudget_test.cpp
+ * @brief Tests for automatic texture memory budget calculations.
+ *
+ * $LicenseInfo:firstyear=2026&license=viewerlgpl$
+ * Second Life Viewer Source Code
+ * Copyright (C) 2026, Linden Research, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation;
+ * version 2.1 of the License only.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * Linden Research, Inc., 945 Battery Street, San Francisco, CA  94111  USA
+ * $/LicenseInfo$
+ */
+
+#include "linden_common.h"
+
+#include "../lltexturememorybudget.h"
+#include "../test/lltut.h"
+
+namespace tut
+{
+    struct texture_memory_budget_test
+    {
+    };
+
+    typedef test_group<texture_memory_budget_test> texture_memory_budget_test_t;
+    typedef texture_memory_budget_test_t::object texture_memory_budget_object_t;
+    texture_memory_budget_test_t tut_texture_memory_budget("LLTextureMemoryBudget");
+
+    template<> template<>
+    void texture_memory_budget_object_t::test<1>()
+    {
+        ensure_equals("dedicated VRAM uses the configured divisor",
+                      LLTextureMemoryBudget::getAutomaticBudgetMB(8192, 2, 32768, false),
+                      4096U);
+        ensure_equals("a zero divisor is treated as one",
+                      LLTextureMemoryBudget::getAutomaticBudgetMB(8192, 0, 32768, false),
+                      8192U);
+        ensure_equals("the automatic budget has a minimum",
+                      LLTextureMemoryBudget::getAutomaticBudgetMB(512, 2, 32768, false),
+                      LLTextureMemoryBudget::MIN_AUTOMATIC_BUDGET_MB);
+    }
+
+    template<> template<>
+    void texture_memory_budget_object_t::test<2>()
+    {
+        ensure_equals("unified-memory budget is capped by physical memory",
+                      LLTextureMemoryBudget::getAutomaticBudgetMB(38338, 1, 49152, true),
+                      6144U);
+        ensure_equals("a smaller detected VRAM budget remains unchanged",
+                      LLTextureMemoryBudget::getAutomaticBudgetMB(4096, 2, 49152, true),
+                      2048U);
+        ensure_equals("small unified-memory systems retain the minimum budget",
+                      LLTextureMemoryBudget::getAutomaticBudgetMB(6144, 2, 8192, true),
+                      LLTextureMemoryBudget::MIN_AUTOMATIC_BUDGET_MB);
+        ensure_equals("missing physical memory data does not collapse the budget",
+                      LLTextureMemoryBudget::getAutomaticBudgetMB(8192, 2, 0, true),
+                      4096U);
+    }
+}


### PR DESCRIPTION
## What changed

- cap automatic texture and vertex-buffer budgeting on ARM64 macOS to one eighth of physical unified memory
- preserve the existing VRAM divisor and automatic-budget behavior on Windows, Linux, and Intel macOS
- preserve explicit manual VRAM budgets
- report the computed automatic budget in viewer diagnostics instead of `Unlimited`
- add focused unit coverage for dedicated and unified-memory calculations

## Why

A profile of Firestorm 7.2.5.81344 on a 48 GB Apple Silicon Mac showed that the viewer detected 38,338 MB as VRAM. With the automatic limiter disabled, the existing controller allowed a target near 30 GB before aggressive texture downscaling. The process reached a 13.9 GB physical-footprint peak, including roughly 8 GB of graphics allocations.

Apple Silicon VRAM is shared system memory, so treating most of the reported value as independently available graphics memory creates avoidable memory pressure. The new cap produces a 6,144 MB automatic budget on the profiled machine before the existing 80% safety target is applied.

The platform-neutral VRAM divisor remains at Firestorm's existing default of `1`; non-unified-memory platforms retain their original budgeting calculation.

## Upstream status

This optimization is also proposed upstream in secondlife/viewer#6034. This Firestorm PR remains a draft pending the upstream review.

## Validation

- compiled the production budget helper and ran all seven regression cases with Nix Clang using `-std=c++17 -Wall -Wextra -Werror`
- covered dedicated VRAM, zero-divisor, minimum-budget, 48 GB unified-memory, low-memory, and missing-memory-data cases
- `xmllint --noout indra/newview/app_settings/settings.xml`
- `git diff --check`

A full viewer build was not run because the profiling host does not have the Linden dependency bundle or an accepted full-Xcode license.
