### PR TITLE
FIX - FS group title floater does not correctly initialize new region-based buttons

### DIFF
--- a/indra/newview/fsfloatergrouptitles.cpp
+++ b/indra/newview/fsfloatergrouptitles.cpp
@@ -260,6 +260,7 @@ void FSFloaterGroupTitles::processGroupTitleResults(const LLGroupData& group_dat
     }
 
     mTitleList->scrollToShowSelected();
+    selectedTitleChanged();
     updateDefaultColumn();
 
     // Remove observer
@@ -328,6 +329,7 @@ void FSFloaterGroupTitles::selectedTitleChanged()
     }
     else
     {
+        mInfoButton->setEnabled(false);
         mSetRegionButton->setEnabled(false);
         mSetRegionManualButton->setEnabled(false);
         mClearRegionButton->setEnabled(false);


### PR DESCRIPTION
Minor fix to the group title floater: 
On first init, the buttons for the new region-based roles ("This Region", "Clear Region", etc.) would not correctly initialize after the title list was populated, leaving them incorrectly disabled if you had a title selected. This would force you to click inside the window for their state to refresh proper.
