### PR TITLE
Budget incremental reflection probe updates

### DIFF
--- a/indra/newview/app_settings/settings.xml
+++ b/indra/newview/app_settings/settings.xml
@@ -13034,6 +13034,17 @@ Change of this parameter will affect the layout of buttons in notification toast
     <string>F32</string>
     <key>Value</key>
     <real>2.0</real>
+    </map>
+  <key>RenderReflectionProbeUpdateBudget</key>
+  <map>
+    <key>Comment</key>
+    <string>CPU time in milliseconds accrued per frame for incremental reflection probe updates. Set to 0 to disable throttling.</string>
+    <key>Persist</key>
+    <integer>1</integer>
+    <key>Type</key>
+    <string>F32</string>
+    <key>Value</key>
+    <real>1.0</real>
   </map>
   <key>RenderReflectionProbeLevel</key>
   <map>

--- a/indra/newview/llreflectionmapmanager.cpp
+++ b/indra/newview/llreflectionmapmanager.cpp
@@ -40,6 +40,7 @@
 #include "llstartup.h"
 #include "llviewermenufile.h"
 #include "llnotificationsutil.h"
+#include "lltimer.h"
 
 #if LL_WINDOWS
 #pragma warning (push)
@@ -218,6 +219,8 @@ void LLReflectionMapManager::update()
         return;
     }
 
+    replenishProbeUpdateBudget();
+
     if (mPaused && gFrameTimeSeconds > mResumeTime)
     {
         resume();
@@ -335,7 +338,10 @@ void LLReflectionMapManager::update()
     if (mUpdatingProbe != nullptr)
     {
         did_update = true;
-        doProbeUpdate();
+        if (hasProbeUpdateBudget())
+        {
+            doBudgetedProbeUpdate();
+        }
     }
 
     // update distance to camera for all probes
@@ -499,7 +505,7 @@ void LLReflectionMapManager::update()
     }
 
     // switch to updating the next oldest probe
-    if (!did_update && oldestProbe != nullptr)
+    if (!did_update && oldestProbe != nullptr && hasProbeUpdateBudget())
     {
         LLReflectionMap* probe = oldestProbe;
         llassert(probe->mCubeIndex != -1);
@@ -508,7 +514,7 @@ void LLReflectionMapManager::update()
 
         sUpdateCount++;
         mUpdatingProbe = probe;
-        doProbeUpdate();
+        doBudgetedProbeUpdate();
     }
 
     if (oldestOccluded)
@@ -725,6 +731,44 @@ void LLReflectionMapManager::deleteProbe(U32 i)
     }
 
     mProbes.erase(mProbes.begin() + i);
+}
+
+void LLReflectionMapManager::replenishProbeUpdateBudget()
+{
+    static LLCachedControl<F32> update_budget(gSavedSettings, "RenderReflectionProbeUpdateBudget", 1.f);
+
+    mProbeUpdateBudget = llmax((F32)update_budget, 0.f);
+    ++mFramesSinceProbeUpdate;
+
+    if (mProbeUpdateBudget > 0.f)
+    {
+        // Permit a small burst so an expensive face does not permanently put
+        // the scheduler behind, while preventing unlimited idle-time credit.
+        const F32 credit_limit = llmax(mProbeUpdateBudget * 4.f, mProbeUpdateCost * 2.f);
+        mProbeUpdateCredit = llmin(mProbeUpdateCredit + mProbeUpdateBudget, credit_limit);
+    }
+}
+
+bool LLReflectionMapManager::hasProbeUpdateBudget() const
+{
+    constexpr U32 MAX_DEFERRED_FRAMES = 30;
+    return mProbeUpdateBudget <= 0.f ||
+           mProbeUpdateCredit >= mProbeUpdateCost ||
+           mFramesSinceProbeUpdate >= MAX_DEFERRED_FRAMES;
+}
+
+void LLReflectionMapManager::doBudgetedProbeUpdate()
+{
+    LLTimer timer;
+    doProbeUpdate();
+
+    const F32 elapsed_ms = timer.getElapsedTimeF32() * 1000.f;
+    mProbeUpdateCost = lerp(mProbeUpdateCost, llmax(elapsed_ms, 0.01f), 0.2f);
+    if (mProbeUpdateBudget > 0.f)
+    {
+        mProbeUpdateCredit -= elapsed_ms;
+    }
+    mFramesSinceProbeUpdate = 0;
 }
 
 

--- a/indra/newview/llreflectionmapmanager.h
+++ b/indra/newview/llreflectionmapmanager.h
@@ -210,6 +210,11 @@ private:
     // perform an update on the currently updating Probe
     void doProbeUpdate();
 
+    // Accumulate and consume the per-frame CPU budget for non-realtime probe updates.
+    void replenishProbeUpdateBudget();
+    bool hasProbeUpdateBudget() const;
+    void doBudgetedProbeUpdate();
+
     // update the specified face of the specified probe
     void updateProbeFace(LLReflectionMap* probe, U32 face);
 
@@ -255,6 +260,12 @@ private:
     U32 mRenderReflectionProbeCount = 256U;
     S32 mRenderReflectionProbeDynamicAllocation = -1;
 
+    // CPU milliseconds available for incremental reflection probe work.
+    F32 mProbeUpdateBudget = 0.f;
+    F32 mProbeUpdateCredit = 0.f;
+    F32 mProbeUpdateCost = 1.f;
+    U32 mFramesSinceProbeUpdate = 0;
+
     // resolution of reflection probes
     U32 mProbeResolution = 128;
 
@@ -276,4 +287,3 @@ private:
 
     ReflectionProbeData mProbeData;
 };
-


### PR DESCRIPTION
## Summary

- add a token-bucket CPU budget for incremental reflection probe face updates
- measure actual update cost and maintain a smoothed estimate for scheduling
- cap accumulated idle credit so probe work cannot burst without limit
- force an update after 30 deferred frames to guarantee forward progress
- add `RenderReflectionProbeUpdateBudget` with a 1 ms/frame default; `0` restores unthrottled behavior

## Why

A native profile placed `LLReflectionMapManager::update()` / `doProbeUpdate()` on roughly 8% of main-thread samples even with static-only reflections. The existing scheduler performs one incremental face every frame whenever work is pending, without considering the CPU time already consumed by prior faces.

The budget applies to incremental non-realtime updates. Explicit realtime probes retain their current six-face-per-frame behavior.

## Validation

- `git diff --check`
- `xmllint --noout indra/newview/app_settings/settings.xml`
- reviewed credit accrual, measured-cost debit, disabled-budget behavior, and the starvation escape path

A full native viewer build was not available on this host because the autobuild dependency bundle and full Xcode toolchain are not installed.
