### PR TITLE
Move texture upload preparation off the main thread

### DIFF
--- a/indra/llrender/llimagegl.cpp
+++ b/indra/llrender/llimagegl.cpp
@@ -42,6 +42,7 @@
 #include "llwindow.h"
 #include "llframetimer.h"
 #include <unordered_set>
+#include <utility>
 
 extern LL_COMMON_API bool on_main_thread();
 
@@ -541,6 +542,8 @@ void LLImageGL::init(bool usemipmaps, bool allow_compression)
 
     mIsMask = false;
     mNeedsAlphaAndPickMask = true ;
+    mTextureUploadPrepared = false;
+    mUploadPreparation.reset();
     mAlphaStride = 0 ;
     mAlphaOffset = 0 ;
 
@@ -749,6 +752,26 @@ bool LLImageGL::setImage(const U8* data_in, bool data_hasmips /* = false */, S32
 {
     LL_PROFILE_ZONE_SCOPED_CATEGORY_TEXTURE;
 
+    if (mUploadPreparation)
+    {
+        TextureUploadPreparation preparation = std::move(*mUploadPreparation);
+        mUploadPreparation.reset();
+        if (preparation.mAlphaAnalyzed)
+        {
+            mIsMask = preparation.mIsMask;
+        }
+
+        freePickMask();
+        if (!preparation.mPickMask.empty())
+        {
+            mPickMask = new U8[preparation.mPickMask.size()];
+            memcpy(mPickMask, preparation.mPickMask.data(), preparation.mPickMask.size());
+            mPickMaskWidth = preparation.mPickMaskWidth;
+            mPickMaskHeight = preparation.mPickMaskHeight;
+        }
+        mTextureUploadPrepared = true;
+    }
+
     const bool is_compressed = isCompressed();
 
     if (mUseMipMaps)
@@ -808,11 +831,14 @@ bool LLImageGL::setImage(const U8* data_in, bool data_hasmips /* = false */, S32
                     }
 
                     LLImageGL::setManualImage(mTarget, gl_level, mFormatInternal, w, h, mFormatPrimary, GL_UNSIGNED_BYTE, (GLvoid*)data_in, mAllowCompression);
-                    if (gl_level == 0)
+                    if (gl_level == 0 && !mTextureUploadPrepared)
                     {
                         analyzeAlpha(data_in, w, h);
                     }
-                    updatePickMask(w, h, data_in);
+                    if (!mTextureUploadPrepared)
+                    {
+                        updatePickMask(w, h, data_in);
+                    }
 
                     if(mFormatSwapBytes)
                     {
@@ -854,10 +880,16 @@ bool LLImageGL::setImage(const U8* data_in, bool data_hasmips /* = false */, S32
                                  w, h,
                                  mFormatPrimary, mFormatType,
                                  data_in, mAllowCompression);
-                    analyzeAlpha(data_in, w, h);
+                    if (!mTextureUploadPrepared)
+                    {
+                        analyzeAlpha(data_in, w, h);
+                    }
                     stop_glerror();
 
-                    updatePickMask(w, h, data_in);
+                    if (!mTextureUploadPrepared)
+                    {
+                        updatePickMask(w, h, data_in);
+                    }
 
                     if(mFormatSwapBytes)
                     {
@@ -927,6 +959,7 @@ bool LLImageGL::setImage(const U8* data_in, bool data_hasmips /* = false */, S32
                             }
 
                             mGLTextureCreated = false;
+                            mTextureUploadPrepared = false;
                             return false;
                         }
                         else
@@ -955,12 +988,12 @@ bool LLImageGL::setImage(const U8* data_in, bool data_hasmips /* = false */, S32
                         }
 
                         LLImageGL::setManualImage(mTarget, m, mFormatInternal, w, h, mFormatPrimary, mFormatType, cur_mip_data, mAllowCompression);
-                        if (m == 0)
+                        if (m == 0 && !mTextureUploadPrepared)
                         {
                             analyzeAlpha(data_in, w, h);
                         }
                         stop_glerror();
-                        if (m == 0)
+                        if (m == 0 && !mTextureUploadPrepared)
                         {
                             updatePickMask(w, h, cur_mip_data);
                         }
@@ -1012,9 +1045,15 @@ bool LLImageGL::setImage(const U8* data_in, bool data_hasmips /* = false */, S32
 
             LLImageGL::setManualImage(mTarget, 0, mFormatInternal, w, h,
                          mFormatPrimary, mFormatType, (GLvoid *)data_in, mAllowCompression);
-            analyzeAlpha(data_in, w, h);
+            if (!mTextureUploadPrepared)
+            {
+                analyzeAlpha(data_in, w, h);
+            }
 
-            updatePickMask(w, h, data_in);
+            if (!mTextureUploadPrepared)
+            {
+                updatePickMask(w, h, data_in);
+            }
 
             stop_glerror();
 
@@ -1027,6 +1066,7 @@ bool LLImageGL::setImage(const U8* data_in, bool data_hasmips /* = false */, S32
         }
     }
     stop_glerror();
+    mTextureUploadPrepared = false;
     mGLTextureCreated = true;
     return true;
 }
@@ -2119,6 +2159,143 @@ void LLImageGL::setNeedsAlphaAndPickMask(bool need_mask)
     }
 }
 
