### PR TITLE
Tweak to CMakeLists

### DIFF
--- a/indra/newview/CMakeLists.txt
+++ b/indra/newview/CMakeLists.txt
@@ -2831,7 +2831,7 @@ if (DARWIN)
     OUTPUT_NAME "${product}"
     # From Contents/MacOS/SecondLife, look in Contents/Frameworks
     BUILD_WITH_INSTALL_RPATH 1
-    INSTALL_RPATH "@executable_path/../Frameworks"
+    INSTALL_RPATH "@executable_path/../Frameworks;@executable_path/../Resources"
     MACOSX_BUNDLE_INFO_PLIST "${CMAKE_CURRENT_SOURCE_DIR}/Info-Firestorm.plist"
     XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER "${MACOSX_BUNDLE_GUI_IDENTIFIER}"
     )


### PR DESCRIPTION
Allows fmod to be found in the correct location on my self compiles. Others have reported no issues, but this sorts it for me with the most minor of changes.

## Firestorm Pull Request Checklist
Thank you for contributing to the Phoenix Firestorm Project.
We will endeavour to review you changes and accept/reject/request changes as soon as possible. 
Please read and follow the [Firestorm Pull Request Guidelines](https://github.com/firestormviewer/phoenix-firestorm/blob/master/CONTRIBUTING.md) to reduce the likelihood that we need to ask for "Bureaucratic" changes to make the code comply with our workflows.
