### PR TITLE
Restore Now Playing stream metadata (artist/title in nearby chat)

### DIFF
--- a/indra/media_plugins/libvlc/media_plugin_libvlc.cpp
+++ b/indra/media_plugins/libvlc/media_plugin_libvlc.cpp
@@ -67,6 +67,9 @@ private:
     void setVolume(const F64 volume);
     void setVolumeVLC();
     void updateTitle(const char* title);
+    void updateStreamMetadata(int meta_type);
+
+    std::string mLastMetadataSent;
 
     static void* lock(void* data, void** p_pixels);
     static void unlock(void* data, void* id, void* const* raw_pixels);
@@ -171,6 +174,12 @@ void MediaPluginLibVLC::initVLC()
     {
         "--no-xlib",
         "--video-filter=transform{type=vflip}",  // MAINT-6578 Y flip textures in plugin vs client
+#if defined(__FreeBSD__)
+        // FreeBSD's VLC build ships only the OSS audio output (no PulseAudio
+        // module), so pin it explicitly; it coexists with the viewer's own OSS
+        // audio engine via the kernel's vchan mixing.
+        "--aout=oss",
+#endif
     };
 
 #if LL_DARWIN
@@ -294,6 +303,20 @@ void MediaPluginLibVLC::eventCallbacks(const libvlc_event_t* event, void* ptr)
         }
     }
     break;
+
+    // <FS:ND> Report ICY/stream metadata (song title/artist) to the viewer
+    case libvlc_MediaMetaChanged:
+    {
+        libvlc_meta_t meta_type = event->u.media_meta_changed.meta_type;
+        if (meta_type == libvlc_meta_NowPlaying ||
+            meta_type == libvlc_meta_Title ||
+            meta_type == libvlc_meta_Artist)
+        {
+            parent->updateStreamMetadata(meta_type);
+        }
+    }
+    break;
+    // </FS:ND>
     }
 }
 
@@ -349,6 +372,15 @@ void MediaPluginLibVLC::playMedia()
         libvlc_event_attach(em, libvlc_MediaPlayerTitleChanged, eventCallbacks, this);
     }
 
+    // <FS:ND> Stream metadata (ICY StreamTitle etc.) arrives on the media's
+    // own event manager, not the player's
+    libvlc_event_manager_t* mem = libvlc_media_event_manager(mLibVLCMedia);
+    if (mem)
+    {
+        libvlc_event_attach(mem, libvlc_MediaMetaChanged, eventCallbacks, this);
+    }
+    // </FS:ND>
+
     libvlc_video_set_callbacks(mLibVLCMediaPlayer, lock, unlock, display, &mLibVLCCallbackContext);
     libvlc_video_set_format(mLibVLCMediaPlayer, "RV32", mWidth, mHeight, mWidth * mDepth);
 
@@ -380,6 +412,18 @@ void MediaPluginLibVLC::playMedia()
         libvlc_media_add_option(mLibVLCMedia, "input-repeat=65535");
     }
 
+    // <FS> The streaming-audio instance is created 1x1 with no visible
+    // surface. Radio doesn't care about latency, and SLPlugin runs at
+    // background priority where VLC's default ~1s network cache underruns
+    // (audible pops/thuds) whenever the viewer loads the machine — buffer
+    // deep. Visible parcel media keeps the default for responsiveness.
+    if (mWidth <= 1 && mHeight <= 1)
+    {
+        libvlc_media_add_option(mLibVLCMedia, ":network-caching=5000");
+        libvlc_media_add_option(mLibVLCMedia, ":no-video");
+    }
+    // </FS>
+
     libvlc_media_player_play(mLibVLCMediaPlayer);
 
     // send a "location_changed" message - this informs the media system
@@ -409,6 +453,87 @@ void MediaPluginLibVLC::updateTitle(const char* title)
     message.setValue("name", title);
     sendMessage(message);
 }
