### PR TITLE
Interleave rigged and world alpha draw calls back-to-front (port of secondlife/viewer#5927)

### DIFF
--- a/indra/newview/app_settings/settings.xml
+++ b/indra/newview/app_settings/settings.xml
@@ -11397,6 +11397,17 @@ Change of this parameter will affect the layout of buttons in notification toast
       <key>Backup</key>
       <integer>0</integer>
     </map>
+    <key>RenderInterleavedAlpha</key>
+    <map>
+      <key>Comment</key>
+      <string>Depth-interleave rigged attachment alpha with the distance-sorted world alpha so transparent objects composite correctly both in front of and behind avatars. Disable to restore two-pass (all rigged first) order.</string>
+      <key>Persist</key>
+      <integer>1</integer>
+      <key>Type</key>
+      <string>Boolean</string>
+      <key>Value</key>
+      <integer>1</integer>
+    </map>
     <key>RenderDebugGLSession</key>
     <map>
       <key>Comment</key>

--- a/indra/newview/llcontrolavatar.cpp
+++ b/indra/newview/llcontrolavatar.cpp
@@ -369,6 +369,22 @@ void LLControlAvatar::idleUpdate(LLAgent &agent, const F64 &time)
     else
     {
         LLVOAvatar::idleUpdate(agent,time);
+
+        // <FS> stamp the animesh bridge like LLVOAvatar::idleUpdateMisc stamps
+        // attachments. Worn animesh is skipped: the wearer's loop stamps this
+        // same bridge with its own depth and order. Bridge fetched from the
+        // drawable -- mControlAVBridge can go stale (see markForDeath).
+        if (mRootVolp && mRootVolp->mDrawable && !getAttachedAvatar())
+        {
+            LLSpatialBridge* bridge = mRootVolp->mDrawable->getSpatialBridge();
+            if (bridge)
+            {
+                bridge->mAvatarp = this;
+                bridge->mRenderOrder = 0;
+                bridge->mAvatarDepth = calcRiggedAlphaDepth();
+            }
+        }
+        // </FS>
     }
 }
 

--- a/indra/newview/lldrawpoolalpha.cpp
+++ b/indra/newview/lldrawpoolalpha.cpp
@@ -26,6 +26,8 @@
 
 #include "llviewerprecompiledheaders.h"
 
+#include <optional>
+
 #include "lldrawpoolalpha.h"
 
 #include "llglheaders.h"
@@ -163,6 +165,17 @@ void LLDrawPoolAlpha::renderPostDeferred(S32 pass)
     // prepare shaders
     llassert(LLPipeline::sRenderDeferred);
 
+    // <FS> interleave rigged + world alpha for the post-water world pass
+    const bool interleave = LLPipeline::canUseInterleavedAlpha() &&
+                            getType() == LLDrawPool::POOL_ALPHA_POST_WATER;
+    if (interleave)
+    {
+        // postSort deliberately leaves the shared lists in legacy order for
+        // pre-water; switch them only for the consumer that performs the merge
+        gPipeline.sortAlphaGroupsForInterleaving();
+    }
+    // </FS>
+
     emissive_shader = &gDeferredEmissiveProgram;
     prepare_alpha_shader(emissive_shader, false, water_sign);
 
@@ -199,14 +212,27 @@ void LLDrawPoolAlpha::renderPostDeferred(S32 pass)
     // already being setup for rendering
     LLGLSLShader::unbind();
 
-    if (!LLPipeline::sRenderingHUDs)
+    // <FS>
+    if (interleave)
     {
-        // first pass, render rigged objects only and render to depth buffer
-        forwardRender(true);
+        // single pass: depth-interleave whole avatars with the distance-sorted
+        // alpha groups so world alpha composites correctly around avatars.
+        // The centralized eligibility gate limits the merged walk to the world
+        // camera; HUD, cube, and reflection renders keep legacy two-pass order.
+        forwardRender(EAlphaStream::INTERLEAVED);
     }
