### PR TITLE
[FIRE-34340] Issue 1: Fix camtextures and setcam_textures RLVa command for PBR materials.

### DIFF
--- a/indra/newview/llviewerobjectlist.cpp
+++ b/indra/newview/llviewerobjectlist.cpp
@@ -68,7 +68,7 @@
 #include "llmeshrepository.h"
 #include "u64.h"
 #include "llviewertexturelist.h"
-// <FS> PBR texture override for @setcam_textures
+// <FS> FIRE-34340-1 PBR texture override for @setcam_textures
 #include "llfetchedgltfmaterial.h"
 #include "lltextureentry.h"
 // </FS>
@@ -841,7 +841,7 @@ void LLViewerObjectList::setAllObjectDefaultTextures(U32 nChannel, bool fShowDef
 }
 // [/SL:KB]
 
-// <FS> PBR texture override for @setcam_textures
+// <FS> FIRE-34340-1 PBR texture override for @setcam_textures
 static std::map<std::pair<LLUUID, S32>, LLUUID> sOrigPBRBaseColorIDs;
 static std::map<LLGLTFMaterial*, LLUUID> sOrigBaseMaterialColorIDs;
 

--- a/indra/newview/llviewerobjectlist.cpp
+++ b/indra/newview/llviewerobjectlist.cpp
@@ -68,6 +68,10 @@
 #include "llmeshrepository.h"
 #include "u64.h"
 #include "llviewertexturelist.h"
+// <FS> PBR texture override for @setcam_textures
+#include "llfetchedgltfmaterial.h"
+#include "lltextureentry.h"
+// </FS>
 #include "lldatapacker.h"
 #ifdef LL_USESYSTEMLIBS
 #include <zlib.h>
@@ -836,6 +840,94 @@ void LLViewerObjectList::setAllObjectDefaultTextures(U32 nChannel, bool fShowDef
     }
 }
 // [/SL:KB]