+
+// <FS:ND> Report stream metadata to the viewer, same message the gstreamer
+// plugin sends. Which meta field carries the track depends on the stream:
+// MP3/AAC ICY updates arrive in NowPlaying ("Artist - Title"), while
+// Ogg/Icecast chains update Title/Artist from in-band Vorbis comments (and
+// often park the static station name in NowPlaying, so a fixed precedence
+// would mask per-track updates). React to the field that actually changed.
+void MediaPluginLibVLC::updateStreamMetadata(int meta_type)
+{
+    if (!mLibVLCMedia)
+    {
+        return;
+    }
+
+    std::string artist;
+    std::string title;
+
+    if (meta_type == libvlc_meta_NowPlaying)
+    {
+        char* meta = libvlc_media_get_meta(mLibVLCMedia, libvlc_meta_NowPlaying);
+        if (meta)
+        {
+            std::string now_playing = meta;
+            libvlc_free(meta);
+
+            size_t sep = now_playing.find(" - ");
+            if (sep != std::string::npos)
+            {
+                artist = now_playing.substr(0, sep);
+                title = now_playing.substr(sep + 3);
+            }
+            else
+            {
+                title = now_playing;
+            }
+        }
+    }
+    else // Title or Artist changed
+    {
+        char* meta = libvlc_media_get_meta(mLibVLCMedia, libvlc_meta_Artist);
+        if (meta)
+        {
+            artist = meta;
+            libvlc_free(meta);
+        }
+
+        meta = libvlc_media_get_meta(mLibVLCMedia, libvlc_meta_Title);
+        if (meta)
+        {
+            title = meta;
+            libvlc_free(meta);
+        }
+
+        // Before any real meta arrives VLC uses the URL's filename as the
+        // title placeholder; that is not worth announcing
+        if (artist.empty() && !title.empty() && mURL.find(title) != std::string::npos)
+        {
+            return;
+        }
+    }
+
+    if (artist.empty() && title.empty())
+    {
+        return;
+    }
+
+    // Both metas of a track boundary land before the first event is
+    // delivered, so Title and Artist events would send the same pair twice
+    std::string dedup_key = artist + "\x01" + title;
+    if (dedup_key == mLastMetadataSent)
+    {
+        return;
+    }
+    mLastMetadataSent = dedup_key;
+
+    LLPluginMessage message(LLPLUGIN_MESSAGE_CLASS_MEDIA, "ndMediadata_change");
+    message.setValue("title", title);
+    message.setValue("artist", artist);
+    sendMessage(message);
+}
+// </FS:ND>
 
 void MediaPluginLibVLC::setVolumeVLC()
 {

--- a/indra/newview/llviewermedia_streamingaudio.cpp
+++ b/indra/newview/llviewermedia_streamingaudio.cpp
@@ -35,8 +35,17 @@
 #include "llmimetypes.h"
 #include "lldir.h"
 
+// <FS> Icecast status sidechannel
+#include "llaudioengine.h"
+#include "llcorehttputil.h"
+#include "llcoros.h"
+// </FS>
+
 LLStreamingAudio_MediaPlugins::LLStreamingAudio_MediaPlugins() :
     mMediaPlugin(NULL),
+    mStatusValid(false),
+    mStatusPollDone(false),
+    mStatusProbeFails(0),
     mGain(1.0)
 {
     // nothing interesting to do?
@@ -65,6 +74,7 @@ void LLStreamingAudio_MediaPlugins::start(const std::string& url)
         LL_INFOS() << "Starting internet stream: " << url << LL_ENDL;
 
         mURL = url; // keep original url here for comparison purposes
+        resetMetadata(); // <FS/>
         std::string snt_url = url;
         LLStringUtil::trim(snt_url);
         size_t pos = snt_url.find(' ');
@@ -101,7 +111,7 @@ void LLStreamingAudio_MediaPlugins::stop()
     mURL.clear();
 
     // <FS:Ansariel> Stream meta data display
-    updateMetadata();
+    resetMetadata();
 }
 
 void LLStreamingAudio_MediaPlugins::pause(int pause)
@@ -189,20 +199,259 @@ LLPluginClassMedia* LLStreamingAudio_MediaPlugins::initializeMedia(const std::st
 // <FS:ND> stream metadata from plugin
 void LLStreamingAudio_MediaPlugins::updateMetadata() noexcept
 {
-    if (!mMediaPlugin)
+    if (mMediaPlugin &&
+        (mPluginTitle != mMediaPlugin->getTitle() || mPluginArtist != mMediaPlugin->getArtist()))
+    {
+        mPluginArtist = mMediaPlugin->getArtist();
+        mPluginTitle = mMediaPlugin->getTitle();
+
+        // The status sidechannel wins once it has delivered track data for
+        // this stream; in-band data only reaches the user until then
+        if (!mStatusValid)
+        {
+            emitMetadata(mPluginArtist, mPluginTitle);
+        }
+    }
+
+    pollStreamStatus();
+}
+// </FS:ND>
+
+// <FS> Icecast status sidechannel
+void LLStreamingAudio_MediaPlugins::resetMetadata()
+{
+    mArtist.clear();
+    mTitle.clear();
+    mPluginArtist.clear();
+    mPluginTitle.clear();
+    mStatusUrl.clear();
+    mMetadata.clear();
+    mStatusValid = false;
+    mStatusPollDone = false;
+    mStatusProbeFails = 0;
+    mStatusPollTimer.reset();
+}
+
+void LLStreamingAudio_MediaPlugins::emitMetadata(const std::string& artist, const std::string& title)
+{
+    if (artist == mArtist && title == mTitle)
     {
         return;
     }
 
-    if (mTitle != mMediaPlugin->getTitle() || mArtist != mMediaPlugin->getArtist())
-    {
-        mArtist = mMediaPlugin->getArtist();
-        mTitle = mMediaPlugin->getTitle();
-        mMetadata.clear();
-        mMetadata["ARTIST"] = mArtist;
-        mMetadata["TITLE"] = mTitle;
+    mArtist = artist;
+    mTitle = title;
+    mMetadata.clear();
+    mMetadata["ARTIST"] = mArtist;
+    mMetadata["TITLE"] = mTitle;
 
-        mMetadataUpdateSignal(mMetadata);
-    }
+    LL_INFOS("StreamMetadata") << "Stream metadata changed: artist='" << mArtist
+                               << "' title='" << mTitle << "'" << LL_ENDL;
+
+    mMetadataUpdateSignal(mMetadata);
 }
-// </FS:ND>
+
+// Many stream servers (Icecast, AzuraCast, ...) publish per-mount metadata
+// at /status-json.xsl regardless of codec. This is the only reliable track
+// source for chained-Ogg streams, whose in-band Vorbis comments libVLC does
+// not surface.
+void LLStreamingAudio_MediaPlugins::pollStreamStatus()
+{
+    const F32 FIRST_POLL_DELAY = 5.f;
+    const F32 POLL_INTERVAL = 20.f;
+    const S32 MAX_PROBE_FAILS = 3;
+
+    if (mURL.empty() || !mMediaPlugin || isPlaying() != 1)
+    {
+        return;
+    }
+
+    if (mStatusProbeFails >= MAX_PROBE_FAILS)
+    {
+        return; // this server has no reachable status endpoint; stop asking
+    }
+
+    F32 threshold = POLL_INTERVAL;
+    if (!mStatusPollDone)
+    {
+        threshold = FIRST_POLL_DELAY;
+    }
+    if (mStatusPollTimer.getElapsedTimeF32() < threshold)
+    {
+        return;
+    }
+    mStatusPollDone = true;
+    mStatusPollTimer.reset();
+
+    size_t scheme_end = mURL.find("://");
+    if (scheme_end == std::string::npos)
+    {
+        return;
+    }
+    size_t path_start = mURL.find('/', scheme_end + 3);
+    std::string base;
+    std::string mount;
+    if (path_start == std::string::npos)
+    {
+        base = mURL;
+    }
+    else
+    {
+        base = mURL.substr(0, path_start);
+        mount = mURL.substr(path_start);
+    }
+
+    LLSD candidates = LLSD::emptyArray();
+    if (!mStatusUrl.empty())
+    {
+        // A previous poll found the endpoint; keep using it
+        candidates.append(mStatusUrl);
+    }
+    else
+    {
+        // The status document sits at the Icecast root, which reverse
+        // proxies (AzuraCast et al.) mount at a subpath rather than the
+        // server root. Walk the mount path upward, most specific first:
+        // /listen/station/radio.ogg -> /listen/station/status-json.xsl,
+        // /listen/status-json.xsl, /status-json.xsl
+        std::string path = mount;
+        while (true)
+        {
+            size_t last_slash = path.rfind('/');
+            if (last_slash == std::string::npos)
+            {
+                break;
+            }
+            path = path.substr(0, last_slash);
+            candidates.append(base + path + "/status-json.xsl");
+            if (path.empty())
+            {
+                break;
+            }
+        }
+        if (candidates.size() == 0)
+        {
+            candidates.append(base + "/status-json.xsl");
+        }
+    }
+
+    LLCoros::instance().launch("StreamStatusPoll",
+        boost::bind(&LLStreamingAudio_MediaPlugins::streamStatusCoro,
+                    this, candidates, mount, mURL));
+}
+
+// static
+void LLStreamingAudio_MediaPlugins::streamStatusCoro(LLStreamingAudio_MediaPlugins* self,
+    LLSD candidates, std::string mount_path, std::string stream_url)
+{
+    LLCore::HttpRequest::policy_t httpPolicy(LLCore::HttpRequest::DEFAULT_POLICY_ID);
+    LLCoreHttpUtil::HttpCoroutineAdapter::ptr_t httpAdapter(
+        new LLCoreHttpUtil::HttpCoroutineAdapter("StreamStatusPoll", httpPolicy));
+    LLCore::HttpRequest::ptr_t httpRequest(new LLCore::HttpRequest);
+
+    LLSD result;
+    std::string status_url;
+    bool got_status = false;
+    for (LLSD::array_const_iterator cand = candidates.beginArray(); cand != candidates.endArray(); ++cand)
+    {
+        status_url = cand->asString();
+        result = httpAdapter->getJsonAndSuspend(httpRequest, status_url);
+
+        LLSD httpResults = result[LLCoreHttpUtil::HttpCoroutineAdapter::HTTP_RESULTS];
+        if (httpResults[LLCoreHttpUtil::HttpCoroutineAdapter::HTTP_RESULTS_SUCCESS].asBoolean() &&
+            result.has("icestats"))
+        {
+            got_status = true;
+            break;
+        }
+    }
+
+    // The streaming impl outlives the coroutine in normal operation, but
+    // guard against shutdown and stream changes while the requests ran
+    if (!gAudiop || gAudiop->getStreamingAudioImpl() != (LLStreamingAudioInterface*)self ||
+        self->getURL() != stream_url)
+    {
+        return;
+    }
+
+    if (!got_status)
+    {
+        self->onStreamStatusFailed();
+        return;
+    }
+
+    // icestats.source is a map for a single mount, an array for several
+    LLSD sources = result["icestats"]["source"];
+    LLSD source;
+    if (sources.isArray())
+    {
+        for (LLSD::array_const_iterator it = sources.beginArray(); it != sources.endArray(); ++it)
+        {
+            std::string listenurl = (*it)["listenurl"].asString();
+            size_t mount_pos = listenurl.rfind(mount_path);
+            if (!mount_path.empty() && mount_pos != std::string::npos &&
+                mount_pos + mount_path.size() == listenurl.size())
+            {
+                source = *it;
+                break;
+            }
+        }
+        if (source.isUndefined() && sources.size() == 1)
+        {
+            source = sources[0];
+        }
+    }
+    else if (sources.isMap())
+    {
+        source = sources;
+    }
+
+    if (source.isUndefined())
+    {
+        return;
+    }
+
+    std::string artist = source["artist"].asString();
+    std::string title = source["title"].asString();
+
+    // Some servers publish a combined "Artist - Title" string
+    if (artist.empty())
+    {
+        size_t sep = title.find(" - ");
+        if (sep != std::string::npos)
+        {
+            artist = title.substr(0, sep);
+            title = title.substr(sep + 3);
+        }
+    }
+
+    self->onStreamStatus(artist, title, status_url);
+}
+
+void LLStreamingAudio_MediaPlugins::onStreamStatus(const std::string& artist, const std::string& title, const std::string& status_url)
+{
+    if (mStatusUrl != status_url)
+    {
+        LL_INFOS("StreamMetadata") << "Using stream status endpoint " << status_url << LL_ENDL;
+        mStatusUrl = status_url;
+    }
+    mStatusProbeFails = 0;
+
+    if (artist.empty() && title.empty())
+    {
+        return;
+    }
+
+    mStatusValid = true;
+    emitMetadata(artist, title);
+}
+
+void LLStreamingAudio_MediaPlugins::onStreamStatusFailed()
+{
+    // A previously working endpoint failing may be transient; forget it and
+    // re-probe. Repeated full-probe failures disable the sidechannel for
+    // this stream.
+    mStatusUrl.clear();
+    ++mStatusProbeFails;
+}
+// </FS>

--- a/indra/newview/llviewermedia_streamingaudio.h
+++ b/indra/newview/llviewermedia_streamingaudio.h
@@ -32,6 +32,7 @@
 #include "stdtypes.h" // from llcommon
 
 #include "llstreamingaudio.h"
+#include "lltimer.h"
 
 class LLPluginClassMedia;
 
@@ -63,11 +64,31 @@ private:
 
     // <FS:ND> stream metadata from plugin
     void updateMetadata() noexcept;
-
-    std::string mArtist;
-    std::string mTitle;
-    LLSD mMetadata;
     // </FS:ND>
+
+    // <FS> Stream metadata. Two sources feed it: in-band metadata surfaced
+    // by the media plugin (ICY etc.), and the stream server's Icecast
+    // status-json.xsl sidechannel, which also works where VLC does not
+    // surface in-band data (chained Ogg). The sidechannel wins once it has
+    // delivered data for the current stream.
+    void emitMetadata(const std::string& artist, const std::string& title);
+    void pollStreamStatus();
+    void onStreamStatus(const std::string& artist, const std::string& title, const std::string& status_url);
+    void onStreamStatusFailed();
+    static void streamStatusCoro(LLStreamingAudio_MediaPlugins* self, LLSD candidates, std::string mount_path, std::string stream_url);
+    void resetMetadata();
+
+    std::string mArtist;        // last emitted pair
+    std::string mTitle;
+    std::string mPluginArtist;  // last seen from the media plugin
+    std::string mPluginTitle;
+    std::string mStatusUrl;     // status endpoint that answered for this stream
+    bool mStatusValid;          // sidechannel has delivered data for this stream
+    bool mStatusPollDone;       // first poll fired (shorter initial delay)
+    S32 mStatusProbeFails;      // consecutive all-candidate failures; gives up at limit
+    LLTimer mStatusPollTimer;
+    LLSD mMetadata;
+    // </FS>
 
     F32 mGain;
 };


### PR DESCRIPTION
## Firestorm Pull Request Checklist
Thank you for contributing to the Phoenix Firestorm Project.
We will endeavour to review you changes and accept/reject/request changes as soon as possible. 
Please read and follow the [Firestorm Pull Request Guidelines](https://github.com/firestormviewer/phoenix-firestorm/blob/master/CONTRIBUTING.md) to reduce the likelihood that we need to ask for "Bureaucratic" changes to make the code comply with our workflows.

## Description

Restores "Now Playing" stream metadata so the currently-playing track's artist/title is shown in local/nearby chat again.

The media-plugin streaming path (`LLStreamingAudio_MediaPlugins`) only surfaced ICY title/artist when libVLC exposed in-band metadata. Chained-Ogg and many Icecast/AzuraCast streams don't surface it, so stream metadata in nearby chat went silent for those. This restores both the in-band path and a server-status fallback, plus the viewer-side emitter that feeds the chat display.

Changes:

- **Viewer receiver/emitter** (`indra/newview/llviewermedia_streamingaudio.{cpp,h}`): `emitMetadata`/`resetMetadata` emit the deduplicated `ARTIST`/`TITLE` pair on `mMetadataUpdateSignal` (the existing chat receiver subscribes to it). The Icecast `status-json.xsl` sidechannel polls the stream server's status JSON, walking the mount path upward (handles AzuraCast subpath mounts) and parsing `icestats.source`; it wins once it has delivered data for the stream, with in-band data used until then. Polling gives up after 3 failed probes so servers without a status endpoint aren't polled forever.
- **libVLC in-band ICY sender** (`indra/media_plugins/libvlc/media_plugin_libvlc.cpp`): handle `libvlc_MediaMetaChanged`, parse `Artist - Title`, dedup, and send `ndMediadata_change` to the viewer (the MP3/AAC path). Also restores the streaming-audio buffering fix (deep network-caching + no-video for the 1×1 radio instance, so a background-priority SLPlugin doesn't underrun) and pins `--aout=oss` on FreeBSD (which ships no PulseAudio module).

All changes are inside existing `<FS>` comment blocks or are new code wrapped in `<FS>` tags; modified lines preserve the prior code per the comment-tag convention.

(Supersedes #282, which was based on a branch that also carried unrelated renderer work; this branch is off upstream master with only the metadata commit.)

## Testing

- Build: 0 errors (Windows 64-bit). The receiver emitter + status sidechannel are compiled into the viewer binary; the `ndMediadata` sender into `media_plugin_libvlc.dll`.
- In-world: on a parcel with a streaming-audio URL (Icecast/MP3 or chained-Ogg/AzuraCast), the current track's artist/title appears in nearby chat and updates on track change. Verified on both an MP3 (in-band) stream and an Ogg stream that only exposes metadata via the status sidechannel.