### PR TITLE
[FIRE-34340] Issue 2: Fix camavdist RLVa command to use impostors instead of jelly dolls

### DIFF
--- a/indra/newview/llvoavatar.cpp
+++ b/indra/newview/llvoavatar.cpp
@@ -4775,6 +4775,11 @@ bool LLVOAvatar::isRlvSilhouette() const
     if (!RlvActions::hasBehaviour(RLV_BHVR_SETCAM_AVDIST))
         return false;
 
+    // <FS> FIRE-34340-2 RLV silhouette should not override the user's complexity settings
+    if (isSelf() || isTooComplex() || isTooSlowWithoutShadows())
+        return false;
+    // </FS>
+
     static RlvCachedBehaviourModifier<float> s_nSetCamAvDist(RLV_MODIFIER_SETCAM_AVDIST);
 
     const F64 now = LLFrameTimer::getTotalSeconds();
@@ -9738,12 +9743,6 @@ bool LLVOAvatar::hasFirstFullAttachmentData() const
 
 bool LLVOAvatar::isTooComplex() const
 {
-    // [RLVa] FIRE-35778 @camavdist:1=n RLVa command turns avatars invisible in stead of a silhouette (fix from Ellie Sable)
-    if (isRlvSilhouette())
-    {
-        return true;
-    }
-    // [/RLVa]
     bool too_complex;
     static LLCachedControl<S32> complexity_render_mode(gSavedSettings, "RenderAvatarComplexityMode");
     bool render_friend =  (isBuddy() && complexity_render_mode > AV_RENDER_LIMIT_BY_COMPLEXITY);
@@ -12213,6 +12212,9 @@ bool LLVOAvatar::isImpostor()
             // isVisuallyMuted() ||
             is_visual_muted || // Save from calling isVisuallyMuted a second time
             // </FS:minerjr> [FIRE-35735]
+            // <FS> FIRE-34340-2 RLV silhouettes must be impostored
+            isRlvSilhouette() ||
+            // </FS>
             isTooSlowWithoutShadows() ||
             (sLimitNonImpostors && (mUpdatePeriod > 1) )
     );

--- a/indra/newview/pipeline.cpp
+++ b/indra/newview/pipeline.cpp
@@ -12027,7 +12027,9 @@ void LLPipeline::generateImpostor(LLVOAvatar* avatar, bool preview_avatar, bool 
 
         LLGLDisable blend(GL_BLEND);
 
-        if (visually_muted || too_complex)
+        // <FS> FIRE-34340-2 RLV silhouettes need a solid color baked into the impostor too
+        if (visually_muted || too_complex || rlv_silhouette)
+        // </FS>
         {
             gGL.setColorMask(true, true);
         }
@@ -12052,8 +12054,8 @@ void LLPipeline::generateImpostor(LLVOAvatar* avatar, bool preview_avatar, bool 
 
         gDebugProgram.bind();
 
-        // <FS> FIRE-34340-2 Use getMutedAVColor() for all muted/complex/silhouette avatars
-        if (visually_muted || too_complex || rlv_silhouette)
+        // <FS> FIRE-34340-2 Use getMutedAVColor() for all muted/silhouette avatars
+        if (visually_muted || rlv_silhouette)
         // </FS>
         {   // Visually muted avatar
             LLColor4 muted_color(avatar->getMutedAVColor());

--- a/indra/newview/pipeline.cpp
+++ b/indra/newview/pipeline.cpp
@@ -11760,6 +11760,9 @@ void LLPipeline::generateImpostor(LLVOAvatar* avatar, bool preview_avatar, bool 
     LL_DEBUGS_ONCE("AvatarRenderPipeline") << "Avatar " << avatar->getID()
                               << " is " << ( too_complex ? "" : "not ") << "too complex"
                               << LL_ENDL;
+    // <FS> FIRE-34340-2 RLV silhouettes need full avatar geometry, not jelly-doll-only
+    bool rlv_silhouette = !for_profile && !preview_avatar && avatar->isRlvSilhouette();
+    // </FS>
 
     pushRenderTypeMask();
 
@@ -12049,7 +12052,9 @@ void LLPipeline::generateImpostor(LLVOAvatar* avatar, bool preview_avatar, bool 
 
         gDebugProgram.bind();
 
-        if (visually_muted)
+        // <FS> FIRE-34340-2 Use getMutedAVColor() for all muted/complex/silhouette avatars
+        if (visually_muted || too_complex || rlv_silhouette)
+        // </FS>
         {   // Visually muted avatar
             LLColor4 muted_color(avatar->getMutedAVColor());
             LL_DEBUGS_ONCE("AvatarRenderPipeline") << "Avatar " << avatar->getID() << " MUTED set solid color " << muted_color << LL_ENDL;


### PR DESCRIPTION
Fixes [FIRE-34340 Second Issue](https://jira.firestormviewer.org/browse/FIRE-34340), i.e.
```
Issue 2:
@camavdist:1=n hides avatars or turns them into slightly pixelated tiny blobs
```

This issue has been opened a second one with [FIRE-35778](https://jira.firestormviewer.org/browse/FIRE-35778) which had been resolved with commit [86760e7](https://github.com/FirestormViewer/phoenix-firestorm/commit/86760e7b1faf69b30a01423349d56537901d8cb9)

But I believe the original intent was to have the actual silhouette of an avatar, made pitch black, rendered through an impostor, instead of a jelly doll.

For reference, this is what RLV LSL documentation says:
```
When active, this restriction makes all the avatars beyond <distance> look as if they were visually muted, but colored pitch black. 
```

I could not confirm original behaviour as non PBR FS viewer (6.6.17) already had the issue. I did not go further back in git history to track down the actual intended behaviour.
Any Impostors rendering issues are not fixed by this PR.

Furthermore, I would like to denote that the [Third Issue from FIRE-34340](https://jira.firestormviewer.org/browse/FIRE-34340) has been fixed or is at least not reproductible on my end.