### PR TITLE
Fix LLCallbackMap::map_t incomplete-type build error under GCC/libstdc++

### DIFF
--- a/indra/llui/llcallbackmap.h
+++ b/indra/llui/llcallbackmap.h
@@ -39,9 +39,10 @@ public:
     // callback definition.
     typedef std::function<void* (void* data)> callback_t;
 
-    typedef std::unordered_map<std::string, LLCallbackMap> map_t;
-    typedef map_t::iterator map_iter_t;
-    typedef map_t::const_iterator map_const_iter_t;
+    // map_t/map_iter_t/map_const_iter_t are declared after the class (below), not
+    // as nested typedefs: unordered_map<std::string, LLCallbackMap> needs LLCallbackMap
+    // to be a complete type, which it never is within its own body. MSVC's STL
+    // tolerates the incomplete type here; libstdc++ does not.
 
     template <class T>
     static void* buildPanel(void* data)
@@ -56,5 +57,12 @@ public:
     callback_t  mCallback;
     void*       mData;
 };
+
+namespace LLCallbackMapTypes
+{
+    typedef std::unordered_map<std::string, LLCallbackMap> map_t;
+    typedef map_t::iterator map_iter_t;
+    typedef map_t::const_iterator map_const_iter_t;
+}
 
 #endif // LLCALLBACKMAP_H

--- a/indra/llui/llpanel.cpp
+++ b/indra/llui/llpanel.cpp
@@ -834,13 +834,13 @@ bool LLPanel::buildFromFile(const std::string& filename, const LLPanel::Params& 
 //-----------------------------------------------------------------------------
 LLPanel* LLPanel::createFactoryPanel(const std::string& name)
 {
-    std::deque<const LLCallbackMap::map_t*>::iterator itor;
+    std::deque<const LLCallbackMapTypes::map_t*>::iterator itor;
     for (itor = sFactoryStack.begin(); itor != sFactoryStack.end(); ++itor)
     {
-        const LLCallbackMap::map_t* factory_map = *itor;
+        const LLCallbackMapTypes::map_t* factory_map = *itor;
 
         // Look up this panel's name in the map.
-        LLCallbackMap::map_const_iter_t iter = factory_map->find( name );
+        LLCallbackMapTypes::map_const_iter_t iter = factory_map->find( name );
         if (iter != factory_map->end())
         {
             // Use the factory to create the panel, instead of using a default LLPanel.

--- a/indra/llui/llpanel.h
+++ b/indra/llui/llpanel.h
@@ -161,7 +161,7 @@ public:
 
     LLHandle<LLPanel>   getHandle() const { return getDerivedHandle<LLPanel>(); }
 
-    const LLCallbackMap::map_t& getFactoryMap() const { return mFactoryMap; }
+    const LLCallbackMapTypes::map_t& getFactoryMap() const { return mFactoryMap; }
 
     CommitCallbackRegistry::ScopedRegistrar& getCommitCallbackRegistrar() { return mCommitCallbackRegistrar; }
     EnableCallbackRegistry::ScopedRegistrar& getEnableCallbackRegistrar() { return mEnableCallbackRegistrar; }
@@ -224,14 +224,14 @@ public:
 protected:
     // Override to set not found list
     LLButton*       getDefaultButton() { return mDefaultBtn; }
-    LLCallbackMap::map_t mFactoryMap;
+    LLCallbackMapTypes::map_t mFactoryMap;
     CommitCallbackRegistry::ScopedRegistrar mCommitCallbackRegistrar;
     EnableCallbackRegistry::ScopedRegistrar mEnableCallbackRegistrar;
 
     commit_signal_t* mVisibleSignal;        // Called when visibility changes, passes new visibility as LLSD()
 
     std::string     mHelpTopic;         // the name of this panel's help topic to display in the Help Viewer
-    typedef std::deque<const LLCallbackMap::map_t*> factory_stack_t;
+    typedef std::deque<const LLCallbackMapTypes::map_t*> factory_stack_t;
     static factory_stack_t  sFactoryStack;
 
     // for setting the xml filename when building panel in context dependent cases


### PR DESCRIPTION
Fixes a GCC/Linux build error in llcallbackmap.h. LLCallbackMap::map_t was declared as a nested typedef using LLCallbackMap as the value type of a std::unordered_map, referencing itself before its own definition was complete. MSVC's STL tolerates this, but libstdc++ requires the value type to be complete when the hashtable node is instantiated, causing a build failure.

Moved the typedef out of the class into a new LLCallbackMapTypes namespace, declared after LLCallbackMap is fully defined. Updated the two call sites in llpanel.h/llpanel.cpp from LLCallbackMap::map_t to LLCallbackMapTypes::map_t (and the associated iterator typedefs) accordingly. No behavior change.

The build error has been introduced by commit 0e687a83b5 — "Optimize various usages of std::map with frequent find access with std::unordered_map" — which swapped LLCallbackMap::map_t from std::map to std::unordered_map, exposing the pre-existing incomplete-type self-reference that only std::map had been tolerating.