+
+// <FS> PBR texture override for @setcam_textures
+static std::map<std::pair<LLUUID, S32>, LLUUID> sOrigPBRBaseColorIDs;
+static std::map<LLGLTFMaterial*, LLUUID> sOrigBaseMaterialColorIDs;
+
+void LLViewerObjectList::setAllObjectPBRDefaultTextures(const LLUUID& override_id, bool fShowDefault)
+{
+    for (LLViewerObject* pObj : mObjects)
+    {
+        LLDrawable* pDrawable = pObj->mDrawable;
+        if (!pDrawable || pDrawable->isDead())
+            continue;
+        if (pObj->isAttachment())
+            continue;
+        if (LL_PCODE_VOLUME != pObj->getPCode())
+            continue;
+
+        for (int idxFace = 0, cntFace = pDrawable->getNumFaces(); idxFace < cntFace; idxFace++)
+        {
+            LLFace* pFace = pDrawable->getFace(idxFace);
+            if (!pFace)
+                continue;
+
+            S32 te_idx = pFace->getTEOffset();
+            const LLTextureEntry* te = pObj->getTE(te_idx);
+            if (!te)
+                continue;
+
+            LLGLTFMaterial* render_mat_raw = te->getGLTFRenderMaterial();
+            if (!render_mat_raw)
+                continue;
+
+            if (render_mat_raw == te->getGLTFMaterial())
+            {
+                if (fShowDefault && override_id.notNull())
+                {
+                    if (sOrigBaseMaterialColorIDs.find(render_mat_raw) == sOrigBaseMaterialColorIDs.end())
+                        sOrigBaseMaterialColorIDs[render_mat_raw] = render_mat_raw->mTextureId[LLGLTFMaterial::GLTF_TEXTURE_INFO_BASE_COLOR];
+                    render_mat_raw->mTextureId[LLGLTFMaterial::GLTF_TEXTURE_INFO_BASE_COLOR] = override_id;
+                }
+                else if (!fShowDefault)
+                {
+                    auto it = sOrigBaseMaterialColorIDs.find(render_mat_raw);
+                    if (it != sOrigBaseMaterialColorIDs.end())
+                    {
+                        render_mat_raw->mTextureId[LLGLTFMaterial::GLTF_TEXTURE_INFO_BASE_COLOR] = it->second;
+                        sOrigBaseMaterialColorIDs.erase(it);
+                    }
+                }
+            }
+            else
+            {
+                LLFetchedGLTFMaterial* render_mat = dynamic_cast<LLFetchedGLTFMaterial*>(render_mat_raw);
+                if (!render_mat)
+                    continue;
+
+                auto key = std::make_pair(pObj->getID(), te_idx);
+
+                if (fShowDefault && override_id.notNull())
+                {
+                    auto it = sOrigPBRBaseColorIDs.find(key);
+                    if (it == sOrigPBRBaseColorIDs.end())
+                        sOrigPBRBaseColorIDs[key] = render_mat->mTextureId[LLGLTFMaterial::GLTF_TEXTURE_INFO_BASE_COLOR];
+                    render_mat->mTextureId[LLGLTFMaterial::GLTF_TEXTURE_INFO_BASE_COLOR] = override_id;
+                }
+                else if (!fShowDefault)
+                {
+                    auto it = sOrigPBRBaseColorIDs.find(key);
+                    if (it != sOrigPBRBaseColorIDs.end())
+                    {
+                        render_mat->mTextureId[LLGLTFMaterial::GLTF_TEXTURE_INFO_BASE_COLOR] = it->second;
+                        sOrigPBRBaseColorIDs.erase(it);
+                    }
+                }
+            }
+        }
+
+        if (LLVOVolume* pVoVolume = pDrawable->getVOVolume())
+            pVoVolume->markForUpdate();
+    }
+
+    if (!fShowDefault)
+    {
+        sOrigPBRBaseColorIDs.clear();
+        sOrigBaseMaterialColorIDs.clear();
+    }
+}
+// </FS>
 
 void LLViewerObjectList::updateApparentAngles(LLAgent &agent)
 {

--- a/indra/newview/llviewerobjectlist.h
+++ b/indra/newview/llviewerobjectlist.h
@@ -127,7 +127,7 @@ public:
 // [SL:KB] - Patch: Render-TextureToggle (Catznip-4.0)
     void setAllObjectDefaultTextures(U32 nChannel, bool fShowDefault);
 // [/SL:KB]
-// <FS> PBR texture override for @setcam_textures
+// <FS> FIRE-34340-1 PBR texture override for @setcam_textures
     void setAllObjectPBRDefaultTextures(const LLUUID& override_id, bool fShowDefault);
 // </FS>
 

--- a/indra/newview/llviewerobjectlist.h
+++ b/indra/newview/llviewerobjectlist.h
@@ -127,6 +127,9 @@ public:
 // [SL:KB] - Patch: Render-TextureToggle (Catznip-4.0)
     void setAllObjectDefaultTextures(U32 nChannel, bool fShowDefault);
 // [/SL:KB]
+// <FS> PBR texture override for @setcam_textures
+    void setAllObjectPBRDefaultTextures(const LLUUID& override_id, bool fShowDefault);
+// </FS>
 
     void removeFromActiveList(LLViewerObject* objectp);
     void updateActive(LLViewerObject *objectp);

--- a/indra/newview/rlvhandler.cpp
+++ b/indra/newview/rlvhandler.cpp
@@ -2416,11 +2416,13 @@ void RlvBehaviourModifierHandler<RLV_MODIFIER_SETCAM_TEXTURE>::onValueChange() c
             RLV_INFOS << "Toggling diffuse textures for @setcam_textures" << RLV_ENDL;
             LLViewerFetchedTexture::sDefaultDiffuseImagep = LLViewerTextureManager::getFetchedTexture(pBhvrModifier->getValue<LLUUID>(), FTT_DEFAULT, MIPMAP_YES, LLGLTexture::BOOST_NONE, LLViewerTexture::LOD_TEXTURE);
             gObjectList.setAllObjectDefaultTextures(LLRender::DIFFUSE_MAP, true);
+            gObjectList.setAllObjectPBRDefaultTextures(pBhvrModifier->getValue<LLUUID>(), true);
         }
         else
         {
             RLV_INFOS << "Restoring diffuse textures for @setcam_textures" << RLV_ENDL;
             gObjectList.setAllObjectDefaultTextures(LLRender::DIFFUSE_MAP, false);
+            gObjectList.setAllObjectPBRDefaultTextures(LLUUID::null, false);
             LLViewerFetchedTexture::sDefaultDiffuseImagep = nullptr;
         }
     }


### PR DESCRIPTION
Fixes [FIRE-34340 First Issue](https://jira.firestormviewer.org/browse/FIRE-34340), i.e.
```
Issue 1:
@camtextures=n does not turn PBR objects grey.
```
This fix also applies to the command `@setcam_textures:[uuid]=<y/n>`

This adds a second pass that iterates all volume prims and overrides the base color UUID on each PBR face's render material. Originals are tracked and restored when the command is removed/cleared.

It matches the Blinn-Phong behaviour.