### PR TITLE
[Windows] Keep fullscreen active for native file dialogs

### DIFF
--- a/indra/llwindow/llwindowwin32.cpp
+++ b/indra/llwindow/llwindowwin32.cpp
@@ -169,6 +169,21 @@ void show_window_creation_error(const std::string& title)
     LL_WARNS("Window") << title << LL_ENDL;
 }
 
+// <FS:volksec> Keep native dialog focus changes inside the viewer process.
+static bool is_thread_from_current_process(DWORD thread_id)
+{
+    HANDLE thread_handle = OpenThread(THREAD_QUERY_LIMITED_INFORMATION, FALSE, thread_id);
+    if (!thread_handle)
+    {
+        return false;
+    }
+
+    const DWORD process_id = GetProcessIdOfThread(thread_handle);
+    CloseHandle(thread_handle);
+    return process_id == GetCurrentProcessId();
+}
+// </FS:volksec>
+
 HGLRC SafeCreateContext(HDC &hdc)
 {
     __try
@@ -2464,7 +2479,7 @@ LRESULT CALLBACK LLWindowWin32::mainWindowProc(HWND h_wnd, UINT u_msg, WPARAM w_
             {
                 initializeDeviceCLSIDArray();
             }
-            
+
             if (w_param == DBT_DEVICEARRIVAL || w_param == DBT_DEVICEREMOVECOMPLETE)
             {
                 DEV_BROADCAST_HDR* dtype = (DEV_BROADCAST_HDR*)l_param;
@@ -2479,7 +2494,7 @@ LRESULT CALLBACK LLWindowWin32::mainWindowProc(HWND h_wnd, UINT u_msg, WPARAM w_
                         {
                             bool deviceRemoved = (w_param == DBT_DEVICEREMOVECOMPLETE);
                             WINDOW_IMP_POST(window_imp->mCallbacks->handleDeviceChange(window_imp, deviceRemoved));
-                            break; 
+                            break;
                         }
                     }
                 }
@@ -2540,6 +2555,14 @@ LRESULT CALLBACK LLWindowWin32::mainWindowProc(HWND h_wnd, UINT u_msg, WPARAM w_
                 {
                     // This message should be sent whenever the app gains or loses focus.
                     BOOL activating = (BOOL)w_param;
+
+                    // <FS:volksec> Native file dialogs run on a worker thread.
+                    // Do not minimize fullscreen when focus stays in this process.
+                    if (!activating && is_thread_from_current_process(static_cast<DWORD>(l_param)))
+                    {
+                        activating = TRUE;
+                    }
+                    // </FS:volksec>
 
                     if (window_imp->mFullscreen)
                     {


### PR DESCRIPTION
## Summary

Prevent the Windows viewer from minimizing and resetting the display mode when focus moves between an exclusive-fullscreen viewer window and a native file dialog owned by another thread in the same process.

Related upstream report: https://github.com/secondlife/viewer/issues/4569

## Root cause

Windows file pickers are opened by `LLFilePickerThread`, while the viewer window has its own window thread. The `WM_ACTIVATEAPP` handler currently treats every deactivation notification as a switch to another application. In fullscreen mode that immediately minimizes the viewer and resets the display resolution, which can leave the owned picker hidden and the viewer unusable.

For a deactivation notification, Win32 places the thread ID of the window being activated in `lParam`. The handler can therefore distinguish an in-process focus transfer from a real application switch.

## Changes

- Resolve the process ID for the thread referenced by `WM_ACTIVATEAPP::lParam`.
- Treat focus as still active when that thread belongs to the current viewer process.
- Preserve the existing minimize/display-reset behavior for real switches to another process.
- Mark the additions with `<FS:volksec>` blocks as required for inherited Linden Lab code.

## User impact

Native open/save dialogs remain usable when Firestorm runs in exclusive fullscreen. Normal Alt+Tab behavior is unchanged because external-process activation still follows the existing fullscreen path.

## Validation

- `pre-commit run --files indra/llwindow/llwindowwin32.cpp`
- Configured Windows x64 `ReleaseFS_open` with `LL_TESTS=FALSE`.
- Built the `llwindow` target successfully with Visual Studio 2022 Build Tools.
- Built and linked the complete `firestorm-bin` Release target successfully.

## Manual QA

1. Launch Firestorm directly in exclusive fullscreen on Windows 10 or 11.
2. Open native Open, Save, and directory picker flows.
3. Move focus between the picker and viewer, then accept and cancel each picker.
4. Confirm the picker remains visible and the viewer is not minimized.
5. Alt+Tab to a different application and confirm the existing fullscreen minimize/restore behavior still works.