+    else
+    {
+        if (!LLPipeline::sRenderingHUDs)
+        {
+            // first pass, render rigged objects only and render to depth buffer
+            forwardRender(EAlphaStream::RIGGED);
+        }
 
-    // second pass, regular forward alpha rendering
-    forwardRender();
+        // second pass, regular forward alpha rendering
+        forwardRender();
+    }
+    // </FS>
 
     // final pass, render to depth for depth of field effects
     if (!LLPipeline::sImpostorRender && LLPipeline::RenderDepthOfField && !gCubeSnapshot && !LLPipeline::sRenderingHUDs && getType() == LLDrawPool::POOL_ALPHA_POST_WATER)
@@ -229,7 +255,9 @@ void LLDrawPoolAlpha::renderPostDeferred(S32 pass)
     }
 }
 
-void LLDrawPoolAlpha::forwardRender(bool rigged)
+// <FS> void LLDrawPoolAlpha::forwardRender(bool rigged)
+void LLDrawPoolAlpha::forwardRender(EAlphaStream stream)
+// </FS>
 {
     gPipeline.enableLightsDynamic();
 
@@ -238,7 +266,9 @@ void LLDrawPoolAlpha::forwardRender(bool rigged)
     //enable writing to alpha for emissive effects
     gGL.setColorMask(true, true);
 
-    bool write_depth = rigged ||
+    // <FS> bool write_depth = rigged ||
+    bool write_depth = stream == EAlphaStream::RIGGED ||
+    // </FS>
         LLDrawPoolWater::sSkipScreenCopy
         // we want depth written so that rendered alpha will
         // contribute to the alpha mask used for impostors
@@ -246,7 +276,9 @@ void LLDrawPoolAlpha::forwardRender(bool rigged)
         || getType() == LLDrawPoolAlpha::POOL_ALPHA_PRE_WATER; // needed for accurate water fog
 
 
-    LLGLDepthTest depth(GL_TRUE, write_depth ? GL_TRUE : GL_FALSE);
+    // <FS> in interleaved mode depth writes are decided per group inside renderAlpha
+    LLGLDepthTest depth(GL_TRUE, (write_depth && stream != EAlphaStream::INTERLEAVED) ? GL_TRUE : GL_FALSE);
+    // </FS>
 
     mColorSFactor = LLRender::BF_SOURCE_ALPHA;           // } regular alpha blend
     mColorDFactor = LLRender::BF_ONE_MINUS_SOURCE_ALPHA; // }
@@ -254,8 +286,14 @@ void LLDrawPoolAlpha::forwardRender(bool rigged)
     mAlphaDFactor = LLRender::BF_ONE_MINUS_SOURCE_ALPHA;       // }
     gGL.blendFunc(mColorSFactor, mColorDFactor, mAlphaSFactor, mAlphaDFactor);
 
-    if (rigged && mType == LLDrawPool::POOL_ALPHA_POST_WATER)
+    // <FS> if (rigged && mType == LLDrawPool::POOL_ALPHA_POST_WATER)
+    if (stream != EAlphaStream::WORLD && mType == LLDrawPool::POOL_ALPHA_POST_WATER)
+    // </FS>
     { // draw GLTF scene to depth buffer before rigged alpha
+        // <FS> (explicit depth-write scope: in interleaved mode the pass-wide depth
+        // state above has writes off)
+        LLGLDepthTest gltf_depth(GL_TRUE, GL_TRUE);
+        // </FS>
         LL::GLTFSceneManager::instance().render(false, false);
         LL::GLTFSceneManager::instance().render(false, true);
         LL::GLTFSceneManager::instance().render(false, false, true);
@@ -264,11 +302,13 @@ void LLDrawPoolAlpha::forwardRender(bool rigged)
 
     // If the face is more than 90% transparent, then don't update the Depth buffer for Dof
     // We don't want the nearly invisible objects to cause of DoF effects
-    renderAlpha(getVertexDataMask() | LLVertexBuffer::MAP_TEXTURE_INDEX | LLVertexBuffer::MAP_TANGENT | LLVertexBuffer::MAP_TEXCOORD1 | LLVertexBuffer::MAP_TEXCOORD2, false, rigged);
+    renderAlpha(getVertexDataMask() | LLVertexBuffer::MAP_TEXTURE_INDEX | LLVertexBuffer::MAP_TANGENT | LLVertexBuffer::MAP_TEXCOORD1 | LLVertexBuffer::MAP_TEXCOORD2, false, stream);
 
     gGL.setColorMask(true, false);
 
-    if (!rigged && (LLPipeline::sRenderingHUDs || getType() == LLDrawPoolAlpha::POOL_ALPHA_POST_WATER))
+    // <FS> if (!rigged && (LLPipeline::sRenderingHUDs || getType() == LLDrawPoolAlpha::POOL_ALPHA_POST_WATER))
+    if (stream != EAlphaStream::RIGGED && (LLPipeline::sRenderingHUDs || getType() == LLDrawPoolAlpha::POOL_ALPHA_POST_WATER))
+    // </FS>
     { //render "highlight alpha" on final non-rigged pass for non-HUDs (HUDs only run pre-water alpha pass)
         // NOTE -- hacky call here protected by !rigged instead of alongside "forwardRender"
         // so renderDebugAlpha is executed while gls_pipeline_alpha and depth GL state
@@ -580,9 +620,15 @@ void LLDrawPoolAlpha::renderRiggedPbrEmissives(std::vector<LLDrawInfo*>& emissiv
     }
 }
 
-void LLDrawPoolAlpha::renderAlpha(U32 mask, bool depth_only, bool rigged)
+// <FS> void LLDrawPoolAlpha::renderAlpha(U32 mask, bool depth_only, bool rigged)
+void LLDrawPoolAlpha::renderAlpha(U32 mask, bool depth_only, EAlphaStream stream)
+// </FS>
 {
     LL_PROFILE_ZONE_SCOPED_CATEGORY_DRAWPOOL;
+    // <FS> merged mode walks both streams; stream flips per group
+    const bool merged = stream == EAlphaStream::INTERLEAVED;
+    bool rigged = stream == EAlphaStream::RIGGED;
+    // </FS>
     bool initialized_lighting = false;
     bool light_enabled = true;
 
@@ -591,19 +637,24 @@ void LLDrawPoolAlpha::renderAlpha(U32 mask, bool depth_only, bool rigged)
     const LLGLSLShader* lastAvatarShader = nullptr;
     bool skipLastSkin = false;
 
-    LLCullResult::sg_iterator begin;
-    LLCullResult::sg_iterator end;
+    // <FS> dual iterators for the merged walk
+    LLCullResult::sg_iterator iter = nullptr;
+    LLCullResult::sg_iterator iter_end = nullptr;
+    LLCullResult::sg_iterator rigged_iter = nullptr;
+    LLCullResult::sg_iterator rigged_end = nullptr;
 
-    if (rigged)
+    if (merged || rigged)
     {
-        begin = gPipeline.beginRiggedAlphaGroups();
-        end = gPipeline.endRiggedAlphaGroups();
+        rigged_iter = gPipeline.beginRiggedAlphaGroups();
+        rigged_end = gPipeline.endRiggedAlphaGroups();
     }
-    else
+
+    if (merged || !rigged)
     {
-        begin = gPipeline.beginAlphaGroups();
-        end = gPipeline.endAlphaGroups();
+        iter = gPipeline.beginAlphaGroups();
+        iter_end = gPipeline.endAlphaGroups();
     }
+    // </FS>
 
     LLEnvironment& env = LLEnvironment::instance();
     F32 water_height = env.getWaterHeight();
@@ -614,11 +665,61 @@ void LLDrawPoolAlpha::renderAlpha(U32 mask, bool depth_only, bool rigged)
         above_water = !above_water;
     }
 
+    // <FS> depth-write conditions that apply to every group in this pass; in merged
+    // mode, stamped rigged groups additionally write depth (see below)
+    const bool write_depth_always = LLDrawPoolWater::sSkipScreenCopy ||
+                                    LLPipeline::sImpostorRenderAlphaDepthPass ||
+                                    getType() == LLDrawPoolAlpha::POOL_ALPHA_PRE_WATER;
 
-    for (LLCullResult::sg_iterator i = begin; i != end; ++i)
+    // merged mode: per-group depth-write guard, re-emplaced only when the
+    // write state changes (one glDepthMask per run, not per group)
+    std::optional<LLGLDepthTest> depth_state;
+    bool depth_state_writes = false;
+    // </FS>
+
+    // <FS> for (LLCullResult::sg_iterator i = begin; i != end; ++i)
+    while (iter != iter_end || rigged_iter != rigged_end)
+    // </FS>
     {
         LL_PROFILE_ZONE_NAMED_CATEGORY_DRAWPOOL("renderAlpha - group");
-        LLSpatialGroup* group = *i;
+        // <FS> in merged mode, take the farther of the two stream heads; an
+        // ensemble's groups share one avatar depth, so each avatar drains
+        // contiguously -- rigged run first (ties go rigged), then its unrigged
+        // attachment groups, which composite over it
+        if (merged)
+        {
+            if (rigged_iter == rigged_end)
+            {
+                rigged = false;
+            }
+            else if (iter == iter_end)
+            {
+                rigged = true;
+            }
+            else
+            {
+                F32 rigged_depth = (*rigged_iter)->mAvatarDepth;
+                F32 world_depth = (*iter)->worldAlphaDepth();
+                if (rigged_depth != world_depth)
+                {
+                    rigged = rigged_depth > world_depth;
+                }
+                else
+                {
+                    // equal depth: keep each avatar's ensemble contiguous. Its
+                    // own rigged draws before its own unrigged; a plain world
+                    // group composites over it (rigged first); two coincident
+                    // avatars drain in the sorts' std::less identity order.
+                    const LLVOAvatar* world_av = (*iter)->mAvatarp;
+                    const LLVOAvatar* rigged_av = (*rigged_iter)->mAvatarp;
+                    rigged = !rigged_av || !world_av || world_av == rigged_av ||
+                             std::less<const LLVOAvatar*>()(rigged_av, world_av);
+                }
+            }
+        }
+
+        LLSpatialGroup* group = rigged ? *rigged_iter++ : *iter++;
+        // </FS>
         llassert(group);
         llassert(group->getSpatialPartition());
 
@@ -646,6 +747,21 @@ void LLDrawPoolAlpha::renderAlpha(U32 mask, bool depth_only, bool rigged)
                     }
                 }
             }