+namespace
+{
+bool analyze_alpha_mask(const U8* data, U32 width, U32 height, S32 alpha_stride, S32 alpha_offset)
+{
+    U32 length = width * height;
+    U32 alpha_total = 0;
+    U32 sample[16] = {};
+
+    if (width >= 2 && height >= 2)
+    {
+        llassert(width % 2 == 0);
+        llassert(height % 2 == 0);
+        const U8* row_start = data + alpha_offset;
+        for (U32 y = 0; y < height; y += 2)
+        {
+            const U8* current = row_start;
+            for (U32 x = 0; x < width; x += 2)
+            {
+                const U32 s1 = current[0];
+                alpha_total += s1;
+                const U32 s2 = current[width * alpha_stride];
+                alpha_total += s2;
+                current += alpha_stride;
+                const U32 s3 = current[0];
+                alpha_total += s3;
+                const U32 s4 = current[width * alpha_stride];
+                alpha_total += s4;
+                current += alpha_stride;
+
+                ++sample[s1 / 16];
+                ++sample[s2 / 16];
+                ++sample[s3 / 16];
+                ++sample[s4 / 16];
+
+                const U32 average_sum = s1 + s2 + s3 + s4;
+                alpha_total += average_sum;
+                sample[average_sum / (16 * 4)] += 4;
+            }
+
+            row_start += 2 * width * alpha_stride;
+        }
+        length *= 2;
+    }
+    else
+    {
+        const U8* current = data + alpha_offset;
+        for (U32 i = 0; i < length; ++i)
+        {
+            const U32 alpha = *current;
+            alpha_total += alpha;
+            ++sample[alpha / 16];
+            current += alpha_stride;
+        }
+    }
+
+    U32 midrange_total = 0;
+    for (U32 i = 2; i < 13; ++i)
+    {
+        midrange_total += sample[i];
+    }
+    U32 lower_half_total = 0;
+    for (U32 i = 0; i < 8; ++i)
+    {
+        lower_half_total += sample[i];
+    }
+    U32 upper_half_total = 0;
+    for (U32 i = 8; i < 16; ++i)
+    {
+        upper_half_total += sample[i];
+    }
+
+    return midrange_total <= length / 48 &&
+           (lower_half_total != length || alpha_total == 0) &&
+           (upper_half_total != length || alpha_total == 255 * length);
+}
+}
+
+LLImageGL::TextureUploadPreparation LLImageGL::prepareForUpload(const LLImageRaw* image)
+{
+    LL_PROFILE_ZONE_NAMED_CATEGORY_TEXTURE("prepare texture upload");
+
+    TextureUploadPreparation result;
+    if (!image || image->isBufferInvalid())
+    {
+        return result;
+    }
+
+    const S32 width = image->getWidth();
+    const S32 height = image->getHeight();
+    const S32 components = image->getComponents();
+    const U8* data = image->getData();
+    if (!data || (components != 1 && components != 2 && components != 4))
+    {
+        return result;
+    }
+
+    if (!sSkipAnalyzeAlpha)
+    {
+        result.mAlphaAnalyzed = true;
+        result.mIsMask = analyze_alpha_mask(data, width, height, components, components - 1);
+    }
+
+    if (components == 4)
+    {
+        result.mPickMaskWidth = width / 2;
+        result.mPickMaskHeight = height / 2;
+        const U32 bit_count = (width / 2 + 1) * (height / 2 + 1);
+        result.mPickMask.resize((bit_count + 7) / 8);
+
+        U32 pick_bit = 0;
+        for (S32 y = 0; y < height; y += 2)
+        {
+            for (S32 x = 0; x < width; x += 2)
+            {
+                if (data[(y * width + x) * 4 + 3] > 32)
+                {
+                    result.mPickMask[pick_bit / 8] |= 1 << (pick_bit % 8);
+                }
+                ++pick_bit;
+            }
+        }
+    }
+
+    return result;
+}
+
+void LLImageGL::applyUploadPreparation(TextureUploadPreparation&& preparation)
+{
+    mUploadPreparation = std::make_unique<TextureUploadPreparation>(std::move(preparation));
+}
+
+void LLImageGL::discardUploadPreparation()
+{
+    mUploadPreparation.reset();
+    mTextureUploadPrepared = false;
+}
+
 void LLImageGL::calcAlphaChannelOffsetAndStride()
 {
     if(mAlphaOffset == INVALID_OFFSET)//do not need alpha mask
@@ -2200,98 +2377,7 @@ void LLImageGL::analyzeAlpha(const void* data_in, U32 w, U32 h)
     }
 
     LL_PROFILE_ZONE_SCOPED_CATEGORY_TEXTURE;