+
+            // <FS> merged mode: stamped rigged groups write depth so attachment-order
+            // layering holds; an unstamped group has no defined position in the
+            // rigged order and must not depth-reject geometry behind it (it
+            // still blends). Non-merged passes keep the caller's depth state.
+            if (merged)
+            {
+                bool write_depth = write_depth_always || (rigged && group->mAvatarp != nullptr);
+                if (!depth_state || write_depth != depth_state_writes)
+                {
+                    depth_state.emplace(GL_TRUE, write_depth ? GL_TRUE : GL_FALSE);
+                    depth_state_writes = write_depth;
+                }
+            }
+            // </FS>
 
             static std::vector<LLDrawInfo*> emissives;
             static std::vector<LLDrawInfo*> rigged_emissives;

--- a/indra/newview/lldrawpoolalpha.h
+++ b/indra/newview/lldrawpoolalpha.h
@@ -58,13 +58,26 @@ public:
     /*virtual*/ void renderPostDeferred(S32 pass);
     /*virtual*/ S32  getNumPasses() { return 1; }
 
-    void forwardRender(bool write_depth = false);
+    // <FS> which alpha stream(s) a pass draws
+    enum class EAlphaStream
+    {
+        WORLD,      // the distance-sorted alpha groups
+        RIGGED,     // the rigged alpha groups only (depth-writing prepass)
+        INTERLEAVED // both streams in one back-to-front walk; depth writes
+                    // decided per group inside renderAlpha
+    };
+
+    // void forwardRender(bool write_depth = false);
+    void forwardRender(EAlphaStream stream = EAlphaStream::WORLD);
+    // </FS>
     /*virtual*/ void prerender();
 
     void renderDebugAlpha();
 
     void renderGroupAlpha(LLSpatialGroup* group, U32 type, U32 mask, bool texture = true);