-
-    U32 length = w * h;
-    U32 alphatotal = 0;
-
-    U32 sample[16];
-    memset(sample, 0, sizeof(U32)*16);
-
-    // generate histogram of quantized alpha.
-    // also add-in the histogram of a 2x2 box-sampled version.  The idea is
-    // this will mid-skew the data (and thus increase the chances of not
-    // being used as a mask) from high-frequency alpha maps which
-    // suffer the worst from aliasing when used as alpha masks.
-    if (w >= 2 && h >= 2)
-    {
-        llassert(w % 2 == 0);
-        llassert(h % 2 == 0);
-        const GLubyte* rowstart = ((const GLubyte*) data_in) + mAlphaOffset;
-        for (U32 y = 0; y < h; y += 2)
-        {
-            const GLubyte* current = rowstart;
-            for (U32 x = 0; x < w; x += 2)
-            {
-                const U32 s1 = current[0];
-                alphatotal += s1;
-                const U32 s2 = current[w * mAlphaStride];
-                alphatotal += s2;
-                current += mAlphaStride;
-                const U32 s3 = current[0];
-                alphatotal += s3;
-                const U32 s4 = current[w * mAlphaStride];
-                alphatotal += s4;
-                current += mAlphaStride;
-
-                ++sample[s1/16];
-                ++sample[s2/16];
-                ++sample[s3/16];
-                ++sample[s4/16];
-
-                const U32 asum = (s1+s2+s3+s4);
-                alphatotal += asum;
-                sample[asum/(16*4)] += 4;
-            }
-
-            rowstart += 2 * w * mAlphaStride;
-        }
-        length *= 2; // we sampled everything twice, essentially
-    }
-    else
-    {
-        const GLubyte* current = ((const GLubyte*) data_in) + mAlphaOffset;
-        for (U32 i = 0; i < length; i++)
-        {
-            const U32 s1 = *current;
-            alphatotal += s1;
-            ++sample[s1/16];
-            current += mAlphaStride;
-        }
-    }
-
-    // if more than 1/16th of alpha samples are mid-range, this
-    // shouldn't be treated as a 1-bit mask
-
-    // also, if all of the alpha samples are clumped on one half
-    // of the range (but not at an absolute extreme), then consider
-    // this to be an intentional effect and don't treat as a mask.
-
-    U32 midrangetotal = 0;
-    for (U32 i = 2; i < 13; i++)
-    {
-        midrangetotal += sample[i];
-    }
-    U32 lowerhalftotal = 0;
-    for (U32 i = 0; i < 8; i++)
-    {
-        lowerhalftotal += sample[i];
-    }
-    U32 upperhalftotal = 0;
-    for (U32 i = 8; i < 16; i++)
-    {
-        upperhalftotal += sample[i];
-    }
-
-    if (midrangetotal > length/48 || // lots of midrange, or
-        (lowerhalftotal == length && alphatotal != 0) || // all close to transparent but not all totally transparent, or
-        (upperhalftotal == length && alphatotal != 255*length)) // all close to opaque but not all totally opaque
-    {
-        mIsMask = false; // not suitable for masking
-    }
-    else
-    {
-        mIsMask = true;
-    }
+    mIsMask = analyze_alpha_mask(static_cast<const U8*>(data_in), w, h, mAlphaStride, mAlphaOffset);
 }
 
 //----------------------------------------------------------------------------
@@ -2660,4 +2746,3 @@ void LLImageGLThread::run()
     gGL.shutdown();
     mWindow->destroySharedContext(mContext);
 }
-

--- a/indra/llrender/llimagegl.h
+++ b/indra/llrender/llimagegl.h
@@ -39,7 +39,9 @@
 #include "llrender.h"
 #include "threadpool.h"
 #include "workqueue.h"
+#include <memory>
 #include <unordered_set>
+#include <vector>
 
 #define LL_IMAGEGL_THREAD_CHECK 0 //set to 1 to enable thread debugging for ImageGL
 