-    void renderAlpha(U32 mask, bool depth_only = false, bool rigged = false);
+    // <FS> void renderAlpha(U32 mask, bool depth_only = false, bool rigged = false);
+    void renderAlpha(U32 mask, bool depth_only = false, EAlphaStream stream = EAlphaStream::WORLD);
+    // </FS>
     void renderAlphaHighlight();
 
     static bool sShowDebugAlpha;

--- a/indra/newview/llspatialpartition.h
+++ b/indra/newview/llspatialpartition.h
@@ -46,6 +46,7 @@
 //<FS:Beq> needed to resolve render_hull dep
 #include "llmodel.h"
 //</FS:Beq>
+#include <functional>
 #include <queue>
 #include <unordered_map>
 
@@ -249,18 +250,96 @@ public:
         }
     };
 
+    // <FS> interleaved world-alpha sort key: a stamped attachment's groups
+    // sort at the wearer's avatar depth, everything else at bounds depth
+    F32 worldAlphaDepth() const { return mAvatarp ? mAvatarDepth : mDepth; }
+
+    struct CompareWorldAlphaDepth
+    {
+        bool operator()(const LLSpatialGroup* const& lhs, const LLSpatialGroup* const& rhs)
+        {
+            F32 lhs_depth = lhs->worldAlphaDepth();
+            F32 rhs_depth = rhs->worldAlphaDepth();
+            if (lhs_depth != rhs_depth)
+            {
+                return lhs_depth > rhs_depth;
+            }
+
+            if (lhs->mAvatarp != rhs->mAvatarp)
+            {
+                // at an exact depth tie, drain stamped ensembles before plain
+                // world groups so a null head cannot split every ensemble
+                if (!lhs->mAvatarp)
+                {
+                    return false;
+                }
+                if (!rhs->mAvatarp)
+                {
+                    return true;
+                }
+                // std::less: raw < on unrelated pointers is unspecified
+                return std::less<const LLVOAvatar*>()(lhs->mAvatarp, rhs->mAvatarp);
+            }
+
+            // groups of one ensemble keep their bounds order among themselves
+            return lhs->mDepth > rhs->mDepth;
+        }
+    };
+    // </FS>
+
     struct CompareRenderOrder
     {
         bool operator()(const LLSpatialGroup* const& lhs, const LLSpatialGroup* const& rhs)
         {
             if (lhs->mAvatarp != rhs->mAvatarp)
             {
-                return lhs->mAvatarp < rhs->mAvatarp;
+                // <FS> std::less: raw < on unrelated pointers is unspecified
+                // return lhs->mAvatarp < rhs->mAvatarp;
+                return std::less<const LLVOAvatar*>()(lhs->mAvatarp, rhs->mAvatarp);
+                // </FS>
             }
 
             return lhs->mRenderOrder > rhs->mRenderOrder;
         }
     };
+
+    // <FS>
+    struct CompareDepthRenderOrder
+    {
+        bool operator()(const LLSpatialGroup* const& lhs, const LLSpatialGroup* const& rhs)
+        {
+            // farther avatars draw first; all of an avatar's groups share one
+            // depth, keeping its run contiguous and in attachment order
+            if (lhs->mAvatarDepth != rhs->mAvatarDepth)
+            {
+                return lhs->mAvatarDepth > rhs->mAvatarDepth;
+            }
+
+            if (lhs->mAvatarp != rhs->mAvatarp)
+            {
+                // An unstamped rigged group has no ensemble key; keep it first
+                // at an exact depth tie, matching the merge's legacy fallback.
+                if (!lhs->mAvatarp)
+                {
+                    return true;
+                }
+                if (!rhs->mAvatarp)
+                {
+                    return false;
+                }
+                return std::less<const LLVOAvatar*>()(lhs->mAvatarp, rhs->mAvatarp);
+            }
+
+            if (lhs->mRenderOrder != rhs->mRenderOrder)
+            {
+                return lhs->mRenderOrder > rhs->mRenderOrder;
+            }
+
+            // bounds depth: stable back-to-front order within one attachment
+            return lhs->mDepth > rhs->mDepth;
+        }
+    };
+    // </FS>
 
     typedef enum
     {
@@ -364,6 +443,10 @@ public:
     //used by LLVOAVatar to set render order in alpha draw pool to preserve legacy render order behavior
     LLVOAvatar* mAvatarp = nullptr;
     U32 mRenderOrder = 0;
+    // <FS> avatar-ensemble sort key, fanned out from the bridge in
+    // LLPipeline::postSort; mDepth stays bounds-derived
+    F32 mAvatarDepth = 0.f;
+    // </FS>
     // Reflection Probe associated with this node (if any)
     LLPointer<LLReflectionMap> mReflectionProbe = nullptr;
 } LL_ALIGN_POSTFIX(16);