@@ -61,6 +63,15 @@ class LLImageGL : public LLRefCount
 {
     friend class LLTexUnit;
 public:
+    struct TextureUploadPreparation
+    {
+        bool mAlphaAnalyzed = false;
+        bool mIsMask = false;
+        U16 mPickMaskWidth = 0;
+        U16 mPickMaskHeight = 0;
+        std::vector<U8> mPickMask;
+    };
+
 
     // call once per frame
     static void updateClass();
@@ -210,6 +221,10 @@ public:
     virtual void cleanup(); // Clean up the LLImageGL so it can be reinitialized.  Be careful when using this in derived class destructors
 
     void setNeedsAlphaAndPickMask(bool need_mask);
+    bool getNeedsAlphaAndPickMask() const { return mNeedsAlphaAndPickMask; }
+    static TextureUploadPreparation prepareForUpload(const LLImageRaw* image);
+    void applyUploadPreparation(TextureUploadPreparation&& preparation);
+    void discardUploadPreparation();
 
 #if LL_IMAGEGL_THREAD_CHECK
     // thread debugging
@@ -245,6 +260,8 @@ private:
 
     bool mIsMask;
     bool mNeedsAlphaAndPickMask;
+    bool mTextureUploadPrepared;
+    std::unique_ptr<TextureUploadPreparation> mUploadPreparation;
     S8   mAlphaStride ;
     S8   mAlphaOffset ;
 

--- a/indra/newview/llviewertexture.cpp
+++ b/indra/newview/llviewertexture.cpp
@@ -63,6 +63,8 @@
 #include "lltexturecache.h"
 #include "llviewerwindow.h"
 #include "llwindow.h"
+
+#include <utility>
 ///////////////////////////////////////////////////////////////////////////////
 
 // statics
@@ -1651,6 +1653,7 @@ bool LLViewerFetchedTexture::createTexture(S32 usename/*= 0*/)
 void LLViewerFetchedTexture::postCreateTexture()
 {
     LL_PROFILE_ZONE_SCOPED_CATEGORY_TEXTURE;
+    mGLTexturep->discardUploadPreparation();
     if (!mNeedsCreateTexture)
     {
         return;
@@ -1748,6 +1751,54 @@ void LLViewerFetchedTexture::scheduleCreateTexture()
                         postCreateTexture();
                         unref();
                     });
+            }
+            else if (!mGLTexturep->getHasExplicitFormat() &&
+                     mGLTexturep->getNeedsAlphaAndPickMask() &&
+                     mRawImage->getComponents() != 3)
+            {
+                auto main_queue = mMainQueue.lock();
+                auto general_queue = LL::WorkQueue::getInstance("General");
+                if (main_queue && general_queue)
+                {
+                    LLPointer<LLImageRaw> raw_image = mRawImage;
+                    ref();
+                    const bool posted = main_queue->postTo(
+                        general_queue,
+                        [raw_image]()
+                        {
+                            return LLImageGL::prepareForUpload(raw_image);
+                        },
+                        [this, raw_image](LLImageGL::TextureUploadPreparation preparation)
+                        {
+                            if (mNeedsCreateTexture)
+                            {
+                                if (mRawImage == raw_image)
+                                {
+                                    mGLTexturep->applyUploadPreparation(std::move(preparation));
+                                }
+                                if (!mCreatePending)
+                                {
+                                    mCreatePending = true;
+                                    gTextureList.mCreateTextureList.push(this);
+                                }
+                            }
+                            unref();
+                        });
+                    if (!posted)
+                    {
+                        unref();
+                        if (!mCreatePending)
+                        {
+                            mCreatePending = true;
+                            gTextureList.mCreateTextureList.push(this);
+                        }
+                    }
+                }
+                else if (!mCreatePending)
+                {
+                    mCreatePending = true;
+                    gTextureList.mCreateTextureList.push(this);
+                }
             }
             else
             {
@@ -4224,4 +4275,3 @@ void LLTexturePipelineTester::LLTextureTestSession::reset()
 //----------------------------------------------------------------------------------------------
 //end of LLTexturePipelineTester
 //----------------------------------------------------------------------------------------------
-


### PR DESCRIPTION
## Summary

- precompute fetched-texture alpha classification and pick masks on the existing General worker pool when shared-context texture uploads are disabled
- carry the prepared metadata to the main thread and consume it immediately before the GL upload
- retain the existing synchronous path for explicit formats, unavailable queues, and shared-context uploads
- discard stale preparation when an upload becomes redundant

## Why

A native sample on Apple Silicon placed `LLViewerTextureList::updateImagesCreateTextures()` on roughly 9% of main-thread samples. `LLImageGL::analyzeAlpha()` and pick-mask generation were running as CPU scans inside `setImage()` on the frame-critical path. Firestorm intentionally disables shared-context GL texture uploads for Apple GPUs, but these CPU-only preparation steps do not need the GL context.

## Validation

- `git diff --check`
- deterministic code-path review against the existing alpha-mask and pick-mask algorithms; both paths now share the same alpha classifier
- fallback and stale-result paths verified by inspection

A full native viewer build was not available on this host because the autobuild dependency bundle and full Xcode toolchain are not installed.