@@ -471,6 +554,15 @@ public:
     //transform agent space bounding box into this Spatial Bridge's coordinate frame
     void transformExtents(const LLVector4a* src, LLVector4a* dst);
     LLDrawable* mDrawable;
+
+    // <FS> alpha draw-order stamp, set by LLVOAvatar::idleUpdateMisc /
+    // LLControlAvatar::idleUpdate and fanned out to this bridge's alpha
+    // groups in LLPipeline::postSort. mAvatarp is only ever compared,
+    // never dereferenced (avatar may die first).
+    LLVOAvatar* mAvatarp = nullptr;
+    U32 mRenderOrder = 0;
+    F32 mAvatarDepth = 0.f;
+    // </FS>
 };
 
 class LLCullResult

--- a/indra/newview/llvoavatar.cpp
+++ b/indra/newview/llvoavatar.cpp
@@ -3391,6 +3391,28 @@ static void override_bbox(LLDrawable* drawable, LLVector4a* extents)
     drawable->movePartition();
 }
 
+// <FS> camera-axis depth of this avatar, stamped onto every rigged alpha bridge
+// (attachments below, animesh in LLControlAvatar::idleUpdate) so its alpha
+// interleaves with world alpha (LLDrawPoolAlpha::renderAlpha). From the
+// animated extents, so avatars sharing a sit target still order
+// deterministically; pulled a quarter of the bounds toward the camera to match
+// the metric LLSpatialPartition::calcDistance stamps onto world alpha groups.
+F32 LLVOAvatar::calcRiggedAlphaDepth() const
+{
+    LLViewerCamera* camera = LLViewerCamera::getInstance();
+    const LLVector3& at_axis = camera->getAtAxis();
+    if (mLastAnimExtents[0] == LLVector3() || mLastAnimExtents[1] == LLVector3())
+    { // extents not computed yet
+        return (getRenderPosition() - camera->getOrigin()) * at_axis;
+    }
+
+    const LLVector3 center = (mLastAnimExtents[0] + mLastAnimExtents[1]) * 0.5f;
+    const LLVector3 half = (mLastAnimExtents[1] - mLastAnimExtents[0]) * 0.5f;
+    return (center - camera->getOrigin()) * at_axis -
+           0.25f * (half * at_axis.scaledVec(at_axis));
+}
+// </FS>
+
 void LLVOAvatar::idleUpdateMisc(bool detailed_update)
 {
     LL_PROFILE_ZONE_SCOPED_CATEGORY_AVATAR;
@@ -3408,6 +3430,7 @@ void LLVOAvatar::idleUpdateMisc(bool detailed_update)
     if (detailed_update)
     {
         U32 draw_order = 0;
+        const F32 rigged_depth = calcRiggedAlphaDepth(); // <FS/>
         bool attachment_selected = LLSelectMgr::getInstance()->getSelection()->getObjectCount() > 0 && LLSelectMgr::getInstance()->getSelection()->isAttachment();
         for (const auto& [attachment_point_id, attachment] : mAttachmentPoints)
         {
@@ -3475,14 +3498,23 @@ void LLVOAvatar::idleUpdateMisc(bool detailed_update)
                             bridge->setState(LLDrawable::MOVE_UNDAMPED);
                             bridge->updateMove();
                             bridge->setState(LLDrawable::EARLY_MOVE);
-
-                            LLSpatialGroup* group = attached_object->mDrawable->getSpatialGroup();
-                            if (group)
-                            { //set draw order of group
-                                group->mAvatarp = this;
-                                group->mRenderOrder = draw_order++;
-                            }
                         }
+
+                        // <FS> stamp the attachment's draw order; LLPipeline::postSort
+                        // fans it out to the bridge's alpha groups, sorting the
+                        // wearer's whole ensemble at one avatar depth. HUD alpha
+                        // sorts in HUD space, so unrigged HUDs stay unstamped.
+                        // Stale-safe: mUpdatePeriod > 1 implies isImpostor(),
+                        // whose attachments never enter the live alpha streams.
+                        // (Previously this stamped the rigged group's spatial
+                        // group directly inside the else branch above.)
+                        if (rigged || !attached_object->isHUDAttachment())
+                        {
+                            bridge->mAvatarp = this;
+                            bridge->mRenderOrder = draw_order++;
+                            bridge->mAvatarDepth = rigged_depth;
+                        }
+                        // </FS>
                     }
 
                     attached_object->updateText();

--- a/indra/newview/llvoavatar.h
+++ b/indra/newview/llvoavatar.h
@@ -285,6 +285,7 @@ public:
     void            updateRootPositionAndRotation(LLAgent &agent, F32 speed, bool was_sit_ground_constrained);
 
     void            idleUpdateVoiceVisualizer(bool voice_enabled, const LLVector3 &position);
+    F32             calcRiggedAlphaDepth() const; // <FS/> interleaved world-alpha depth key
     void            idleUpdateMisc(bool detailed_update);
     virtual void    idleUpdateAppearanceAnimation();
     void            idleUpdateLipSync(bool voice_enabled);

--- a/indra/newview/pipeline.cpp
+++ b/indra/newview/pipeline.cpp
@@ -3747,6 +3747,21 @@ void renderSoundHighlights(LLDrawable *drawablep)
     }
 }
 
+// <FS>
+bool LLPipeline::canUseInterleavedAlpha()
+{
+    static LLCachedControl<bool> interleaved_alpha(gSavedSettings, "RenderInterleavedAlpha", true);
+    return interleaved_alpha && !sRenderingHUDs && !sShadowRender && !gCubeSnapshot &&
+           LLViewerCamera::sCurCameraID == LLViewerCamera::CAMERA_WORLD;
+}
+
+void LLPipeline::sortAlphaGroupsForInterleaving()
+{
+    std::sort(sCull->beginAlphaGroups(), sCull->endAlphaGroups(), LLSpatialGroup::CompareWorldAlphaDepth());
+    std::sort(sCull->beginRiggedAlphaGroups(), sCull->endRiggedAlphaGroups(), LLSpatialGroup::CompareDepthRenderOrder());
+}
+// </FS>
+
 void LLPipeline::postSort(LLCamera &camera)
 {
     LL_PROFILE_ZONE_SCOPED_CATEGORY_PIPELINE;
@@ -3827,11 +3842,23 @@ void LLPipeline::postSort(LLCamera &camera)
         if (hasRenderType(LLPipeline::RENDER_TYPE_PASS_ALPHA))
         {
             LL_PROFILE_ZONE_NAMED_CATEGORY_PIPELINE("Collect Alpha groups");
+            // <FS> fan the attachment's stamp (LLVOAvatar::idleUpdateMisc) out from
+            // the bridge to every visible alpha group of the linkset; the shared
+            // mAvatarDepth keys the wearer's ensemble as one block in the walk
+            LLSpatialBridge *bridge = group->getSpatialPartition()->asBridge();
+            if (bridge && bridge->mAvatarp)
+            {
+                group->mAvatarp = bridge->mAvatarp;
+                group->mRenderOrder = bridge->mRenderOrder;
+                group->mAvatarDepth = bridge->mAvatarDepth;
+            }
+            // </FS>
+
             LLSpatialGroup::draw_map_t::iterator alpha = group->mDrawMap.find(LLRenderPass::PASS_ALPHA);
 
             if (alpha != group->mDrawMap.end())
             {  // store alpha groups for sorting
-                LLSpatialBridge *bridge = group->getSpatialPartition()->asBridge();
+                // <FS> (bridge already fetched above for the stamp fan-out)
                 if (LLViewerCamera::sCurCameraID == LLViewerCamera::CAMERA_WORLD && !gCubeSnapshot)
                 {
                     if (bridge)
@@ -3901,11 +3928,11 @@ void LLPipeline::postSort(LLCamera &camera)
         LL_PROFILE_ZONE_NAMED_CATEGORY_PIPELINE("sort alpha groups");
     if (!sShadowRender)
     {
-        // order alpha groups by distance
+        // <FS> Legacy order is the baseline for every consumer. Post-water replaces
+        // it with the interleaved order only when it actually uses the merge.
         std::sort(sCull->beginAlphaGroups(), sCull->endAlphaGroups(), LLSpatialGroup::CompareDepthGreater());
-
-        // order rigged alpha groups by avatar attachment order
         std::sort(sCull->beginRiggedAlphaGroups(), sCull->endRiggedAlphaGroups(), LLSpatialGroup::CompareRenderOrder());
+        // </FS>
     }
     }
 

--- a/indra/newview/pipeline.h
+++ b/indra/newview/pipeline.h
@@ -387,6 +387,7 @@ public:
     LLCullResult::sg_iterator endAlphaGroups();
     LLCullResult::sg_iterator beginRiggedAlphaGroups();
     LLCullResult::sg_iterator endRiggedAlphaGroups();
+    void sortAlphaGroupsForInterleaving(); // <FS/> re-sort the shared lists for the merged post-water pass
 
     void addTrianglesDrawn(S32 index_count);
     void recordTrianglesDrawn();
@@ -402,6 +403,7 @@ public:
     bool hasAnyRenderType(const U32 type, ...) const;
 
     static bool isWaterClip();
+    static bool canUseInterleavedAlpha(); // <FS/> central eligibility gate for the merged alpha walk
 
     void setRenderTypeMask(U32 type, ...);
     // This is equivalent to 'setRenderTypeMask'


### PR DESCRIPTION
## Summary

Port of [secondlife/viewer#5927](https://github.com/secondlife/viewer/pull/5927) (by Viscerous). Replaces the two-phase alpha render (rigged attachments drawn in an earlier separate batch) with a **single back-to-front interleaved pass** that merges rigged-attachment and world alpha streams. This fixes incorrect draw ordering where rigged alpha objects render behind world-alpha geometry they should be in front of (and vice versa) — e.g. alpha hair/clothing on avatars sorting wrongly against world alpha surfaces.

Early adopters (Alchemy Viewer) report positive results.

## Changes (9 files, +346/−36)

- `llspatialpartition.h` — `LLSpatialGroup::worldAlphaDepth()`/`mAvatarDepth` for cross-stream depth ordering; `CompareWorldAlphaDepth` + `CompareDepthRenderOrder` comparators (`std::less` for pointer tie-breaks)
- `pipeline.{cpp,h}` — `EAlphaStream {WORLD, RIGGED, INTERLEAVED}`; `LLPipeline::canUseInterleavedAlpha()` + `sortAlphaGroupsForInterleaving()`; bridge stamp fan-out in `postSort`
- `llvoavatar.{cpp,h}` + `llcontrolavatar.cpp` — `LLVOAvatar::calcRiggedAlphaDepth()` stamps rigged alpha groups with the avatar's depth
- `lldrawpoolalpha.{cpp,h}` — `renderAlpha` walks both streams in one interleaved pass via dual iterators; per-group `LLGLDepthTest` (stamped rigged groups depth-write, unstamped blend-only)
- `app_settings/settings.xml` — `RenderInterleavedAlpha` setting, default **on**, as an escape hatch

Ported following FS preserve-original conventions (`// <FS> ... // </FS>` comment blocks).

## Test plan

- [x] Cherry-picks cleanly onto current master (no conflicts)
- [x] Builds clean on Windows (MSVC 2022, ReleaseFS_open): 0 errors, 0 warnings
- [x] Static analysis: no diagnostics on any touched file; settings.xml parses
- [ ] In-world visual verification of alpha ordering (avatar alpha attachments vs world alpha surfaces)

## Notes

- Default **on**; `RenderInterleavedAlpha` remains as a runtime toggle if issues surface.
- Original work by **Viscerous** — secondlife/viewer PR #5927.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the LGPL-2.1 license and that I have the right to submit it under that license.